### PR TITLE
fix(doc): fix community vs subscription info and provide examples for upload servlets usage

### DIFF
--- a/md/manage-files-using-upload-servlet-and-rest-api.md
+++ b/md/manage-files-using-upload-servlet-and-rest-api.md
@@ -1,58 +1,40 @@
 # Manage files using upload servlet and REST API
 
-In the Community, Teamwork, Efficiency, and Performance editions
-you can upload files by doing a multipart post request on any of the available servlets.
+In the Community, Teamwork, Efficiency, and Performance editions you can upload files by doing a multipart post request on any of the available servlets.
 It returns the name of the temporary uploaded file.
-This file name can be used to link those files with any REST resource.
+This file name can be used to link those files with any REST resources.
 
-Available servlet list:
+## Available servlets
 
-* `/portal/fileUpload`, supports any type of file
+* `/portal/fileUpload`, supports any type of files
 * `/portal/processUpload`, supports only `.bar` files
 * `/portal/organizationUpload`, supports only `.xml` files
 * `/portal/actorsUpload`, supports only `.xml` files
 * `/portal/imageUpload`, supports only `.png`, `.jpg`, `.gif`, `.jpeg`, `.bmp`, `.wbmp` or `.tga` files
+* `/portal/pageUpload`, supports only `.zip` files
+* `/portal/applicationsUpload`, supports only `.xml` files
 * `/portal/connectorImplementation`, supports only `.zip` files (not available in Community edition)
-* `/portal/pageUpload`, supports only `.zip` files (not available in Community edition)
 * `/portal/reportUpload`, supports any type of file (not available in Community edition)
 * `/portal/resourceUpload`, supports only `.jar` files (not available in Community edition)
 * `/portal/profilesUpload`, supports only `.xml` files (not available in Community edition)
-* `/portal/applicationsUpload`, supports only `.xml` files (not available in Community edition)
 
-### Example: link an icon to a new organisation group
+## Example
 
-1. Upload an image by using a multipart post request on the image upload servlet, `http://localhost:8080/bonita/portal/imageUpload`.
-2. The image is stored temporarily in Bonita Home, in `/client/tenants/`_`tenantId`_`/tmp`.
-3. The servlet returns the name of the temporary file.
-4. When you create the new group, link this image to the group by specifying this temporary file name
+You can refer to the [example-upload-servlet](https://github.com/Bonitasoft-Community/example-upload-sevlet) project that demonstrate the two use cases explained below.
 
-#### Example
-Request url
-/API/identity/group
 
-Request method
+### Link an icon to a new organization group
 
-POST
+1. Call to the login service: `/bonita/loginservice` for authentication.
+1. Upload an image by using a multipart post request on the image upload servlet, `/bonita/portal/imageUpload`.
+1. The image is stored in a temporary folder.
+1. The servlet call response includes the name of the temporary file.
+1. Call the Identity API to create a new group: `/bonita/API/identity/group`, link this image to the group by specifying this temporary file name in the request body.
 
-Request payload
+### Deploy programmatically a new REST API extension
 
-    {
-    "icon":"tmp_7501171996762091204.jpg","name":"HR",
-    "displayName":"Human Resources",
-    "parent_group_id":"1",
-    "description":"Human resources department"
-    }
-
-Response payload
-
-    {
-    "id":"14",
-    "creation_date":"2014-12-02 16:19:28.925",
-    "created_by_user_id":"4",
-    "icon":"tmp_7501171996762091204.jpg","parent_path":"/acme"
-    ,"description":"Human resources department",
-    "name":"HR",
-    "path":"/acme/HR",
-    "displayName":"Human Resources",
-    "last_update_date":"2014-12-02 16:19:28.925"
-    }
+1. Call to the login service: `/bonita/loginservice` for authentication.
+1. Upload a REST API extension by using a multipart post request on the page upload servlet: `/bonita/portal/pageUpload`. It will send the REST API extension (handle as a "page") zip file from client side to server side.
+1. REST API extension zip file is stored in a temporary folder.
+1. The servlet call response includes the name of the temporary file.
+1. Call the Portal API to register the newly uploaded REST API extension: `/bonita/API/portal/page`.

--- a/md/manage-files-using-upload-servlet-and-rest-api.md
+++ b/md/manage-files-using-upload-servlet-and-rest-api.md
@@ -25,7 +25,7 @@ You can refer to the [example-upload-servlet](https://github.com/Bonitasoft-Comm
 
 ### Link an icon to a new organization group
 
-1. Call to the login service: `/bonita/loginservice` for authentication.
+1. Call the login service: `/bonita/loginservice` for authentication.
 1. Upload an image by using a multipart post request on the image upload servlet, `/bonita/portal/imageUpload`.
 1. The image is stored in a temporary folder.
 1. The servlet call response includes the name of the temporary file.
@@ -33,7 +33,7 @@ You can refer to the [example-upload-servlet](https://github.com/Bonitasoft-Comm
 
 ### Deploy programmatically a new REST API extension
 
-1. Call to the login service: `/bonita/loginservice` for authentication.
+1. Call the login service: `/bonita/loginservice` for authentication.
 1. Upload a REST API extension by using a multipart post request on the page upload servlet: `/bonita/portal/pageUpload`. It will send the REST API extension (handle as a "page") zip file from client side to server side.
 1. REST API extension zip file is stored in a temporary folder.
 1. The servlet call response includes the name of the temporary file.


### PR DESCRIPTION
Update documentation for upload servlets as pageUpload and applicationsUpload are available in Community edition.
Add more details about how to use the upload servlets and provide a link to an example (Groovy code) host on bonitasoft-community GitHub organization.

Help to answer: http://stackoverflow.com/questions/43146828/how-to-use-rest-api-to-create-extension-api-on-bonita-bpm

Closes [BS-16533](https://bonitasoft.atlassian.net/browse/BS-16533)