### PR TITLE
fix(jboss): remove unexisting folder in jboss bundle content

### DIFF
--- a/md/jboss-bundle.md
+++ b/md/jboss-bundle.md
@@ -36,7 +36,6 @@ The JBoss bundle is based on a standard JBoss installation with the following ad
 * `bonita-start.bat`: script to start the bundle on Windows.
 * `bonita-start.sh`: script to start the bundle on Linux.
 * `standalone/configuration/standalone.xml`: JBoss context configuration for Bonita BPM Portal. It defines data sources used by Bonita BPM Engine.
-* `lib/bonita`: extra libraries needed by Bonita BPM. The following libraries are included: Bitronix JTA Transaction Manager, h2, SLF4J (required by Bitronix).
 * `request_key_utils`: script to generate license request keys (Subscription editions only).
 * `standalone/deployments/h2.sar`: application that runs the h2 server. (h2 is the default embedded database, not for production)
 * `standalone/deployments/bonita-all-in-one-[version].ear`: Bonita BPM Portal (web application) and EJB3 API.


### PR DESCRIPTION
Remove listing of bonita/lib folder since it does not exists in jboss bundle.
All librairies needed are included in ear adn we do not use bitronix in Jboss bundles

Closes [BS-15997](https://bonitasoft.atlassian.net/browse/BS-15997)