### PR TITLE
feat(process display name) Add limitation for jasper reports

### DIFF
--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -51,6 +51,8 @@ To be documented
 
 ## Limitations and known issues
 
+* Process display name is now used everywhere in Bonita portal (when it has been set in the process design) except in the default provided Jasper reports.
+
 ## Bug fixes
 
 ### Fixes in Bonita 7.6


### PR DESCRIPTION
- provided Jasper reports still use the name rather than the
displayname. This is a known limitation.

Covers [BS-16825](https://bonitasoft.atlassian.net/browse/BS-16825)