### PR TITLE
fix(groups): Document the groupName character limitations

### DIFF
--- a/md/configure-a-test-organization.md
+++ b/md/configure-a-test-organization.md
@@ -23,7 +23,7 @@ To an organization, you create the organization, create the group hierarchy, spe
 4. Add groups to your organization:
    1. Select the name of your organization and click **_Next_**.
    2. Click **_Add group_** to add a group. You can specify the following:
-     * the group Name, which is used internally by the Bonita BPM software
+     * the group Name, which is used internally by the Bonita BPM software._**NB: Bonita BPM doesn't support the '/' character in the group name field. A group name that contains a '/' may lead to unstable behaviour.**_ 
      * the Display name, which is the group name displayed in lists and wizards
      * the Path, which shows the hierarchical relationship between groups
      * a Description of the group

--- a/md/configure-a-test-organization.md
+++ b/md/configure-a-test-organization.md
@@ -23,7 +23,7 @@ To an organization, you create the organization, create the group hierarchy, spe
 4. Add groups to your organization:
    1. Select the name of your organization and click **_Next_**.
    2. Click **_Add group_** to add a group. You can specify the following:
-     * the group Name, which is used internally by the Bonita BPM software._**NB: Bonita BPM doesn't support the '/' character in the group name field. A group name that contains a '/' may lead to unstable behaviour.**_ 
+     * the group Name, which is used internally by the Bonita BPM software._**NB: Bonita BPM doesn't support the '/' character in the group name field. A group name that contains a '/' may lead to unstable behaviour and may be forbidden in the future.**_ 
      * the Display name, which is the group name displayed in lists and wizards
      * the Path, which shows the hierarchical relationship between groups
      * a Description of the group

--- a/md/group.md
+++ b/md/group.md
@@ -9,7 +9,7 @@ Logged on with the Administrator profile, you have rights to manage groups as fo
 3. In the pop-up window, enter the name (required), the parent group and a description.
 4. Click _**Create**_.
 
-_**NB: Bonita BPM doesn't support the '/' character in the group name field. A group name that contains a '/' may lead to unstable behaviourmay lead to unstable behaviour and may be forbidden in the future.**_ 
+_**NB: Bonita BPM doesn't support the '/' character in the group name field. A group name that contains a '/' may lead to unstable behaviour and may be forbidden in the future.**_ 
 
 ## How to delete a group
 

--- a/md/group.md
+++ b/md/group.md
@@ -9,6 +9,8 @@ Logged on with the Administrator profile, you have rights to manage groups as fo
 3. In the pop-up window, enter the name (required), the parent group and a description.
 4. Click _**Create**_.
 
+_**NB: Bonita BPM doesn't support the '/' character in the group name field. A group name that contains a '/' may lead to unstable behaviour.**_ 
+
 ## How to delete a group
 
 1. Go to the **Organization** menu and choose **Groups**.

--- a/md/group.md
+++ b/md/group.md
@@ -9,7 +9,7 @@ Logged on with the Administrator profile, you have rights to manage groups as fo
 3. In the pop-up window, enter the name (required), the parent group and a description.
 4. Click _**Create**_.
 
-_**NB: Bonita BPM doesn't support the '/' character in the group name field. A group name that contains a '/' may lead to unstable behaviour.**_ 
+_**NB: Bonita BPM doesn't support the '/' character in the group name field. A group name that contains a '/' may lead to unstable behaviourmay lead to unstable behaviour and may be forbidden in the future.**_ 
 
 ## How to delete a group
 

--- a/md/organization-management-in-bonita-bpm-studio.md
+++ b/md/organization-management-in-bonita-bpm-studio.md
@@ -29,7 +29,7 @@ To specify an organization manually, you create the organization, create the gro
 4. Add groups to your organization:
   1. Select the name of your organization and click **_Next_**.
   2. Click **_Add_** to add a group. You can specify the following:
-    * the group Name, which is used internally by the Bonita BPM software._**NB: Bonita BPM doesn't support the '/' character in the group name field. A group name that contains a '/' may lead to unstable behaviourmay lead to unstable behaviour and may be forbidden in the future.**_ 
+    * the group Name, which is used internally by the Bonita BPM software._**NB: Bonita BPM doesn't support the '/' character in the group name field. A group name that contains a '/' may lead to unstable behaviour and may be forbidden in the future.**_ 
     * the Display name, which is the group name displayed in lists and wizards
     * the Path, which shows the hierarchical relationship between groups
     * a Description of the group

--- a/md/organization-management-in-bonita-bpm-studio.md
+++ b/md/organization-management-in-bonita-bpm-studio.md
@@ -29,7 +29,7 @@ To specify an organization manually, you create the organization, create the gro
 4. Add groups to your organization:
   1. Select the name of your organization and click **_Next_**.
   2. Click **_Add_** to add a group. You can specify the following:
-    * the group Name, which is used internally by the Bonita BPM software
+    * the group Name, which is used internally by the Bonita BPM software._**NB: Bonita BPM doesn't support the '/' character in the group name field. A group name that contains a '/' may lead to unstable behaviour.**_ 
     * the Display name, which is the group name displayed in lists and wizards
     * the Path, which shows the hierarchical relationship between groups
     * a Description of the group

--- a/md/organization-management-in-bonita-bpm-studio.md
+++ b/md/organization-management-in-bonita-bpm-studio.md
@@ -29,7 +29,7 @@ To specify an organization manually, you create the organization, create the gro
 4. Add groups to your organization:
   1. Select the name of your organization and click **_Next_**.
   2. Click **_Add_** to add a group. You can specify the following:
-    * the group Name, which is used internally by the Bonita BPM software._**NB: Bonita BPM doesn't support the '/' character in the group name field. A group name that contains a '/' may lead to unstable behaviour.**_ 
+    * the group Name, which is used internally by the Bonita BPM software._**NB: Bonita BPM doesn't support the '/' character in the group name field. A group name that contains a '/' may lead to unstable behaviourmay lead to unstable behaviour and may be forbidden in the future.**_ 
     * the Display name, which is the group name displayed in lists and wizards
     * the Path, which shows the hierarchical relationship between groups
     * a Description of the group


### PR DESCRIPTION
You can't use the character '/' when naming a group. The PR aims to document the issue. Further limitations necessary in the studio, portal, engine and LDAP synchronizer to properly close the bug.

Relates to [BS-16612](https://bonitasoft.atlassian.net/browse/BS-16612)