### PR TITLE
feat(sqlserver): setup tool accepts the new open source jdbc jar

### DIFF
--- a/md/tomcat-bundle.md
+++ b/md/tomcat-bundle.md
@@ -209,7 +209,7 @@ My **Microsoft SQL Server** or **Oracle** database drivers do not seem to be tak
 Driver file must respect some naming convention.
 
 **Solution**:  
-For Microsoft SQL Server, rename it so that the name contains at least the word `sqlserver` or `sqljdbc` (case insensitive)  
+For Microsoft SQL Server, rename it so that the name contains at least the word `sqlserver` or `sqljdbc` or `mssql` (case insensitive)  
 For Oracle, rename it so that the name contains at least the word `oracle` or `ojdbc` (case insensitive)
 
 ---

--- a/md/wildfly-bundle.md
+++ b/md/wildfly-bundle.md
@@ -197,7 +197,7 @@ My **Microsoft SQL Server** or **Oracle** database drivers do not seem to be tak
 Driver file must respect some naming convention.
 
 **Solution**:  
-For Microsoft SQL Server, rename it so that the name contains at least the word `sqlserver` or `sqljdbc` (case insensitive)  
+For Microsoft SQL Server, rename it so that the name contains at least the word `sqlserver` or `sqljdbc` or `mssql` (case insensitive)  
 For Oracle, rename it so that the name contains at least the word `oracle` or `ojdbc` (case insensitive)
 
 ---


### PR DESCRIPTION
Microsoft has changed the name of the jar starting from version 6.2.
It is now mssql-jdbc-version.jre8.jar

Relates to [BS-16867](https://bonitasoft.atlassian.net/browse/BS-16867)