### PR TITLE
BS-15942 Order is not working in the REST API

### DIFF
--- a/md/bpm-api.md
+++ b/md/bpm-api.md
@@ -481,6 +481,19 @@ Retrieve humanTask objects that match the specified filters.
   `GET`
 * **Data Params**  
   [Standard search parameters](rest-api-overview.md#resource_search) are available.  
+  
+  * o: only parameters available in HumanTaskInstanceSearchDescriptor.java and in the result are accepted: 
+	* assignee_id
+	* diplayname
+	* dueDate
+	* name
+	* priority
+	* processid
+	* id
+	* reached_state_date
+	* state
+	
+	
   You can also use the [flow node data params](#flownode-search-data-params).  
   For instance, you can filter on:
   * `assigned_id={user_id}`: retrieve only the human tasks assigned to the specified ID. For example, retrieve the human tasks assigned to user with id 2: `/API/bpm/humanTask?p=0&c=10&f=assigned\_id%3d2`

--- a/md/bpm-api.md
+++ b/md/bpm-api.md
@@ -482,16 +482,16 @@ Retrieve humanTask objects that match the specified filters.
 * **Data Params**  
   [Standard search parameters](rest-api-overview.md#resource_search) are available.  
   
-  * o: only parameters available in HumanTaskInstanceSearchDescriptor.java and in the result are accepted: 
-	* assignee_id
-	* diplayname
-	* dueDate
-	* name
-	* priority
-	* processid
-	* id
-	* reached_state_date
-	* state
+  * o: only fields available in [HumanTaskInstanceSearchDescriptor] (http://documentation.bonitasoft.com/javadoc/api/7.3/org/bonitasoft/engine/bpm/flownode/HumanTaskInstanceSearchDescriptor.html) and in the result are accepted: 
+    * case_id
+    * root_case_id
+    * parent_case_id
+    * process_id
+    * state
+    * type    	
+    * assignee_user_id
+    * priority
+
 	
 	
   You can also use the [flow node data params](#flownode-search-data-params).  


### PR DESCRIPTION
Add a description in `/API/bpm/humanTask` to give explicitly the list of attribute to order the list (because this is not the "any attribute in the result can be ordered". See BS-15942 and the explanation of Anthony.
