### PR TITLE
fix(cluster) - current instead of initial folder

### DIFF
--- a/md/install-a-bonita-bpm-cluster.md
+++ b/md/install-a-bonita-bpm-cluster.md
@@ -121,7 +121,7 @@ The platform setup tool is also present in the Tomcat or WildFly bundle under th
 :::
 * Configure it as described in the [platform setup tool page](BonitaBPM_platform_setup.md)
 * Run the `setup.sh pull` or `setup.bat pull`. This will retrieve the configuration of your platform under `platform_conf/current` folder.
-* Update configuration files that are in the `platform_conf/initial` folder of the platform setup tool.
+* Update configuration files that are in the `platform_conf/current` folder of the platform setup tool.
     * In `platform_init_engine/bonita-platform-init-community-custom.properties` uncomment and update the value of `activeProfiles` property from **`community`** to **`community,performance`**.
     * In `platform_engine/bonita-platform-sp-custom.properties`
         * uncomment and set the **`bonita.cluster`** property to `true`.


### PR DESCRIPTION
When you want to convert a single node installation into a cluster, you need to edit the "current" configuration and not the "initial" as currently stated in the documentation.