### PR TITLE
fix(doc): fix out-of-date info in wildfly-bundle

### DIFF
--- a/md/wildfly-bundle.md
+++ b/md/wildfly-bundle.md
@@ -40,9 +40,9 @@ The WildFly bundle is based on a standard WildFly installation with the followin
 * `server/bin/standalone.conf.bat`: script to configure JVM system properties on Windows systems.
 * `server/modules/system/layers/base/sun/jdk/main/module.xml`: list of base jdk module necessary for WildFly and Bonita to execute.
 * `server/request_key_utils`: script to generate license request keys (Subscription editions only).
-* `server/standalone/configuration/standalone.xml`: WildFly context configuration for Bonita BPM Portal. It defines data sources used by Bonita BPM Engine.
 * `server/standalone/deployments/bonita-all-in-one-[version].ear`: Bonita BPM Portal (web application) and EJB3 API.
 * `setup/`: a tool to manage Bonita BPM Platform configuration, stored in database instead of filesystem. Also ships a tool to centralize all the required WildFly bundle configuration.
+* `setup/wildfly-templates/standalone.xml`: WildFly context configuration for Bonita BPM Portal. It defines data sources used by Bonita BPM Engine.
 * `start-bonita.bat`: script to start the bundle on Windows.
 * `start-bonita.sh`: script to start the bundle on Linux.
 
@@ -138,7 +138,7 @@ The **start-bonita** script does the following:
     2. install the license files (Subscription editions only) in the database.
 2. Runs the **`setup configure`** command:
     The Setup Configure command configures the WildFly environment to access the right databases:
-    1. updates the file `<WILDFLY_HOME>/server/standalone/configuration/standalone.xml` with the values you set in file `database.properties` for **Bonita BPM internal database** & **Business Data database**
+    1. updates the file `<WILDFLY_HOME>/setup/wildfly-templates/standalone.xml` with the values you set in file `database.properties` for **Bonita BPM internal database** & **Business Data database**
     2. creates the file(s) `<WILDFLY_HOME>/server/modules/**/main/modules.xml` that WildFly needs, according to your database settings
     3. copies your database vendor-specific drivers into `<WILDFLY_HOME>/server/modules/**/main/` folders
 3. Starts the WildFly bundle


### PR DESCRIPTION
server/standalone/configuration/standalone.xml => setup/wildfly-templates/standalone.xml

Versions: 7.4, 7.5, 7.6
