### PR TITLE
fix error in the bdm API

### DIFF
--- a/md/tenant-api.md
+++ b/md/tenant-api.md
@@ -45,7 +45,7 @@ Install or update a BDM on your tenant. Your tenant services need to be paused.
  :::
  
 * **URL**  
-  `/API/accessControl/bdm`  
+  `/API/tenant/bdm`  
 * **Method**  
   `POST`
 * **Success Response**


### PR DESCRIPTION
* The API to update the bdm is  `/API/tenant/bdm`  and not `/API/accessControl/bdm`

closes [BS-18037](https://bonitasoft.atlassian.net/browse/BS-18037)