### PR TITLE
fix(actors): use direct link to 6.5 documentation page on anonymous user

### DIFF
--- a/md/actors.md
+++ b/md/actors.md
@@ -36,7 +36,7 @@ If you use 6.x forms, you can configure a process to be started by an anonymous 
 a new user can browse stock and save items to a cart, then register with the site if they want to save
 their cart for later or to buy something. This is known as supporting anonymous users. Anonymous users are always process initiators.
 
-To support anonymous users in a process report to the [6.x documentation page](/actors-859#Allowing%20anonymous%20users).
+To support anonymous users in a process report to the [6.x documentation page](http://documentation.bonitasoft.com/actors-859#Allowing%20anonymous%20users).
 
 ## Set the initiator
 


### PR DESCRIPTION
Using relative links from current document to legacy one do not worki
because of link management during md to html transformation.
Use absolute link instead.

Closes [BS-15273](https://bonitasoft.atlassian.net/browse/BS-15273)