### PR TITLE
fix(Portal URLs): specify autologin only supported for v6 forms

### DIFF
--- a/md/bonita-bpm-portal-urls.md
+++ b/md/bonita-bpm-portal-urls.md
@@ -170,6 +170,10 @@ With the above format, the first task with the name "request approval" available
 Bonita BPM 6.x URL syntax is supported in 7.x. Thus, 6.x autologin feature is supported in 7.0 version with 6.x URL syntax.
 Go to [Accessing Bonita BPM Portal and forms by URL 6.5 documentation](bonita-bpm-portal-urls.md) for more information about this.
 
+::: danger
+:fa-exclamation-triangle: **Warning:** The autologin feature only works with v6-type instantiation forms.
+:::
+
 ## URL parameter summary
 
 | | | |


### PR DESCRIPTION
Versions: 7.3, 7.4, 7.5, 7.6

Specify autologin feature in 7.x is only supported for v6 instantiation forms.
