### PR TITLE
fix(custom layout) share migration steps from 7.2

### DIFF
--- a/md/customize-living-application-layout.md
+++ b/md/customize-living-application-layout.md
@@ -119,3 +119,22 @@ Once your changes are made, save the new layout using a new name and then export
 6. In the application details section, click on the URL link to navigate to your living application.
 7. See your new application layout with a side menu.
 8. Feel free to add lots of new improvements to create the layout that fits your needs.
+
+## Troubleshooting
+
+### Living application layout log 3 error 500 on loading
+
+This issue has been fixed in the 7.3.0 version ("[BS-14885] - Living application layout log 3 error 500 on loading").
+If you created a custom layout with an oldest UIDesigner version, you have to perform the following step to prevent the issue to occur when running on newest
+version.
+
+1. Import the CustomLayout_7.2.x in UIDesigner 7.3.3  
+2. Export the default layout from Bonita Portal  
+3. Import the default layout and confirm the overwrite of custom widgets  
+4. Open the CustomLayout_7.2.x Layout and remove the 3 variables AuthorizeApplicationAPI, AuthorizeApplicationPageAPI and AuthorizeApplicationMenuAPI (as shown below) 
+Those variables are responsible of the SEVERE error logs on server.  
+5. Select the iFrame widget and set the reziseToContent option to yes  
+6. Save then Export the layout (feel free to rename the layout if you want)  
+7. On Bonita Portal server edit the layout and import the newly exported layout  
+8. confirm all the messages  
+9. Validate that your application has a layout that fits your requirements. 

--- a/md/customize-living-application-layout.md
+++ b/md/customize-living-application-layout.md
@@ -125,8 +125,8 @@ Once your changes are made, save the new layout using a new name and then export
 ### Living application layout log 3 error 500 on loading
 
 This issue has been fixed in the 7.3.0 version ("[BS-14885] - Living application layout log 3 error 500 on loading").
-If you created a custom layout with an oldest UIDesigner version, you have to perform the following step to prevent the issue to occur when running on newest
-version.
+If you want to import a custom layout created with an oldest UIDesigner version (7.2.x or lower) in a 7.3.0 (or greater version), you have to perform the following
+steps to prevent the issue to occur.
 
 1. Import the CustomLayout_7.2.x in UIDesigner 7.3.3  
 2. Export the default layout from Bonita Portal  

--- a/md/customize-living-application-layout.md
+++ b/md/customize-living-application-layout.md
@@ -125,7 +125,7 @@ Once your changes are made, save the new layout using a new name and then export
 ### Living application layout log 3 error 500 on loading
 
 This issue has been fixed in the 7.3.0 version ("[BS-14885] - Living application layout log 3 error 500 on loading").
-If you want to import a custom layout created with an oldest UIDesigner version (7.2.x or lower) in a 7.3.0 (or greater version), you have to perform the following
+If you want to import a custom layout created with an oldest UIDesigner version (7.2.x or lower) in a 7.3.0 (or greater) version, you have to perform the following
 steps to prevent the issue to occur.
 
 1. Import the CustomLayout_7.2.x in UIDesigner 7.3.3  

--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -92,7 +92,7 @@ Many improvements to existing features:
 * Default applications layout is not compatible with new task list custom page
 * Having executed a task in a subprocess, I cannot see the overview of the root process instance
 
-## Migrate a custom layout to 7.3.x
+## Migrate a custom layout to 7.3.3
 
 If you want to import a custom living application layout created with an oldest UIDesigner version (7.2.x or lower), please perform migration steps described in
 the troubleshooting section of the [customize living application layout](customize-living-application-layout.md) page.

--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -94,8 +94,8 @@ Many improvements to existing features:
 
 ## Migrate a custom layout to 7.3.x
 
-If you created a custom living application layout with an oldest UIDesigner version (7.2.x or lower), please perform migration steps described in the troubleshooting
-section of the[customize living application layout](customize-living-application-layout.md) page.
+If you want to import a custom living application layout created with an oldest UIDesigner version (7.2.x or lower), please perform migration steps described in
+the troubleshooting section of the [customize living application layout](customize-living-application-layout.md) page.
 
 ## Bug fixes
 

--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -92,20 +92,10 @@ Many improvements to existing features:
 * Default applications layout is not compatible with new task list custom page
 * Having executed a task in a subprocess, I cannot see the overview of the root process instance
 
-## Migrate a custom layout to 7.3.3
-  
-Custom layout migration step to fix "[BS-14885] - Living application layout log 3 error 500 on loading":  
-1. Import the CustomLayout_7.2.x in UIDesigner 7.3.3  
-2. Export the default layout from Bonita Portal  
-3. Import the default layout and confirm the overwrite of custom widgets  
-4. Open the CustomLayout_7.2.x Layout and remove the 3 variables AuthorizeApplicationAPI, AuthorizeApplicationPageAPI and AuthorizeApplicationMenuAPI (as shown below) 
-Those variables are responsible of the SEVERE error logs on server.  
-5. Select the iFrame widget and set the reziseToContent option to yes  
-6. Save then Export the layout (feel free to rename the layout if you want)  
-7. On Bonita Portal server edit the layout and import the newly exported layout  
-8. confirm all the messages  
-9. Validate that your application has a layout that fits your requirements.  
+## Migrate a custom layout to 7.3.x
 
+If you created a custom living application layout with an oldest UIDesigner version (7.2.x or lower), please perform migration steps described in the troubleshooting
+section of the[customize living application layout](customize-living-application-layout.md) page.
 
 ## Bug fixes
 


### PR DESCRIPTION
Move the migration steps from the 7.3 release notes to a new layout section in the "customize living application" layout page.
This lets the user get the information also for newest version.

Relates to [BS-16287](https://bonitasoft.atlassian.net/browse/BS-16287)