### PR TITLE
fix(csrf): Explain how to use page from 7.3.3 version or lower

### DIFF
--- a/md/create-or-modify-a-page.md
+++ b/md/create-or-modify-a-page.md
@@ -42,6 +42,7 @@ The preview displays the artifact as it would be displayed on the selected type 
 
 Custom widget is a special artifact that we will explain in a later chapter.
 
+<a id="export"/>
 ## Export an artifact
 
 You can export a page or a layout to deploy it in Bonita BPM Portal as a custom page.  
@@ -51,6 +52,7 @@ To export an artifact, click the **_Export_** button ![Export button](images/ima
 
 After export you can modify your page or layout code by directly editing the code located in _resources_ folder. Be aware that such a modification to the code will work when the page or layout is deployed in Bonita BPM Portal but it may be broken if you import the page into another UI Designer.
 
+<a id="import"/>
 ## Import an artifact
 
 To import an artifact from another UI Designer, go to the UI Designer home page and click the **_Import_** button ![Import button](images/images-6_0/pb-import.png). When you import a page, layout, form or fragment, its dependencies (such as custom widgets and fragments used) are automatically be imported too.

--- a/md/csrf-security.md
+++ b/md/csrf-security.md
@@ -73,3 +73,15 @@ To activate the addition of the secure flag, edit the configuration file and cha
 [User authentication overview](user-authentication-overview.md)
 [Read more about CSRF attacks](http://www.acunetix.com/websitesecurity/csrf-attacks)
 
+
+## How to Migrate your pages to 7.4.0 or greater when CSRF security is enabled
+To use a UI page or form that was created in lower version than 7.4, you need to re-import this old page in actual UI designer. If you don't update your page, any API call in your outdated version will be failed because `X-Bonita-API-Token` will be absent in the response header. 
+Follow this few steps to update your page or form:
+
+In UI designer:
+1) [**Import**](create-or-modify-a-page.md#import) the page from 7.3.X or lower version.
+1) [**Export**](create-or-modify-a-page.md#export) the page you previously imported.
+
+In the portal as Administrator:
+1) Go on Resources entry.
+1) [Edit the existing page](resource-management.md#modify) by uploading the new one.

--- a/md/resource-management.md
+++ b/md/resource-management.md
@@ -74,6 +74,7 @@ If you have specified a resource permission that is not defined in the [REST API
 
 After a resource is added to the portal, it can be used in an [application](applications.md) or in a custom profile.
 
+<a id="modify"/>
 ## Modify a resource
 
 To modify a resource in the portal, you upload a zip archive containing the new version.


### PR DESCRIPTION
add section in csrf-security to explain how to use a page form 7.3.3 or lower version to 7.4.0 or greater when CSRF is enabled

Covers[BS-16681](https://bonitasoft.atlassian.net/browse/BS-16681)