### PR TITLE
fix(forms URL) remove deprecated warning

### DIFF
--- a/md/bonita-bpm-portal-urls.md
+++ b/md/bonita-bpm-portal-urls.md
@@ -99,7 +99,7 @@ Example:
 ## Task URL
 
 ::: danger
-:fa-exclamation-triangle: **Important:** A task is not automatically assigned to the user who accesses the task form. If a user is using Bonita BPM Portal, the assignment is automatic. However, if a user is accessing a form directly from an application, there must first be a [REST API call to assign the task to the user](bpm-api.md). Otherwise, the user will not be able to execute the task.
+:fa-exclamation-triangle: **Important:** A task is not automatically assigned to the user who accesses the task form. There must first be a [REST API call to assign the task to the user](bpm-api.md). Otherwise, the user will not be able to execute the task.
 :::
 
 The following code samples show how to generate a link to a human task.


### PR DESCRIPTION
- remove information regarding portal automatic task assign as this is no longer the case since 7.3