### PR TITLE
Update event-handlers.md

### DIFF
--- a/md/event-handlers.md
+++ b/md/event-handlers.md
@@ -17,6 +17,10 @@ You can create an event handler to track any change to any object in the databas
 
 At the end of this page there is a list of all the events.
 
+::: warning
+In a cluster environment, Event handlers must be Serializable (implements Serializable and have all its fields serializable or transient) because they are shared with other nodes of the cluster.
+:::
+
 ## Example: deploy an event handler
 
 This example shows an event handler that detects changes in the state of activity instances. When executing, the event handler calls [technical logger service](technical-logging.md).


### PR DESCRIPTION
Added: ::: warning
In a cluster environment, Event handlers must be Serializable (implements Serializable and have all its fields serializable or transient) because they are shared with other nodes of the cluster.
:::
