### PR TITLE
fix(Installation): Fix wrong path for logs in 7.4

### DIFF
--- a/md/log-files.md
+++ b/md/log-files.md
@@ -30,7 +30,7 @@ For Bonita BPM Studio, you can set the level of logging. Edit the `config.ini` i
 When you run a process locally from Bonita BPM Studio for testing, you can access the Engine log file by choosing **Bonita BPM Engine log** from the **Help** menu. 
 The logging level for Engine when it is started from Studio is always `INFO`. 
 
-On a deployed system, you can configure the log level and you can access the log files directly, in `$BONITA_HOME/tomcat/logs`. 
+On a deployed system, you can configure the log level and you can access the log files directly, in `<TOMCAT_HOME>/server/logs`. 
 Each file name includes the date when the file was created. There are several log files:
 
 * _bonita.date_.log is the Bonita BPM Engine log file.


### PR DESCRIPTION
fix(Installation): wrong path for logs.
Versions: 7.4, 7.5, 7.6, 7.7

Existing documentation is refering to BONITA_HOME. Since this folder doesnt exist anymore starting from 7.3, a path change is required on this documentation page.