### PR TITLE
doc(SAML): fix typo loging.jsp to login.jsp

### DIFF
--- a/md/single-sign-on-with-saml.md
+++ b/md/single-sign-on-with-saml.md
@@ -44,7 +44,7 @@ it is composed of:
 
 ::: warning  
  Bonita "username" should match the NameId or one attribute of the subject returned by the IdP in the response. 
- If some users need to be able to log in without having an account on the IDP, you can authorize it by activating an option in the file `authenticationManager-config.properties` (see 2. below). Users will then be able to log in using the portal login page (/loging.jsp) provided they have a bonita account and their password is different from their username.
+ If some users need to be able to log in without having an account on the IDP, you can authorize it by activating an option in the file `authenticationManager-config.properties` (see 2. below). Users will then be able to log in using the portal login page (/login.jsp) provided they have a bonita account and their password is different from their username.
 :::
 
 ## Configure Bonita BPM Bundle for SAML
@@ -84,7 +84,7 @@ To configure Bonita BPM for SAML:
     Make sure to [set the right tenant admin username](multi-tenancy-and-tenant-configuration#toc2).
     It is recommended to also replace the value of the passphrase (property auth.passphrase) which is used by the engine to verify the authentication request.
     The value must be the same as in the file **bonita-tenant-sp-custom.properties**.  
-    If you need some users to be able to log in without having an account on the IDP, you can authorize it by setting the property `saml.auth.standard.allowed` to true. Users will then be able to log in using the portal login page (/loging.jsp) provided they have a bonita account and their password is different from their username.
+    If you need some users to be able to log in without having an account on the IDP, you can authorize it by setting the property `saml.auth.standard.allowed` to true. Users will then be able to log in using the portal login page (/login.jsp) provided they have a bonita account and their password is different from their username.
 
 3. In the tenant_engine folder of each existing tenant: `$TOMCAT_HOME/setup/platform_conf/current/tenants/<TENANT_ID>/tenant_engine/`,
   edit the file **bonita-tenant-sp-custom.xml** to uncomment the bean passphraseOrPasswordAuthenticationService:


### PR DESCRIPTION
Fix typo in 2 sentences, (/loging.jsp) becomes (/login.jsp) : 
"Users will then be able to log in using the portal login page (/loging.jsp) provided they have a bonita account and their password is different from their username."