### PR TITLE
fix(database setup): document support for backslash characters \ must be doubled \\ in (database|internal).properties

### DIFF
--- a/md/BonitaBPM_platform_setup.md
+++ b/md/BonitaBPM_platform_setup.md
@@ -199,3 +199,13 @@ Or also if you need to use a specific **database Driver** java class name:
 **Solution**: Edit file `database.properties` and ensure there is a valid `db.vendor` value. Also ensure the line is not commented (no `#` at the beginning of the line)
 
 ---
+
+<a id="backslash_support" />
+
+**Issue**: My database name / password / ... contains a backslash (`\`) character. It seems to be ignored in file `database.properties`
+
+**Cause**: Backslash (`\`) characters are special characters in a .properties file
+
+**Solution**: Replace your backslash (`\`) characters by double-backslashes (`\\`) everywhere in file `database.properties` (and also in file `internal.properties` if you have modified it)
+
+---

--- a/md/deploy-bundle.md
+++ b/md/deploy-bundle.md
@@ -126,7 +126,7 @@ When you receive your license, copy the file to the `DEPLOY_ZIP_HOME/setup/platf
 We assume here that the database has already been [created and configured for Bonita](database-configuration.md#database_creation).
 Once created and configured you need to initialize it using the setup tool provided in the deploy bundle archive.
 This will create database schema and initial values.
-1. In DEPLOY_ZIP_HOME/setup folder, edit the file database.properties with properties matching your rdbms
+1. In DEPLOY_ZIP_HOME/setup folder, edit the file database.properties with properties matching your rdbms. Beware of [backslash characters](BonitaBPM_platform_setup.md#backslash_support).
 2. In DEPLOY_ZIP_HOME/setup/lib add your jdbc driver if needed (only for Microsoft SQL Server or Oracle, see [proprietary jdbc drivers](database-configuration.md#proprietary_jdbc_drivers))
 3. In DEPLOY_ZIP_HOME/setup folder, run `setup.(sh|bat) init`
 

--- a/md/install-a-bonita-bpm-cluster.md
+++ b/md/install-a-bonita-bpm-cluster.md
@@ -25,7 +25,7 @@ When done you will have a database with all tables created and with a table `CON
 1. [Create the database](database-configuration.md#database_creation).
 1. In case you use [Business data](define-and-deploy-the-bdm.md), [create a database for the Business Data](database-configuration.md#database_creation).
 1. Download a Bonita [Tomcat bundle](tomcat-bundle.md) or a Bonita [WildFly bundle](wildfly-bundle.md), and unzip it at some place of your choice.
-1. Edit file **`setup/database.properties`** and modify the properties to suit your databases (Bonita internal database & Business Data database).
+1. Edit file **`setup/database.properties`** and modify the properties to suit your databases (Bonita internal database & Business Data database). Beware of [backslash characters](BonitaBPM_platform_setup.md#backslash_support).
 
 In the following steps, you will update the configuration files that are in the `setup/platform_conf/initial` folder of the platform setup tool.
 

--- a/md/tomcat-bundle.md
+++ b/md/tomcat-bundle.md
@@ -131,7 +131,7 @@ For production, you are recommended to use one of the supported databases, with 
 :::
 
 1. Make sure [your databases are created](database-configuration.md#database_creation) and [customized to work with Bonita](database-configuration.md#specific_database_configuration).
-2. Edit file `<TOMCAT_HOME>/setup/database.properties` and modify the properties to suit your databases (Bonita internal database & Business Data database)
+2. Edit file `<TOMCAT_HOME>/setup/database.properties` and modify the properties to suit your databases (Bonita internal database & Business Data database). Beware of [backslash characters](BonitaBPM_platform_setup.md#backslash_support).
 3. If you use **Microsoft SQL Server** or **Oracle** database, copy your [jdbc driver](database-configuration.md#proprietary_jdbc_drivers) in `<TOMCAT_HOME>/setup/lib/` folder. 
 4. Run `<TOMCAT_HOME>\setup\start-bonita.bat` (Windows system) or `<TOMCAT_HOME>/setup/start-bonita.sh` (Unix system) to run Bonita Tomcat bundle (see [Tomcat start script](#tomcat_start))
 

--- a/md/upgrade-from-community-to-a-subscription-edition.md
+++ b/md/upgrade-from-community-to-a-subscription-edition.md
@@ -38,7 +38,7 @@ A Bonita platform upgrade can only be performed on the same database type.
 To upgrade a Bonita platform from Community edition to a Subscription edition, follow these steps:
 
 1. [Install the Subscription Bundle](bonita-installation-overview) but do not start it. We will call this installation folder `bonita-subscription`.
-2. Configure the Subscription installation to use your existing database editing the file `<bonita-subscription>/setup/database.properties`.
+2. Configure the Subscription installation to use your existing database editing the file `<bonita-subscription>/setup/database.properties`. Beware of [backslash characters](BonitaBPM_platform_setup.md#backslash_support).
 3. Shut down the Community server being migrated using the `stop-bonita` script, we will call this installation folder `bonita-community`.
 4. Run `<bonita-community>/setup/setup(.sh/.bat) pull` to fetch your current Community configuration in `<bonita-community>/setup/platform_conf/current` and copy this last in a different folder, we will call this new folder `bonita-community-configuration`.
 5. [Backup your Bonita platform and databases](back-up-bonita-platform.md).

--- a/md/wildfly-bundle.md
+++ b/md/wildfly-bundle.md
@@ -118,7 +118,7 @@ For production, you are recommended to use one of the supported databases, with 
 :::
 
 1. Make sure [your databases are created](database-configuration.md#database_creation) and [customized to work with Bonita](database-configuration.md#specific_database_configuration).
-2. Edit file `<WILDFLY_HOME>/setup/database.properties` and modify the properties to suit your databases (Bonita internal database & Business Data database)
+2. Edit file `<WILDFLY_HOME>/setup/database.properties` and modify the properties to suit your databases (Bonita internal database & Business Data database). Beware of [backslash characters](BonitaBPM_platform_setup.md#backslash_support).
 3. If you use **Microsoft SQL Server** or **Oracle** database, copy your [jdbc driver](database-configuration.md#proprietary_jdbc_drivers) in `<WILDFLY_HOME>/setup/lib` folder. 
 4. Run `<WILDFLY_HOME>\start-bonita.bat` (Windows system) or `<WILDFLY_HOME>/start-bonita.sh (Unix system)` to run Bonita WildFly bundle (see [WildFly start script](#wildfly_start))
 


### PR DESCRIPTION
Closes [BS-17304](https://bonitasoft.atlassian.net/browse/BS-17304)