### PR TITLE
feat(CSRF security) activate CSRF security by default

### DIFF
--- a/md/csrf-security.md
+++ b/md/csrf-security.md
@@ -1,59 +1,75 @@
 # CSRF security
 
-This page explains how to secure your application against Cross-Site Request Forgery (CSRF) attacks.
-
-## Default security setup in Bonita BPM
-
-In Bonita BPM, the security feature is optional and disabled by default. This leaves Bonita BPM unprotected from malicious attacks.
-By default (with the security feature disabled), the behavior of the application remains the same but no check is done regarding Tokens in HTTP Requests.
+This page explains how Bonita BPM REST API is secured against Cross-Site Request Forgery (CSRF) attacks.
 
 CSRF (also known as XSRF and Sea-Surf), is an example of a malicious attack on a trusted website.
 While the user is authenticated, by being logged on to a trusted website, malicious requests are transmitted without the user knowing, or giving their consent. 
 For example, by clicking on a link, the user is tricked into performing actions using their ID and privileges, such as giving personal information, bank details, making purchases or payments.
 If the targeted end user is an administrator, the entire web application can be compromised.
 
-## How do I protect my application?
+## Default security setup in Bonita BPM
 
-The activation of the CSRF protection can be done in the file `security-config.properties` for the whole platform.
-The default version of this file is located in `setup/platform_conf/initial/platform_portal`. In order to change the configuration on an installation whose platform has already been initialized, use the [plaform setup tool](BonitaBPM_platform_setup.md) to retrieve the current configuration and update the file in `setup/platform_conf/current/platform_portal`. Then use the tool again to save your changes into to the database.
-
-When CSRF protection is disabled, this file contains this line: 
-`
-security.csrf.enabled false
-`
-
-To enable the CSRF protection, edit the configuration file and change the `security.csrf.enabled ` value to **true**.
+In Bonita BPM, since version 7.4.0, the CSRF protection is enabled by default.
 
 ## How it works
 
-To prevent malicious attacks, an X-Bonita-API-Token header in the HTTP response is added each time a call to the resource `/API/session/* ` is made. 
-All HTTP Calls add this header in the HTTP Request.
-
-An attacker cannot retrieve this value unless they can inject some JavaScript (which has been mitigated thanks to our SecurityFilter), to make a call to the resource `/API/session/*`,
-get the `Header X-Bonita-API-Token`, and create their own requests.
-
-The value is a UUID, generated server-side, and added to the HTTP Session (server-side as well). 
+To prevent malicious attacks a token is generated server-side when logging in and added to the HTTP session (server-side as well).
+A cookie named `X-Bonita-API-Token` is created (hence, client-side) with the value of the token if the login is successful.
+Then for all subsequent REST API calls this token is added to the HTTP request headers.
 For each call, the server is checked to verify that the value in the Header is equal to the value stocked in the HTTP session. 
-If so, we proceed the request. Otherwise, this is considered to be an unauthorized access. (HTTP Status 401).
+If so, the request proceed. Otherwise, this is considered to be an unauthorized access. (HTTP Status 401).
 
-## Do I have to update my application?
+In addition of the cookie, it is also possible to retrieve the token by performing a call to the resource `/API/session/* `. The token is then returned in the headers of the HTTP response.
 
-Yes, if you have developed your own client to communicate with the `REST API`.
+An attacker cannot retrieve the value of the token unless they can inject some JavaScript (which has been mitigated thanks to our SecurityFilter), to make a call to the resource `/API/session/*`,
+get the header `X-Bonita-API-Token`, and create their own requests.
 
-When accessing the resource `/API/session/*` for the first time to get the user\_id, etc. extract the `X-Bonita-API-Token HTTP `header,
-store it and use it for each API call by adding a new header X-Bonita-API-Token in your calls.
-
-## Is there an impact on REST API
+## Is there an impact on REST API calls?
 
 If you are using Bonita BPM Portal there is no impact.
 
-If you have developed an external portal using the rest API to communicate with the Engine, you need to:
+If you have developed an external application or some custom pages using the REST API to communicate with bonita BPM, you need to send the `X-Bonita-API-Token` header in all requests other that GET. There are 2 ways of doing this:
 
-* Send an initial request to the session API.
-* Retrieve the `X-Bonita-API-Token` from the response header and store it.
-* In future API requests, add a header called `X-Bonita-API-Token `containing the stored token. The `X-Bonita-API-Token` is valid for the whole client session.
+* Using the `X-Bonita-API-Token` cookie:
+ * Retrieve the `X-Bonita-API-Token` cookie value (you can retrieve it once and store it in a variable if you don't want to read the cookie each time you perform a call).
+ * In each API request, add a header named `X-Bonita-API-Token` whose value is the token.
 
-_Note:_ in the UI Designer preview page, calls to Bonita REST API will not work if CSRF security is activated (in the Studio's Tomcat). It is due to the fact that UI Designer and Bonita REST API are not in the same web application. 
-The `X-Bonita-API-Token` cookie is therefore not visible to the UI Designer.
+* Using the session API resource
+ * Send an initial request to the session API resource (`/API/session/* `).
+ * Retrieve the `X-Bonita-API-Token` from the response header and store it.
+ * In all future API requests, add a header named `X-Bonita-API-Token` containing the stored token.
+
+The `X-Bonita-API-Token` is valid for the whole client session.
+
+
+## How do I disable it?
+
+Disabling the CSRF protection is not recommended as it will makes Bonita BPM REST API unprotected from malicious attacks.
+
+But if you need to, the deactivation of the CSRF protection can be done in the file `security-config.properties` for the whole platform.
+The default version of this file is located in `setup/platform_conf/initial/platform_portal`. In order to change the configuration on an installation whose platform has already been initialized, use the [platform setup tool](BonitaBPM_platform_setup.md) to retrieve the current configuration and update the file in `setup/platform_conf/current/platform_portal`. Then use the tool again to save your changes into to the database.
+
+When CSRF protection is enables, this file contains this line: 
+`
+security.csrf.enabled true
+`
+
+To disable the CSRF protection, edit the configuration file and change the `security.csrf.enabled ` value to **false**.
+
+## How to secure the X-Bonita-API-Token cookie (HTTPS only)?
+
+You can set the secure flag on the `X-Bonita-API-Token` cookie to make sure the browser will only transmit the cookie if the page is HTTPS.
+
+Activating the addition of the secure flag can be done in the file `security-config.properties` for the whole platform.
+The default version of this file is located in `setup/platform_conf/initial/platform_portal`. In order to change the configuration on an installation whose platform has already been initialized, use the [platform setup tool](BonitaBPM_platform_setup.md) to retrieve the current configuration and update the file in `setup/platform_conf/current/platform_portal`. Then use the tool again to save your changes into to the database.
+
+When the secure flag is not active, this file contains this line: 
+`
+security.csrf.cookie.secure false
+`
+
+To activate the addition of the secure flag, edit the configuration file and change the `security.csrf.cookie.secure ` value to **true**.
+
 [User authentication overview](user-authentication-overview.md)
 [Read more about CSRF attacks](http://www.acunetix.com/websitesecurity/csrf-attacks)
+


### PR DESCRIPTION
- refactor CSRF doc page as the CSRF security is now active by default
- document the new property added to secure the token cookie

Covers [BS-15890](https://bonitasoft.atlassian.net/browse/BS-15890)
