### PR TITLE
SQL Server - setting presume abort for XA in-doubt transaction

### DIFF
--- a/md/database-configuration-for-business-data.md
+++ b/md/database-configuration-for-business-data.md
@@ -18,7 +18,7 @@ Configuration is done per tenant. If you have multiple tenants to configure, you
 
 ## Database creation
 
-In your RDBMS, create a database to be used to store business object. Do not reuse the Bonita BPM Engine database.
+In your RDBMS, create a database to be used to store business object. Do not reuse the Bonita BPM Engine database. Follow the instructions in the [Specific database configuration](database-configuration.md#Specific database configuration) section.
 
 Configure the database to use the UTF-8 character set.
 

--- a/md/database-configuration-for-business-data.md
+++ b/md/database-configuration-for-business-data.md
@@ -18,7 +18,7 @@ Configuration is done per tenant. If you have multiple tenants to configure, you
 
 ## Database creation
 
-In your RDBMS, create a database to be used to store business object. Do not reuse the Bonita BPM Engine database. Follow the instructions in the [Specific database configuration](database-configuration.md#Specific database configuration) section.
+In your RDBMS, create a database to be used to store business object. Do not reuse the Bonita BPM Engine database. Follow the instructions in the [Specific database configuration](database-configuration.md#specific_database_configuration) section.
 
 Configure the database to use the UTF-8 character set.
 

--- a/md/database-configuration.md
+++ b/md/database-configuration.md
@@ -392,9 +392,7 @@ ALTER DATABASE BONITA_BPM SET MULTI_USER
 See [MSDN](https://msdn.microsoft.com/en-us/library/ms175095(v=sql.110).aspx).
 
 
-Run the script below to avoid the SQL Server change the status of the database to SUSPECT during database server startup when in-doubt XA transactions are found.
-The value 2 in the block below means *presume abort*
-To minimize the possibility of extended down time, an administrator might choose to configure this option to presume abort, as shown in the following example
+Run the script below to avoid that the SQL Server changes the status of databases to SUSPECT during database server startup when in-doubt XA transactions are found.  The value 2 in the block below means *presume abort*.  To minimize the possibility of extended down time, an administrator might choose to configure this option to presume abort, as shown in the following example
 
 ```sql
 sp_configure 'show advanced options', 1

--- a/md/database-configuration.md
+++ b/md/database-configuration.md
@@ -393,7 +393,8 @@ See [MSDN](https://msdn.microsoft.com/en-us/library/ms175095(v=sql.110).aspx).
 
 
 Run the script below to avoid the SQL Server change the status of the database to SUSPECT during database server startup when in-doubt XA transactions are found.
-The value 2 in the block below means *presume abort* see the 
+The value 2 in the block below means *presume abort*
+To minimize the possibility of extended down time, an administrator might choose to configure this option to presume abort, as shown in the following example
 
 ```sql
 sp_configure 'show advanced options', 1

--- a/md/database-configuration.md
+++ b/md/database-configuration.md
@@ -391,6 +391,7 @@ ALTER DATABASE BONITA_BPM SET MULTI_USER
 ```
 See [MSDN](https://msdn.microsoft.com/en-us/library/ms175095(v=sql.110).aspx).
 
+#### Recommended configuration in-doubt xact resolution
 
 Run the script below to avoid that the SQL Server changes the status of databases to SUSPECT during database server startup when in-doubt XA transactions are found.  
 The value 2 in the block below means *presume abort*.  

--- a/md/database-configuration.md
+++ b/md/database-configuration.md
@@ -253,6 +253,8 @@ Now that you are almost done with the switch from h2 to your chosen RDBMS, you c
    * Remove the h2 listener, so that h2 is not started automatically: comment out the h2 listener in the `/conf/server.xml` file.
  * Check that h2 is no longer set in JVM system property value. Also, for extra security, you can remove it from `bonita-platform.properties` file and replace it with the value for your chosen RDBMS.
 
+<a id="specific_database_configuration"/>
+
 ## Specific database configuration
 
 ### PostgreSQL

--- a/md/database-configuration.md
+++ b/md/database-configuration.md
@@ -393,7 +393,7 @@ ALTER DATABASE BONITA_BPM SET MULTI_USER
 ```
 See [MSDN](https://msdn.microsoft.com/en-us/library/ms175095(v=sql.110).aspx).
 
-#### Recommended configuration in-doubt xact resolution
+#### Recommended configuration for in-doubt xact resolution
 
 Run the script below to avoid that the SQL Server changes the status of databases to SUSPECT during database server startup when in-doubt XA transactions are found.  
 The value 2 in the block below means *presume abort*.  

--- a/md/database-configuration.md
+++ b/md/database-configuration.md
@@ -389,8 +389,29 @@ ALTER DATABASE BONITA_BPM SET ALLOW_SNAPSHOT_ISOLATION ON
 ALTER DATABASE BONITA_BPM SET READ_COMMITTED_SNAPSHOT ON
 ALTER DATABASE BONITA_BPM SET MULTI_USER
 ```
-
 See [MSDN](https://msdn.microsoft.com/en-us/library/ms175095(v=sql.110).aspx).
+
+
+Run the script below to avoid the SQL Server change the status of the database to SUSPECT during database server startup when in-doubt XA transactions are found.
+The value 2 in the block below means *presume abort* see the 
+
+```sql
+sp_configure 'show advanced options', 1
+GO
+RECONFIGURE
+GO
+sp_configure 'in-doubt xact resolution', 2 
+GO
+RECONFIGURE
+GO
+sp_configure 'show advanced options', 0
+GO
+RECONFIGURE
+GO
+```
+
+See [in-doubt xact resolution Server Configuration Option](https://msdn.microsoft.com/en-us/library/ms179586%28v%3Dsql.110%29.aspx).
+
 
 ### MySQL
 

--- a/md/database-configuration.md
+++ b/md/database-configuration.md
@@ -392,7 +392,9 @@ ALTER DATABASE BONITA_BPM SET MULTI_USER
 See [MSDN](https://msdn.microsoft.com/en-us/library/ms175095(v=sql.110).aspx).
 
 
-Run the script below to avoid that the SQL Server changes the status of databases to SUSPECT during database server startup when in-doubt XA transactions are found.  The value 2 in the block below means *presume abort*.  To minimize the possibility of extended down time, an administrator might choose to configure this option to presume abort, as shown in the following example
+Run the script below to avoid that the SQL Server changes the status of databases to SUSPECT during database server startup when in-doubt XA transactions are found.  
+The value 2 in the block below means *presume abort*.  
+To minimize the possibility of extended down time, an administrator might choose to configure this option to presume abort, as shown in the following example
 
 ```sql
 sp_configure 'show advanced options', 1


### PR DESCRIPTION
This is mandatory setting for all databases involved in a XA transaction: bonita engine database and business data database.
