### PR TITLE
doc(deploy) add warning on tomcat bugged version

### DIFF
--- a/md/deploy-bundle.md
+++ b/md/deploy-bundle.md
@@ -42,6 +42,9 @@ Copy all files and directories from DEPLOY_ZIP_HOME/Tomcat-8.5.23/server to your
 Some configuration files from the deploy zip will overwrite some default tomcat configuration files. Proceed
 with care in a tomcat where other applications are already installed.
 :::
+:::warning
+There is an [issue on tomcat 8.0.32](https://bz.apache.org/bugzilla/show_bug.cgi?id=58999) preventing the portal Look & feel to be compiled. If you deploy bonita on an existing tomcat installation, make sure it is a different version of tomcat (preferably 8.5.x with x>=23).
+:::
 
 ### Configure data sources
 


### PR DESCRIPTION
- version 8.0.32 of tomcat has an [issue](https://bz.apache.org/bugzilla/show_bug.cgi?id=58999) preventing the lib we use to compile LESS to work which make the portal unusable
Add a warning to document that