### PR TITLE
fix(mssql server): jdbc driver version clarification and troubleshooting

### DIFF
--- a/md/BonitaBPM_platform_setup.md
+++ b/md/BonitaBPM_platform_setup.md
@@ -113,7 +113,7 @@ Here is how to do so:
    1. Create the database
    2. Customize it so it works with Bonita BPM
    3. Modify the `database.properties` file: Set the right db vendor and change connection url, user credentials, database name and so on.
-   4. If you are using an Oracle or Microsoft SQL Server database, add the related JDBC driver in the `lib` folder. 
+   4. If you are using an Oracle or Microsoft SQL Server database, add the related [JDBC driver](database-configuration.md#proprietary_jdbc_drivers) in the `lib` folder. 
 
 
 <a id="advanced_use" />

--- a/md/database-configuration.md
+++ b/md/database-configuration.md
@@ -42,6 +42,23 @@ We recommend that you use the WildFly bundle provided by Bonitasoft.
 :::
 
 
+<a id="proprietary_jdbc_drivers" />
+
+### Proprietary Jdbc drivers
+
+Bonita BPM provides out of the box the Jdbc drivers for H2, PostgreSQL and MySQL. For other RDBMS, you have to retrieve the related Jdbc drivers.  
+
+#### SQL Server
+
+1. Download the zip package of [Microsoft SQL Server JDBC Driver 6.0](https://www.microsoft.com/en-us/download/details.aspx?displaylang=en&id=11774) and unzip it. 
+2. Get the `sqljdbc42.jar` file from `%JDBC_DRIVER_INSTALL_ROOT%\sqljdbc_6.0\enu\jre8\`
+
+#### Oracle Database
+
+* For Oracle 11.2.0.x, download [ojdbc6.jar](http://www.oracle.com/technetwork/apps-tech/jdbc-112010-090769.html)
+* For Oracle 12.1.0.x, download [ojdbc7.jar](http://www.oracle.com/technetwork/database/features/jdbc/default-2280470.html)
+
+
 <a id="database_creation" />
 
 ### Create the database(s)
@@ -166,9 +183,9 @@ To support XA transactions, SQL Server requires a specific configuration.
 You can refer to [MSDN](https://msdn.microsoft.com/en-us/library/aa342335(v=sql.110).aspx) for more information.
 Here is the list of steps to perform (as an example, the database name BONITA\_BPM is used):
 
-1. Make sure you have already downloaded the [Microsoft SQL Server JDBC Driver 6.0](https://www.microsoft.com/en-us/download/details.aspx?displaylang=en&id=11774).
+1. Download the zip package of [Microsoft SQL Server JDBC Driver 6.0](https://www.microsoft.com/en-us/download/details.aspx?displaylang=en&id=11774) and unzip it. 
 2. Copy the `sqljdbc_xa.dll` from `%JDBC_DRIVER_INSTALL_ROOT%\sqljdbc_6.0\enu\xa\x64\` (x64 for 64 bit version of Windows, x86 for 32 bit version of Windows) to `%SQLSERVER_INSTALL_ROO%\Instance_root\MSSQL10.MSSQLSERVER\MSSQL\Binn\.`
-3. Copy/paste the content of xa\_install.sql file (located in `%JDBC\_DRIVER\_INSTALL\_ROOT%\\sqljdbc\_6.0\\enu\\xa`) to SQL Server Management Studio's Query Editor.
+3. Copy/paste the content of `install.sql` file (located in `%JDBC_DRIVER_INSTALL_ROOT%\sqljdbc\6.0\enu\xa`) to SQL Server Management Studio's Query Editor.
 4. Execute the query in the Query Editor.
 5. To confirm successful execution of the script, open the "Object Explorer" and go to: **Master** \> **Programmability** \> **Extended Stored Procedures**.   
    You should have 12 new procedures, each with a name starting with `dbo.xp.sqljdbc_xa_`.

--- a/md/database-configuration.md
+++ b/md/database-configuration.md
@@ -166,9 +166,9 @@ To support XA transactions, SQL Server requires a specific configuration.
 You can refer to [MSDN](https://msdn.microsoft.com/en-us/library/aa342335(v=sql.110).aspx) for more information.
 Here is the list of steps to perform (as an example, the database name BONITA\_BPM is used):
 
-1. Make sure you have already downloaded and installed the [Microsoft SQL Server JDBC Driver 4.0](https://www.microsoft.com/en-us/download/details.aspx?displaylang=en&id=11774).
-2. Copy the `sqljdbc_xa.dll` from `%JDBC_DRIVER_INSTALL_ROOT%\sqljdbc_4.0\enu\xa\x64\` (x64 for 64 bit version of Windows, x86 for 32 bit version of Windows) to `%SQLSERVER_INSTALL_ROO%\Instance_root\MSSQL10.MSSQLSERVER\MSSQL\Binn\.`
-3. Copy/paste the content of xa\_install.sql file (located in %JDBC\_DRIVER\_INSTALL\_ROOT%\\sqljdbc\_4.0\\enu\\xa) to SQL Server Management Studio's Query Editor.
+1. Make sure you have already downloaded the [Microsoft SQL Server JDBC Driver 6.0](https://www.microsoft.com/en-us/download/details.aspx?displaylang=en&id=11774).
+2. Copy the `sqljdbc_xa.dll` from `%JDBC_DRIVER_INSTALL_ROOT%\sqljdbc_6.0\enu\xa\x64\` (x64 for 64 bit version of Windows, x86 for 32 bit version of Windows) to `%SQLSERVER_INSTALL_ROO%\Instance_root\MSSQL10.MSSQLSERVER\MSSQL\Binn\.`
+3. Copy/paste the content of xa\_install.sql file (located in `%JDBC\_DRIVER\_INSTALL\_ROOT%\\sqljdbc\_6.0\\enu\\xa`) to SQL Server Management Studio's Query Editor.
 4. Execute the query in the Query Editor.
 5. To confirm successful execution of the script, open the "Object Explorer" and go to: **Master** \> **Programmability** \> **Extended Stored Procedures**.   
    You should have 12 new procedures, each with a name starting with `dbo.xp.sqljdbc_xa_`.

--- a/md/deploy-bundle.md
+++ b/md/deploy-bundle.md
@@ -130,7 +130,7 @@ We assume here that the database has already been [created and configured for Bo
 Once created and configured you need to initialize it using the setup tool provided in the deploy bundle archive.
 This will create database schema and initial values.
 1. In DEPLOY_ZIP_HOME/setup folder, edit the file database.properties with properties matching your rdbms
-2. In DEPLOY_ZIP_HOME/setup/lib add your jdbc driver if needed (only for Microsoft SQL Server or Oracle)
+2. In DEPLOY_ZIP_HOME/setup/lib add your jdbc driver if needed (only for Microsoft SQL Server or Oracle, see [proprietary jdbc drivers](database-configuration.md#proprietary_jdbc_drivers))
 3. In DEPLOY_ZIP_HOME/setup folder, run `setup.(sh|bat) init`
 
 ## Next steps

--- a/md/deploy-bundle.md
+++ b/md/deploy-bundle.md
@@ -74,7 +74,7 @@ JTA data source (managed by Bitronix)
 ### Add Jdbc driver
 You need to add your jdbc driver in TOMCAT_HOME/lib. 
 MySQL and PostgreSQL drivers can be found in deploy bundle under DEPLOY_ZIP_HOME/setup/lib directory. For other RDBMS, 
-use the driver provided by your RDBMS vendor
+use the [jdbc driver](database-configuration.md#proprietary_jdbc_drivers) provided by your RDBMS vendor
 
 <a id="wildfly-installation" />
 

--- a/md/images/special_code/sqlserver/module.xml
+++ b/md/images/special_code/sqlserver/module.xml
@@ -2,10 +2,11 @@
 
 <module xmlns="urn:jboss:module:1.3" name="com.sqlserver">
 	<resources>
-		<resource-root path="sqljdbc4.jar"/>
+		<resource-root path="sqljdbc42.jar"/>
 	</resources>
 	<dependencies>
 		<module name="javax.api"/>
 		<module name="javax.transaction.api"/>
+		<module name="javax.xml.bind.api"/>
 	</dependencies>
 </module>

--- a/md/tomcat-bundle.md
+++ b/md/tomcat-bundle.md
@@ -209,7 +209,7 @@ To update the licenses after the first run, take a look at the [platform setup t
 ---
 
 **Problem**:  
-My **Microsoft SQL Server** or **Oracle** database drivers do not seem to be taken into account when I put them in `<WILDFLY_HOME>/setup/lib` folder.
+My **Microsoft SQL Server** or **Oracle** database drivers do not seem to be taken into account when I put them in `<TOMCAT_HOME>/setup/lib` folder.
 
 **Cause**:  
 Driver file must respect some naming convention.
@@ -220,7 +220,7 @@ For Oracle, rename it so that the name contains at least the word `oracle` or `o
 
 ---
 
-**Issue**: When I run `bonita-start.sh` or `bonita-start.bat`, I get the error message `Invalid Java version (1.7) < 1.8. Please set JRE_HOME or JAVA_HOME variable to a JRE / JDK 1.8+`
+**Issue**: When I run `start-bonita.sh` or `start-bonita.bat`, I get the error message `Invalid Java version (1.7) < 1.8. Please set JRE_HOME or JAVA_HOME variable to a JRE / JDK 1.8+`
 
 **Cause**: Bonita BPM 7.5+ requires Java 1.8 to run
 

--- a/md/tomcat-bundle.md
+++ b/md/tomcat-bundle.md
@@ -138,7 +138,7 @@ For production, you are recommended to use one of the supported databases, with 
 
 1. Make sure [your databases are created](database-configuration.md#database_creation) and [customized to work with Bonita BPM](database-configuration.md#specific_database_configuration).
 2. Edit file `<TOMCAT_HOME>/setup/database.properties` and modify the properties to suit your databases (Bonita BPM internal database & Business Data database)
-3. If you use **Microsoft SQL Server** or **Oracle** database, copy your database drivers in `<TOMCAT_HOME>/setup/lib/` folder. 
+3. If you use **Microsoft SQL Server** or **Oracle** database, copy your [jdbc driver](database-configuration.md#proprietary_jdbc_drivers) in `<TOMCAT_HOME>/setup/lib/` folder. 
 4. Run `<TOMCAT_HOME>\setup\start-bonita.bat` (Windows system) or `<TOMCAT_HOME>/setup/start-bonita.sh` (Unix system) to run Bonita BPM Tomcat bundle (see [Tomcat start script](#tomcat_start))
 
 ::: info

--- a/md/wildfly-bundle.md
+++ b/md/wildfly-bundle.md
@@ -216,3 +216,11 @@ For Oracle, rename it so that the name contains at least the word `oracle` or `o
 **Solution**: Ensure your running environment has a JDK or JRE 1.8 installed and set either JAVA or JAVA_HOME environment variable to point to it.
 
 ---
+
+**Issue**: When I start the Wildfly bundle configured to use a **Microsoft SQL Server** database, I get the error message `java.lang.NoClassDefFoundError: javax/xml/bind/DatatypeConverter`
+
+**Cause**: The WildFly configuration has not been properly updated (BS-16758)
+
+**Solution**: In the _<WILDFLY_HOME>/server/modules/com/sqlserver/main/module.xml_ file, add `<module name="javax.xml.bind.api"/>` in the list of dependencies
+
+---

--- a/md/wildfly-bundle.md
+++ b/md/wildfly-bundle.md
@@ -126,7 +126,7 @@ For production, you are recommended to use one of the supported databases, with 
 
 1. Make sure [your databases are created](database-configuration.md#database_creation) and [customized to work with Bonita BPM](database-configuration.md#specific_database_configuration).
 2. Edit file `<WILDFLY_HOME>/setup/database.properties` and modify the properties to suit your databases (Bonita BPM internal database & Business Data database)
-3. If you use **Microsoft SQL Server** or **Oracle** database, copy your database drivers in `<WILDFLY_HOME>/setup/lib` folder. 
+3. If you use **Microsoft SQL Server** or **Oracle** database, copy your [jdbc driver](database-configuration.md#proprietary_jdbc_drivers) in `<WILDFLY_HOME>/setup/lib` folder. 
 4. Run `<WILDFLY_HOME>\start-bonita.bat` (Windows system) or `<WILDFLY_HOME>/start-bonita.sh (Unix system)` to run Bonita BPM WildFly bundle (see [WildFly start script](#wildfly_start))
 
 ::: info
@@ -219,7 +219,7 @@ For Oracle, rename it so that the name contains at least the word `oracle` or `o
 
 **Issue**: When I start the Wildfly bundle configured to use a **Microsoft SQL Server** database, I get the error message `java.lang.NoClassDefFoundError: javax/xml/bind/DatatypeConverter`
 
-**Cause**: The WildFly configuration has not been properly updated (BS-16758)
+**Cause**: The WildFly configuration has not been properly updated
 
 **Solution**: In the _<WILDFLY_HOME>/server/modules/com/sqlserver/main/module.xml_ file, add `<module name="javax.xml.bind.api"/>` in the list of dependencies
 


### PR DESCRIPTION
In the 7.5.0+ version, user must use the sqlserver42.jar jdbc driver as Bonita runs with Java 8.
Also add a troubleshooting tip for the error that currently occurs with the Wildfly bundle.

Relates to [BS-16758](https://bonitasoft.atlassian.net/browse/BS-16758)