### PR TITLE
doc(licensing): remove cpu license reference link 7.4 wildfly (#295)

### DIFF
--- a/md/wildfly-bundle.md
+++ b/md/wildfly-bundle.md
@@ -158,10 +158,6 @@ WildFly can be started by executing the following script:
 * Windows `<WILDFLY_HOME>\start-bonita.bat`
 * Linux `<WILDFLY_HOME>/start-bonita.sh`
 
-If your Subscription edition license covers fewer CPU cores than are available on your server, you must limit the number of CPUs available in the start script.
-
-To do so, [create a custom WildFly start-up script](specify-cpu-cores.md)
-
 #### WildFly stop script
 
 WildFly can be shut down by executing the following script:


### PR DESCRIPTION
Remove all references to CPU licensing