### PR TITLE
fix(typo) remove un-necessary s in API URL

### DIFF
--- a/md/customuserinfo-api.md
+++ b/md/customuserinfo-api.md
@@ -119,7 +119,7 @@ Use a GET method to search for definitions.
 There are no filters, and no search terms. All the definitions are returned.
 
 * **URL**  
-  `/API/customuserinfo/definitions`  
+  `/API/customuserinfo/definition`  
 * **Method**  
   `GET`
 * **Data Params**  


### PR DESCRIPTION
Remove un-necessary 's' in the URL to call API

This replaces the PR #157 
