### PR TITLE
fix(doc): attempt to enhance the License section

### DIFF
--- a/md/migrate-from-an-earlier-version-of-bonita-bpm.md
+++ b/md/migrate-from-an-earlier-version-of-bonita-bpm.md
@@ -180,23 +180,25 @@ The `bonita_home` and the database have been migrated.
     * `tenants/[TENANT_ID]/conf/dynamic-permissions-checks.properties` : used if dynamic check on permissions is enabled
                
 1. Configure License:
-    If the version after migration is 7.3 or greater, configure the setup tool and download the configuration from database.
-    You may also see this page for more details [Platform configuration](BonitaBPM_platform_setup.md#update_platform_conf).
+
+    If the version after migration is 7.3 or greater, you need to put a new license in the database: see [Platform configuration](BonitaBPM_platform_setup.md#update_platform_conf) for further details.
     
-    There is below a Linux example to download the configuration from database into the local disk, after having configured the setup tool:
-    # cd setup
-    # ./setup.sh pull
-    
-    Make sure there is a valid license file in the ./platform_conf/licenses/ directory:
-    # ls -l ./platform_conf/licenses/
-    
-    If there is no valid license, these 2 pages will help you to request and install a new one:
+    There is below a Linux example :
+    ```
+    cd setup
+    vi database.properties
+    ./setup.sh pull
+    ls -l ./platform_conf/licenses/
+    ```
+    If there is no valid license in the `./platform_conf/licenses/`, these 2 pages will help you to request and install a new one:
     * [Licenses](https://documentation.bonitasoft.com/?page=licenses)
     * [Platform configuration](BonitaBPM_platform_setup.md#update_platform_conf)
    
-    When a valid license file had been stored into ./platform_conf/licenses/ directory, it should be pushed into the database:
-    # ./setup.sh push
-    
+    Install the new license:
+    ```
+    cp BonitaBPMSubscription-7.n-Jerome-myHosname-20171023-20180122.lic ./platform_conf/licenses/
+    ./setup.sh push
+    ```
     
     When the version after migration is 7.2 or lower, simply save a valid license in the bonita_home/server/licenses directory.
     

--- a/md/migrate-from-an-earlier-version-of-bonita-bpm.md
+++ b/md/migrate-from-an-earlier-version-of-bonita-bpm.md
@@ -180,13 +180,26 @@ The `bonita_home` and the database have been migrated.
     * `tenants/[TENANT_ID]/conf/dynamic-permissions-checks.properties` : used if dynamic check on permissions is enabled
                
 1. Configure License:
-    Make sure there is a valid license file
-    * If you have migrated from an earlier maintenance version of the same minor version, for example, from 6.3.0 to 6.3.1, your existing license is still valid and you do not need to do anything.
-    * If you have have migrated from an earlier minor version, for example from 6.0.4 to 6.2.1, you need to [request a new license](licenses.md).
-        * *Before 7.3.0*:
-        Put your new license in `/bonita_home/server/licenses`.
-        * *After 7.3.0*:
-        Put your new license in database as described in [this guide](BonitaBPM_platform_setup.md#update_platform_conf).
+    If the version after migration is 7.3 or greater, configure the setup tool and download the configuration from database.
+    You may also see this page for more details [Platform configuration](BonitaBPM_platform_setup.md#update_platform_conf).
+    
+    There is below a Linux example to download the configuration from database into the local disk, after having configured the setup tool:
+    # cd setup
+    # ./setup.sh pull
+    
+    Make sure there is a valid license file in the ./platform_conf/licenses/ directory:
+    # ls -l ./platform_conf/licenses/
+    
+    If there is no valid license, these 2 pages will help you to request and install a new one:
+    * [Licenses](https://documentation.bonitasoft.com/?page=licenses)
+    * [Platform configuration](BonitaBPM_platform_setup.md#update_platform_conf)
+   
+    When a valid license file had been stored into ./platform_conf/licenses/ directory, it should be pushed into the database:
+    # ./setup.sh push
+    
+    
+    When the version after migration is 7.2 or lower, simply save a valid license in the bonita_home/server/licenses directory.
+    
 1. Start the application server. Before you start Bonita BPM Portal, clear your browser cache. If you do not clear the cache, you might see old, cached versions of Portal pages instead of the new version. 
 Log in to the Portal and verify that the migration has completed. 
 If you did not set the default Look & Feel before migration and you cannot log in, you need to [restore the default Look & Feel](managing-look-feel.md) using a REST client or the Engine API.

--- a/md/migrate-from-an-earlier-version-of-bonita-bpm.md
+++ b/md/migrate-from-an-earlier-version-of-bonita-bpm.md
@@ -181,8 +181,7 @@ The `bonita_home` and the database have been migrated.
                
 1. Configure License:
 
-    If the version after migration is 7.3 or greater, you need to put a new license in the database: see [Platform configuration](BonitaBPM_platform_setup.md#update_platform_conf) for further details.
-    
+    * If the version after migration is **7.3 or greater**, you need to put a new license in the database: see [Platform configuration](BonitaBPM_platform_setup.md#update_platform_conf) for further details.  
     There is below a Linux example :
     ```
     cd setup
@@ -190,17 +189,19 @@ The `bonita_home` and the database have been migrated.
     ./setup.sh pull
     ls -l ./platform_conf/licenses/
     ```
+
     If there is no valid license in the `./platform_conf/licenses/`, these 2 pages will help you to request and install a new one:
-    * [Licenses](https://documentation.bonitasoft.com/?page=licenses)
-    * [Platform configuration](BonitaBPM_platform_setup.md#update_platform_conf)
-   
+
+      * [Licenses](https://documentation.bonitasoft.com/?page=licenses)
+      * [Platform configuration](BonitaBPM_platform_setup.md#update_platform_conf)
+
     Install the new license:
     ```
     cp BonitaBPMSubscription-7.n-Jerome-myHosname-20171023-20180122.lic ./platform_conf/licenses/
     ./setup.sh push
     ```
-    
-    When the version after migration is 7.2 or lower, simply save a valid license in the bonita_home/server/licenses directory.
+
+    * If the version after migration is **7.2.4 or lower**, simply save a valid license in the bonita_home/server/licenses directory.
     
 1. Start the application server. Before you start Bonita BPM Portal, clear your browser cache. If you do not clear the cache, you might see old, cached versions of Portal pages instead of the new version. 
 Log in to the Portal and verify that the migration has completed. 


### PR DESCRIPTION
Change the content of the *License* section because 100% of the customers are failing to start the application server after a migration.

Versions: 7.3, 7.4, 7.5, 7.6
