### PR TITLE
fix(doc): fix out-of-date info in tomcat-bundle

### DIFF
--- a/md/tomcat-bundle.md
+++ b/md/tomcat-bundle.md
@@ -43,9 +43,9 @@ Whatever location you choose, **do not** leave blank spaces in the path to the d
 
 The Tomcat bundle is based on a standard Tomcat installation with the following additions:
 
-* `server/bin/setenv.bat`: script to configure JVM system properties for Windows.
-* `server/bin/setenv.sh`: script to configure JVM system properties for Linux.
-* `server/conf/Catalina/localhost/bonita.xml`: Tomcat context configuration for Bonita web application. Define data sources used by Bonita Engine.
+* `setup/tomcat-templates/setenv.bat`: script to configure JVM system properties for Windows.
+* `setup/tomcat-templates/setenv.sh`: script to configure JVM system properties for Linux.
+* `setup/tomcat-templates/bonita.xml`: Tomcat context configuration for Bonita web application. Define data sources used by Bonita Engine.
 * `server/conf/catalina.properties`: modified to include lib/bonita folder to Tomcat classpath.
 * `server/conf/context.xml`: modified to add JTA support using Bitronix library.
 * `server/conf/logging.properties`: modified to create a log file dedicated to Bonita.
@@ -59,7 +59,7 @@ The Tomcat bundle is based on a standard Tomcat installation with the following 
 * `start-bonita.sh`: script to start the bundle on Linux.
 * `stop-bonita.bat`: script to stop the bundle on Windows.
 * `stop-bonita.sh`: script to stop the bundle on Linux.
-
+ 
 ::: info
 **Note:** Beginning with version 7.3.0, Bonita BPM Platform configuration, including the license file, is stored in the same database as the Bonita BPM Engine data, namely in the `CONFIGURATION` table.
 The initialization of this configuration happens during `start-bonita.bat` (for Windows) or `start.bonita.sh` (for Linux) execution.  
@@ -96,6 +96,11 @@ As a security precaution, we **strongly recommend** that before you start your a
 
 #### Platform administrator
 
+The credentials are defined in a text file:
+ - Before the very first Tomcat start: [`<TOMCAT_HOME>/setup/platform_conf/initial/platform_engine/bonita-platform-community-custom.properties`](BonitaBPM_platform_setup.md)
+ - After the first Tomcat start: [`<TOMCAT_HOME>/setup/platform_conf/current/platform_engine/bonita-platform-community-custom.properties`](BonitaBPM_platform_setup.md)
+
+
 The username and password for the platform administrator are defined in the file [`<TOMCAT_HOME>/setup/platform_conf/initial/platform_engine/bonita-platform-community-custom.properties`](BonitaBPM_platform_setup.md), by the following properties:
 
 * `platformAdminUsername` defines the username (default `platformAdmin`)
@@ -116,11 +121,12 @@ When you create a tenant, the tenant administrator is created with the default u
 Change these tenant-specific credentials for an existing tenant by updating the `userName` and `userPassword` properties in `<TOMCAT_HOME>/setup/platform_conf/current/tenants/<TENANT_ID>/tenant_engine/bonita-tenant-community-custom.properties`.
 
 ::: warning
-For the **default tenant**, the tenant administrator username and password must also be changed in file [`<TOMCAT_HOME>/setup/platform_conf/initial/platform_portal/platform-tenant-config.properties`](BonitaBPM_platform_setup.md),
-with exactly the same values that you set in `bonita-tenant-community-custom.properties` (see above). At platform creation, this file contains the default username and password for the default tenant.  
+For the **default tenant**, the tenant administrator username and password must also be changed in file:
+- Before the very first Tomcat start: [`<TOMCAT_HOME>/setup/platform_conf/initial/platform_portal/platform-tenant-config.properties`](BonitaBPM_platform_setup.md)
+- After the first Tomcat start: [`<TOMCAT_HOME>/setup/platform_conf/current/platform_portal/platform-tenant-config.properties`](BonitaBPM_platform_setup.md),
+
 For further details and a better understanding, please read the section [Tenant administrator credentials](tenant_admin_credentials.md).
 :::
-
 
 <a id="edition_specification" />
 

--- a/md/tomcat-bundle.md
+++ b/md/tomcat-bundle.md
@@ -96,12 +96,12 @@ As a security precaution, we **strongly recommend** that before you start your a
 
 #### Platform administrator
 
-The credentials are defined in a text file:
+The username and password are defined in a text file:
  - Before the very first Tomcat start: [`<TOMCAT_HOME>/setup/platform_conf/initial/platform_engine/bonita-platform-community-custom.properties`](BonitaBPM_platform_setup.md)
  - After the first Tomcat start: [`<TOMCAT_HOME>/setup/platform_conf/current/platform_engine/bonita-platform-community-custom.properties`](BonitaBPM_platform_setup.md)
 
 
-The username and password for the platform administrator are defined in the file [`<TOMCAT_HOME>/setup/platform_conf/initial/platform_engine/bonita-platform-community-custom.properties`](BonitaBPM_platform_setup.md), by the following properties:
+The properties are listed below:
 
 * `platformAdminUsername` defines the username (default `platformAdmin`)
 * `platformAdminPassword` defines the password (default `platform`)


### PR DESCRIPTION
7.4+ new template files appeared for configuration in setup/*-templates directories, and there are used to overwrite the original files (still present in the app server directories) at startup:
 - server/bin/setenv.bat => setup/tomcat-templates/setenv.bat
 - server/bin/setenv.sh => setup/tomcat-templates/setenv.sh
 - server/conf/Catalina/localhost/bonita.xml => setup/tomcat-templates/bonita.xml

Added paths to files after the first tomcat start.

Versions: 7.4, 7.5, 7.6
