### PR TITLE
fix(naming): remove references to Bonita BPM

### DIFF
--- a/md/bpm-api.md
+++ b/md/bpm-api.md
@@ -3508,7 +3508,7 @@ to get the process archive path.
 * **Request Payload**  
   ```javascript
   {
-    "fileupload": "D:\bonita-studio\BonitaBPMSubscription-6.6.4\workspace\tomcat\bonita\client\tenants\1\tmp\tmp_4431838172282406107.bar" // the process archive path
+    "fileupload": "D:\bonita-studio\BonitaSubscription-7.6.3\workspace\tomcat\bonita\client\tenants\1\tmp\tmp_4431838172282406107.bar" // the process archive path
   }
   ```
 * **Success Response**  

--- a/md/deploy-bundle.md
+++ b/md/deploy-bundle.md
@@ -20,7 +20,7 @@ it would be up to you to adapt the documented steps to your very own folder layo
 * `setup`: a command-line tool that creates the Bonita Platform before it can be run. It creates the Bonita Platform internal database, and stores the runtime configuration.
 It is useful to update the configuration, locally or from a remote computer.
 * `Request_key_utils-`_`key_utils.version`_: include script files to generate license request keys.
-* `BonitaBPMSubscription`-_`LDAPSync.version`_-`LDAP-Synchronizer` : LDAP synchronizer to synchronize your organization in Bonita with your LDAP
+* `BonitaSubscription`-_`LDAPSync.version`_-`LDAP-Synchronizer` : LDAP synchronizer to synchronize your organization in Bonita with your LDAP
 * `cas-`_`cas.version`_`-module`: Module files and description to enable CAS dependency to bonita EAR.
 * `License`: license files that apply to Bonita components.
 * `README.TXT`: See this file for more details about the `deploy.zip` contents and structure. 

--- a/md/migrate-from-an-earlier-version-of-bonita-bpm.md
+++ b/md/migrate-from-an-earlier-version-of-bonita-bpm.md
@@ -185,7 +185,7 @@ Please refer to the guide on updating the configurationfile using the [platform 
     ./setup.sh push
     ```
 1. If you have done specific configuration and customization in your server original version, re-do it by configuring the application server at `bonita-target-version/server` (or `bonita-target-version` if target version is 7.3.n): customization, libs etc.
-1. <a id="compound-permission-migration" /> **If your Bonita BPM version is 7.4 or above before migrating, you can skip this point.**In the case where deployed resources have required dedicated [authorizations to use the REST API](resource-management.md#permissions), these authorizations are not automatically migrated.
+1. <a id="compound-permission-migration" /> **If your Bonita version is 7.4 or above before migrating, you can skip this point.**In the case where deployed resources have required dedicated [authorizations to use the REST API](resource-management.md#permissions), these authorizations are not automatically migrated.
     Some manual operation have to be done on files that are  located in the _$BONITA\_HOME_ folder if version <7.3.0 or in the extracted `platform_conf/current` folder in version >=7.3.0 (see [Update Bonita Platform configuration](BonitaBPM_platform_setup.md#update_platform_conf) for more information ). You need to merge the previous file version and the migrated one.
     
     * `tenants/[TENANT_ID]/conf/compound-permissions-mapping.properties` : contains list of permissions used for each resources
@@ -214,7 +214,7 @@ Please refer to the guide on updating the configurationfile using the [platform 
     cp BonitaSubscription-7.n-Jerome-myHosname-20171023-20180122.lic ./platform_conf/licenses/
     ./setup.sh push
     ```
-1. Start the application server. Before you start Bonita BPM Portal, clear your browser cache. If you do not clear the cache, you might see old, cached versions of Portal pages instead of the new version. 
+1. Start the application server. Before you start Bonita Portal, clear your browser cache. If you do not clear the cache, you might see old, cached versions of Portal pages instead of the new version.
 Log in to the Portal and verify that the migration has completed. 
 If you did not set the default Look & Feel before migration and you cannot log in, you need to [restore the default Look & Feel](managing-look-feel.md) using a REST client or the Engine API.
 

--- a/md/rest-api-overview.md
+++ b/md/rest-api-overview.md
@@ -42,7 +42,7 @@ Setting the redirect parameter to false indicates that the service should not re
 After the application is connected to the Bonita Engine, you can start calling API methods. The following is a typical scenario for an end user.
 
 1. [Start a new case with variables](bpm-api.md#case): Provide a form for the user to enter initial data. Then call the method to start a new case using the values entered by the user to initialize some variables. The engine will start the execution of the process. Depending on the design of your process, there might then be some human tasks available for the end user.
-2. [List the pending tasks for a user](bpm-api.md#human-task): Retrieve a list of available human tasks for the logged in user. When the user selects a task to do, you can display the corresponding form. It can be an external form or a Bonita BPM form that can be accessed by url.
+2. [List the pending tasks for a user](bpm-api.md#human-task): Retrieve a list of available human tasks for the logged in user. When the user selects a task to do, you can display the corresponding form. It can be an external form or a Bonita form that can be accessed by url.
 3. [Update variables and execute a task](bpm-api.md#activity): If your application is using an external form, update the values of the variables in your process. 
 You can use a method to update process or activity variables with values coming from your application. When the user submits the external form, you can call a method to execute a task. 
 The engine will then continue the execution of the workflow as designed.

--- a/md/sap-jco-3.md
+++ b/md/sap-jco-3.md
@@ -52,8 +52,8 @@ There is below a step by step procedure on Windows. It is assumed that the Studi
 
 1. Store the `sapjco.dll` in the `C:\windows\system32` directory
 2. Reboot
-3. Store the `sapjco3.jar` in the bonita webpapp library directory, deployed in the tomcat embedded with the Studio: e.g. `C:\BonitaBPMSubscription-7.2.3\workspace\tomcat\webapps\bonita\WEB-INF\lib`
-4. Store the `sapjco3.jar` in the `endorsed` directory of your Bonita Studio installation: e.g. `C:\BonitaBPMSubscription-7.2.3\endorsed`.
+3. Store the `sapjco3.jar` in the bonita webpapp library directory, deployed in the tomcat embedded with the Studio: e.g. `C:\BonitaSubscription-7.6.3\workspace\tomcat\webapps\bonita\WEB-INF\lib`
+4. Store the `sapjco3.jar` in the `endorsed` directory of your Bonita Studio installation: e.g. `C:\BonitaSubscription-7.6.3\endorsed`.
 5. Start the Studio
 6. Open a diagram
 7. Select a Service task 

--- a/md/set-up-continuous-integration.md
+++ b/md/set-up-continuous-integration.md
@@ -45,9 +45,9 @@ This section describes how to create a Jenkins job to build your processes autom
 All example scripts given on this page are compatible with Unix-like operating systems.  
 
 1. Prepare Bonita Studio on the CI server: Bonita Studio includes a BonitaStudioBuilder script to build processes in a CI environment. Install Bonita Studio as follows:  
-  1. Download the OS-independent package (zip) from the Customer Portal. For example use BonitaBPMSubscription-6.1.0.zip for version 6.1.0\. You must have the same version of Bonita Studio for the shared repository and the CI server.    
-  2. Extract the package to a permanent location on the CI server: `$> unzip -d /path/to/BonitaStudio BonitaBPMSubscription-6.1.0.zip`  
-  3. Install your license (a license must have been requested for CI server): `$> cp license.lic /path/to/BonitaStudio/BonitaBPMSubscription-6.1.0/lic_folder/`
+  1. Download the OS-independent package (zip) from the Customer Portal. For example use BonitaSubscription-7.6.3.zip for version 7.6.3\. You must have the same version of Bonita Studio for the shared repository and the CI server.
+  2. Extract the package to a permanent location on the CI server: `$> unzip -d /path/to/BonitaStudio BonitaStudioSubscription-7.6.3.zip`
+  3. Install your license (a license must have been requested for CI server): `$> cp license.lic /path/to/BonitaStudio/BonitaStudioSubscription-7.6.3/lic_folder/`
 
   You are recommended to install a window manager on the CI server in order to have process diagram screenshots generated along with business archives.  
 

--- a/md/single-sign-on-with-cas.md
+++ b/md/single-sign-on-with-cas.md
@@ -141,7 +141,7 @@ If the platform has already been initialized, every update to the configuration 
 
 2. In the `CasLoginModule` configuration, check that the `principalGroupName` property is set to `CallerPrincipal`.  
    This is required to retrieve the username from the Bonita application.
-   Bonita BPM uses the CAS LoginModule in the JASIG implementation, so see the CAS LoginModule section of the [Jasig documentation](https://wiki.jasig.org/display/CASC/JAAS+Integration) for more information.
+   Bonita uses the CAS LoginModule in the JASIG implementation, so see the CAS LoginModule section of the [Jasig documentation](https://wiki.jasig.org/display/CASC/JAAS+Integration) for more information.
 3. Copy `cas-client-core-x.x.x.jar` from `BonitaBPMSubscription-x.x.x-deploy/cas-x.x.x-module/org/jasig/cas/main` into the `TOMCAT_HOME/server/lib` directory.
 4. Copy `commons-logging-x.x.x.jar` from `BonitaBPMSubscription-x.x.x-deploy/BonitaBPMSubscription-x.x.x-LDAP-Synchronizer/BonitaBPMSubscription-x.x.x-LDAP-Synchronizer/lib` into the `TOMCAT_HOME/server/lib` directory.
 5. Update `bonita-tenant-sp-custom.properties` from `setup/platform_conf/initial/tenant_template_engine/` if platform has not been initialized yet or `setup/platform_conf/current/tenants/[TENANT_ID]/tenant_engine/` and `setup/platform_conf/current/tenant_template_engine/`.

--- a/md/single-sign-on-with-cas.md
+++ b/md/single-sign-on-with-cas.md
@@ -53,7 +53,7 @@ For a standard installation, it is not necessary to modify this file.
 To configure Bonita Engine for CAS:
 
 1. If you do not already have it, download the Subscription edition deploy zip from the customer portal.
-2. Add the CAS module. To do this, copy `BonitaBPMSubscription-x.x.x-deploy/cas-x.x.x-module/org` to `WILDFLY_HOME/server/modules` to merge the CAS module with the existing modules.
+2. Add the CAS module. To do this, copy `BonitaSubscription-x.x.x-deploy/cas-x.x.x-module/org` to `WILDFLY_HOME/server/modules` to merge the CAS module with the existing modules.
 3. Make the CAS module global so that it can be used by any application. To do this, edit `WILDFLY_HOME/setup/wildfly-templates/standalone.xml` and change the definition of the `ee` subsystem to the following:
 
 ```xml
@@ -142,8 +142,8 @@ If the platform has already been initialized, every update to the configuration 
 2. In the `CasLoginModule` configuration, check that the `principalGroupName` property is set to `CallerPrincipal`.  
    This is required to retrieve the username from the Bonita application.
    Bonita uses the CAS LoginModule in the JASIG implementation, so see the CAS LoginModule section of the [Jasig documentation](https://wiki.jasig.org/display/CASC/JAAS+Integration) for more information.
-3. Copy `cas-client-core-x.x.x.jar` from `BonitaBPMSubscription-x.x.x-deploy/cas-x.x.x-module/org/jasig/cas/main` into the `TOMCAT_HOME/server/lib` directory.
-4. Copy `commons-logging-x.x.x.jar` from `BonitaBPMSubscription-x.x.x-deploy/BonitaBPMSubscription-x.x.x-LDAP-Synchronizer/BonitaBPMSubscription-x.x.x-LDAP-Synchronizer/lib` into the `TOMCAT_HOME/server/lib` directory.
+3. Copy `cas-client-core-x.x.x.jar` from `BonitaSubscription-x.x.x-deploy/cas-x.x.x-module/org/jasig/cas/main` into the `TOMCAT_HOME/server/lib` directory.
+4. Copy `commons-logging-x.x.x.jar` from `BonitaSubscription-x.x.x-deploy/BonitaSubscription-x.x.x-LDAP-Synchronizer/BonitaSubscription-x.x.x-LDAP-Synchronizer/lib` into the `TOMCAT_HOME/server/lib` directory.
 5. Update `bonita-tenant-sp-custom.properties` from `setup/platform_conf/initial/tenant_template_engine/` if platform has not been initialized yet or `setup/platform_conf/current/tenants/[TENANT_ID]/tenant_engine/` and `setup/platform_conf/current/tenant_template_engine/`.
 ::: info
 If the platform has already been initialized, every update to the configuration files under `setup/platform_conf/current` must be done using the `setup` tool:  
@@ -197,7 +197,7 @@ Then, use the [`LoginAPI`](http://documentation.bonitasoft.com/javadoc/api/${var
 
 If you are configuring Bonita and Tomcat in a cluster environment for CAS, there are some extra steps to do:
 
-1. Copy `commons-logging-x.x.x.jar` from `BonitaBPMSubscription-x.x.x-deploy/BonitaBPMSubscription-x.x.x-LDAP-Synchronizer/BonitaBPMSubscription-x.x.x-LDAP-Synchronizer/lib` into the `TOMCAT_HOME/server/lib` directory.
+1. Copy `commons-logging-x.x.x.jar` from `BonitaSubscription-x.x.x-deploy/BonitaSubscription-x.x.x-LDAP-Synchronizer/BonitaSubscription-x.x.x-LDAP-Synchronizer/lib` into the `TOMCAT_HOME/server/lib` directory.
 2. Remove the `WEB-INF/lib/commons-logging-x.x.x.jar` file from the `TOMCAT_HOME/server/webapps/bonita.war`.
 3. Remove the `TOMCAT_HOME/server/webapps/bonita/WEB-INF/lib/commons-logging-x.x.x.jar` file (if it is present).
 


### PR DESCRIPTION
Bonita BPM product name references have been introduced during older
documentation version updates propagation.