### PR TITLE
fix(Page URI) URI to identify a page was wrong

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ instead of deactivating it.
 
 In this case, edit the appropriate _.md_ file and the build process will do the rest.
 
-<u>Example</u>: To edit the **actors.html** page in version 7.3, edit the `md/actors.md` file and submit a pull request on **7.3** branch.
+<u>Example</u>: To edit the **?page=actors** page in version 7.3, edit the `md/actors.md` file and submit a pull request on **7.3** branch.
 
 
 ## How to add a new page?


### PR DESCRIPTION
Update URI given as example as the new website is not using "filename.html" URI but "?page=filename" instead