### PR TITLE
fix(getting started tutorial): typo in table

### DIFF
--- a/md/getting-started-tutorial.md
+++ b/md/getting-started-tutorial.md
@@ -456,7 +456,7 @@ Now define the form for the _Manager review_ task. Start by automatically genera
    | Label  | Widget type  | Value binding  | Read-only  |
    | -----  | ------------ | -------------- | ---------- |
    | Destination  | Input  | request.destination  | yes  |
-   | Departure date  | Date picker | request.departureDate | date  |yes  |
+   | Departure date  | Date picker | request.departureDate | yes  |
    | Number of nights  | Input  | request.numberOfNights  | yes  |
    | Hotel needed  | Checkbox  | request.hotelNeeded  | yes  |
    | Reason for travel  | Text area  | request.reason  | yes  |


### PR DESCRIPTION
In version 7.3 and 7.4 we use an input widget to display a date using a date filter so in the tutorial we use to have \|date in the table content. In the update for 7.5 we use a date widget and so need to remove the filter but only the \ was removed. This PR fix the issue.