### PR TITLE
Advanced Example needs to be updated for ui-bootstrap >=2.0.0

### DIFF
--- a/md/custom-widgets.md
+++ b/md/custom-widgets.md
@@ -74,11 +74,11 @@ You can now use the _carousel_ and _slide_ directives in your template. Here is 
 
 Template:
 ``` html
-<uib-carousel>
-      <uib-slide ng-repeat="slide in slides" >
+<div uib-carousel>
+      <div uib-slide ng-repeat="slide in slides" >
         <img ng-src="{{slide.url}}" style="margin:auto;" alt="{{slide.alt | uiTranslate}}">
-      </uib-slide>
-</uib-carousel>
+      </div>
+</div>
 ```
 
 Controller:


### PR DESCRIPTION
It took me a long debugging session to figure out why I can't use <uib-carousel> and <uib-slide> tags. It's because starting from version 2.0.0, the ui-bootstrap code added "restrict:'A'" clause to the angular directives for uibCarousel and uibSlide.

fix(Widgets): fixing advanced example for the custom widgets

Fixed advanced example code to work for ui-bootstrap >= v2.0.0. Replaced uib-carousel and uib-slide elements with equivalent div tags.