### PR TITLE
doc(wildfly): add 'troubleshooting' section on new Java 8 requirement

### DIFF
--- a/md/wildfly-bundle.md
+++ b/md/wildfly-bundle.md
@@ -215,7 +215,7 @@ For Oracle, rename it so that the name contains at least the word `oracle` or `o
 
 **Issue**: When I run `bonita-start.sh` or `bonita-start.bat`, I get the error message `Invalid Java version (1.7) < 1.8. Please set JAVA or JAVA_HOME variable to a JDK / JRE 1.8+`
 
-**Cause**: Bonita BPM 7.4+ requires Java 1.8 to run
+**Cause**: Bonita BPM 7.4+ WildFly bundle requires Java 1.8 to run
 
 **Solution**: Ensure your running environment has a JDK or JRE 1.8 installed and set either JAVA or JAVA_HOME environment variable to point to it.
 

--- a/md/wildfly-bundle.md
+++ b/md/wildfly-bundle.md
@@ -212,3 +212,11 @@ For Microsoft SQL Server, rename it so that the name contains at least the word 
 For Oracle, rename it so that the name contains at least the word `oracle` or `ojdbc` (case insensitive)
 
 ---
+
+**Issue**: When I run `bonita-start.sh` or `bonita-start.bat`, I get the error message `Invalid Java version (1.7) < 1.8. Please set JAVA or JAVA_HOME variable to a JDK / JRE 1.8+`
+
+**Cause**: Bonita BPM 7.4+ requires Java 1.8 to run
+
+**Solution**: Ensure your running environment has a JDK or JRE 1.8 installed and set either JAVA or JAVA_HOME environment variable to point to it.
+
+---


### PR DESCRIPTION
:warning: to be merged in 7.4, as for WildFly, Java 8 is required since Bonita BPM 7.4.0