### PR TITLE
add(Install, HW and SW Reqts): add instructions to patch Chrome 60

### DIFF
--- a/md/hardware-and-software-requirements.md
+++ b/md/hardware-and-software-requirements.md
@@ -96,7 +96,7 @@ Therefore, using Bitronix as a transaction manager with SQL Server does not work
 
 1. In an installed Bonita bundle, edit file 'server/webapps/bonita/portal/scripts/includes/common.js':
    1. Add the code below after or before the existing code:
-   ```java
+   ```javascript
    `  // Monkey Patch xhr
       // Due to a specification change in the xhr.getAllResponseHeaders method Bonita Portal does not behave as expected 
       // in browsers that implement this new specification (currently only Chrome >60).

--- a/md/hardware-and-software-requirements.md
+++ b/md/hardware-and-software-requirements.md
@@ -36,7 +36,7 @@ Software required for Bonita BPM Platform (Bonita BPM Engine and Bonita BPM Port
 | Oracle  | 11gR2 (11.2.0.x) and 12c (12.1.0.x.y) |
 | **Browser** |
 | Mozilla Firefox | latest version |
-| Google Chrome | latest version |
+| Google Chrome | latest version (see note 4) |
 | Microsoft Edge | latest version |
 | **Mobile** |
 | Mozilla Firefox | latest version |
@@ -50,5 +50,74 @@ Notes:
 (refer to: [MSDN note](https://msdn.microsoft.com/en-us/library/aa342335.aspx), [Bitronix note](http://bitronix-transaction-manager.10986.n7.nabble.com/Failed-to-recover-SQL-Server-Restart-td148.html)).
 Therefore, using Bitronix as a transaction manager with SQL Server does not work and is not supported. To use SQL Server database requires that you use the WildFly bundle provided by Bonitasoft.
 3. Bonita BPM can be executed on Java 8 and above. All development artifacts (connectors, REST API extensions, etc) must be compiled with Java 8 byte code (target version).
+4. Chrome version 60.0.3112 introduced an incompatibility impacting the functionality of the Bonita Portal. From that version onwards, once your BonitaBPM Platform is installed, please apply the following procedure to resolve this issue:
+
+#### Subscription users
+::: info
+**Note:** In order to apply this procedure, you MUST use a browser version that doesn't suffer from the incompatibility. You can use Firefox, Internet Explorer/Edge or Safari, for example.
+:::
+
+1. Log in the Bonita Portal as Administrator.
+1. In the menu, click on 'Portal'.
+1. Click on 'Export the current Look&Feel'.
+1. Make a back-up copy of the exported file.
+1. Unzip the exported file 'portal-theme.zip'.
+1. Edit 'BonitaConsole.html' file:
+   1. In the `<head>` section, add the code below:
+   ```xml
+   <script>
+      // Monkey Patch xhr
+      // Due to a specification change in the xhr.getAllResponseHeaders method Bonita Portal does not behave as expected 
+      // in browsers that implement this new specification (currently only Chrome >60).
+      // This patch fixes xhr.getAllResponseHeaders unwanted behavior whithin Bonita Portal context
+      //    See https://bugs.chromium.org/p/chromium/issues/detail?id=749086
+      //    See https://github.com/whatwg/xhr/issues/146
+      (function (xhr) {
+          var caseSensitiveHeaders = ['Content-Range', 'X-Bonita-API-Token'];
+          
+          var getAllResponseHeaders = xhr.getAllResponseHeaders;
+          
+          xhr.getAllResponseHeaders = function () {
+              var headers = getAllResponseHeaders.apply(this);
+              for (var i = 0; i < caseSensitiveHeaders.length; i++) {
+                  headers = headers.replace(new RegExp('^' + caseSensitiveHeaders[i].toLowerCase(), 'm'), caseSensitiveHeaders[i]);
+              }
+              return headers;
+          }
+      })(XMLHttpRequest.prototype)
+    </script>
+    ```
+1. Zip all the files and folders again into 'portal-theme.zip'. 
+   (BEWARE: make sure not to zip the 'portal-theme' folder, but its contents. If the 'portal-theme.zip' contains a 'portal-theme' folder at the base, the Bonita Portal will not recognise it as a valid zip structure.)
+1. In the portal, click on 'Import and apply a new Look&Feel' and choose the updated 'portal-theme.zip' file.
+1. Back in your Chrome update 60 browser, empty the cache.
+
+#### Community users
+
+1. In an installed Bonita bundle, edit file 'server/webapps/bonita/portal/scripts/includes/common.js':
+   1. Add the code below after or before the existing code:
+   ```java
+   `  // Monkey Patch xhr
+      // Due to a specification change in the xhr.getAllResponseHeaders method Bonita Portal does not behave as expected 
+      // in browsers that implement this new specification (currently only Chrome >60).
+      // This patch fixes xhr.getAllResponseHeaders unwanted behavior whithin Bonita Portal context
+      //    See https://bugs.chromium.org/p/chromium/issues/detail?id=749086
+      //    See https://github.com/whatwg/xhr/issues/146
+      (function (xhr) {
+          var caseSensitiveHeaders = ['Content-Range', 'X-Bonita-API-Token'];
+    
+          var getAllResponseHeaders = xhr.getAllResponseHeaders;
+    
+          xhr.getAllResponseHeaders = function () {
+              var headers = getAllResponseHeaders.apply(this);
+              for (var i = 0; i < caseSensitiveHeaders.length; i++) {
+                  headers = headers.replace(new RegExp('^' + caseSensitiveHeaders[i].toLowerCase(), 'm'), caseSensitiveHeaders[i]);
+              }
+              return headers;
+          }
+      })(XMLHttpRequest.prototype)`
+      ```
+1. In your Chrome update 60 browser, empty the cache.
+
 
 Your database must be configured to use the UTF-8 character set.

--- a/md/hardware-and-software-requirements.md
+++ b/md/hardware-and-software-requirements.md
@@ -24,19 +24,19 @@ Software required for Bonita BPM Platform (Bonita BPM Engine and Bonita BPM Port
 | Red Hat Enterprise Linux |  6.5 64 bits and higher |
 | Ubuntu | 14.04 LTS 64 bits and higher |
 | **Java Virtual Machine** |
-| Oracle Java SE Runtime Environment | 8u112 (see note 3) |
-| OpenJDK | 8u112 (see note 3) |
+| Oracle Java SE Runtime Environment | 8u112 (see note 4) |
+| OpenJDK | 8u112 (see note 4) |
 | **Application Server** |
 | Apache Tomcat | 7.0.x (x > 67) |
 | Red Hat WildFly | 10.1.x |
 | **Database** |
-| MySQL | 5.5.27 and higher (see note 1) |
+| MySQL | 5.5.27 and higher (see note 2) |
 | PostgreSQL | 9.3 and higher |
-| SQL Server | 2012 (see note 2) |
+| SQL Server | 2012 (see note 3) |
 | Oracle  | 11gR2 (11.2.0.x) and 12c (12.1.0.x.y) |
 | **Browser** |
 | Mozilla Firefox | latest version |
-| Google Chrome | latest version (see note 4) |
+| Google Chrome | latest version (see note 5) |
 | Microsoft Edge | latest version |
 | **Mobile** |
 | Mozilla Firefox | latest version |
@@ -44,13 +44,13 @@ Software required for Bonita BPM Platform (Bonita BPM Engine and Bonita BPM Port
 | Apple Safari | latest version |
 
 Notes:
-
-1. MySQL must be configured with innoDB storage engine.
-2. There is a known issue between Bitronix (the transaction manager shipped by Bonitasoft for the Tomcat bundle and inside the Deploy bundle for Tomcat) and Microsoft SQL Server JDBC driver
+1. Your database must be configured to use the UTF-8 character set.
+2. MySQL must be configured with innoDB storage engine.
+3. There is a known issue between Bitronix (the transaction manager shipped by Bonitasoft for the Tomcat bundle and inside the Deploy bundle for Tomcat) and Microsoft SQL Server JDBC driver
 (refer to: [MSDN note](https://msdn.microsoft.com/en-us/library/aa342335.aspx), [Bitronix note](http://bitronix-transaction-manager.10986.n7.nabble.com/Failed-to-recover-SQL-Server-Restart-td148.html)).
 Therefore, using Bitronix as a transaction manager with SQL Server does not work and is not supported. To use SQL Server database requires that you use the WildFly bundle provided by Bonitasoft.
-3. Bonita BPM can be executed on Java 8 and above. All development artifacts (connectors, REST API extensions, etc) must be compiled with Java 8 byte code (target version).
-4. Chrome version 60.0.3112 introduced an incompatibility impacting the functionality of the Bonita Portal. From that version onwards, once your BonitaBPM Platform is installed, please apply the following procedure to resolve this issue:
+4. Bonita BPM can be executed on Java 8 and above. All development artifacts (connectors, REST API extensions, etc) must be compiled with Java 8 byte code (target version).
+5. Chrome version 60.0.3112 introduced an incompatibility impacting the functionality of the Bonita Portal. From that version onwards, once your BonitaBPM Platform is installed, please apply the following procedure to resolve this issue:
 
 #### Subscription users
 ::: info

--- a/md/hardware-and-software-requirements.md
+++ b/md/hardware-and-software-requirements.md
@@ -118,6 +118,3 @@ Therefore, using Bitronix as a transaction manager with SQL Server does not work
       })(XMLHttpRequest.prototype)`
       ```
 1. In your Chrome update 60 browser, empty the cache.
-
-
-Your database must be configured to use the UTF-8 character set.

--- a/md/hardware-and-software-requirements.md
+++ b/md/hardware-and-software-requirements.md
@@ -64,12 +64,12 @@ Therefore, using Bitronix as a transaction manager with SQL Server does not work
 1. Unzip the exported file 'portal-theme.zip'.
 1. Edit 'BonitaConsole.html' file:
    1. In the `<head>` section, add the code below:
-   ```xml
+   ```javascript
    <script>
       // Monkey Patch xhr
       // Due to a specification change in the xhr.getAllResponseHeaders method Bonita Portal does not behave as expected 
       // in browsers that implement this new specification (currently only Chrome >60).
-      // This patch fixes xhr.getAllResponseHeaders unwanted behavior whithin Bonita Portal context
+      // This patch fixes xhr.getAllResponseHeaders unwanted behavior within Bonita Portal context
       //    See https://bugs.chromium.org/p/chromium/issues/detail?id=749086
       //    See https://github.com/whatwg/xhr/issues/146
       (function (xhr) {
@@ -100,7 +100,7 @@ Therefore, using Bitronix as a transaction manager with SQL Server does not work
    `  // Monkey Patch xhr
       // Due to a specification change in the xhr.getAllResponseHeaders method Bonita Portal does not behave as expected 
       // in browsers that implement this new specification (currently only Chrome >60).
-      // This patch fixes xhr.getAllResponseHeaders unwanted behavior whithin Bonita Portal context
+      // This patch fixes xhr.getAllResponseHeaders unwanted behavior within Bonita Portal context
       //    See https://bugs.chromium.org/p/chromium/issues/detail?id=749086
       //    See https://github.com/whatwg/xhr/issues/146
       (function (xhr) {


### PR DESCRIPTION
Versions: Proposal for 7.5 (should be adapted for all versions starting from 6.2)

Set of instructions to patch Bonita BPM Platform for Chrome 60+ versions, both for Subscription and Community users.

_Reference bug: **BS-16954**- Portal incompatible with Chrome 60 (released 25 Jul 2017)

