### PR TITLE
fix(rest api extensions): example now uses JsonBuilder#toString

### DIFF
--- a/md/rest-api-extensions.md
+++ b/md/rest-api-extensions.md
@@ -85,7 +85,7 @@ int startIndex = p*c
 int endIndex = p*c + users.size() - 1
 
 // Send the result as a JSON representation
-return buildPagedResponse(responseBuilder, new JsonBuilder(result).toPrettyString(), startIndex, endIndex, context.apiClient.identityAPI.numberOfUsers)
+return buildPagedResponse(responseBuilder, new JsonBuilder(result).toString(), startIndex, endIndex, context.apiClient.identityAPI.numberOfUsers)
 ```
 
 Make sure you are adding all missing imports (default shortcut CTRL+SHIFT+o).


### PR DESCRIPTION
The toPrettyString generates human friendly json but larger data, so switch
to toString in the example to provide better guidance.

Relates to [BS-16795](https://bonitasoft.atlassian.net/browse/BS-16795)