### PR TITLE
fix(migration) update permission files migration procedure

### DIFF
--- a/md/migrate-from-an-earlier-version-of-bonita-bpm.md
+++ b/md/migrate-from-an-earlier-version-of-bonita-bpm.md
@@ -185,14 +185,13 @@ The `bonita_home` and the database have been migrated.
     ./setup.sh push
     ```
 1. If you have done specific configuration and customization in your server original version, re-do it by configuring the application server at `bonita-target-version/server` (or `bonita-target-version` if target version is 7.3.n): customization, libs etc.
-1. <a id="compound-permission-migration" /> In the case where deployed resources have required dedicated [authorizations to use the REST API](resource-management.md#permissions), these authorizations are not automatically migrated.  
-
-    Some manual operation have to be done on files that are  located in the _$BONITA\_HOME_ folder if version <7.3.0 or in the extracted `platform_conf/current` folder in version >=7.3.0 (see [Update Bonita BPM Platform configuration](BonitaBPM_platform_setup.md#update_platform_conf) for more information ). You need to merge the previous file version and the migrated one.
+1. <a id="compound-permission-migration" /> **If your Bonita BPM version is 7.3 or above before migrating, you can skip this point.**In the case where deployed resources have required dedicated [authorizations to use the REST API](resource-management.md#permissions), these authorizations are not automatically migrated.
+    Some manual operations have to be done on files that are  located in the extracted `platform_conf/current` folder (see [Update Bonita BPM Platform configuration](BonitaBPM_platform_setup.md#update_platform_conf) for more information). You need to:
     
-    * `tenants/[TENANT_ID]/conf/compound-permissions-mapping.properties` : contains list of permissions used for each resources
-    * `tenants/[TENANT_ID]/conf/resources-permissions-mapping.properties` : contains permissions for REST API extensions
-    * `tenants/[TENANT_ID]/conf/custom-permissions-mapping.properties` : contains custom permissions for users and profiles
-    * `tenants/[TENANT_ID]/conf/dynamic-permissions-checks.properties` : used if dynamic check on permissions is enabled
+    * Perform a diff between the version before migration and the version after migration of `tenants/[TENANT_ID]/conf/compound-permissions-mapping.properties` and put the additional lines into the file `tenants/[TENANT_ID]/conf/compound-permissions-mapping-custom.properties`
+    * Perform a diff between the version before migration and the version after migration of `tenants/[TENANT_ID]/conf/resources-permissions-mapping.properties` and put the additional lines into the file `tenants/[TENANT_ID]/conf/resources-permissions-mapping-custom.properties`
+    * Perform a diff between the version before migration and the version after migration of `tenants/[TENANT_ID]/conf/dynamic-permissions-checks.properties` and put the additional lines into the file `tenants/[TENANT_ID]/conf/dynamic-permissions-checks-custom.properties`
+    * Report all the content of the version before migration of`tenants/[TENANT_ID]/conf/custom-permissions-mapping.properties` into the new version.
                
 1. Configure License:
 

--- a/md/migrate-from-an-earlier-version-of-bonita-bpm.md
+++ b/md/migrate-from-an-earlier-version-of-bonita-bpm.md
@@ -185,8 +185,10 @@ The `bonita_home` and the database have been migrated.
     ./setup.sh push
     ```
 1. If you have done specific configuration and customization in your server original version, re-do it by configuring the application server at `bonita-target-version/server` (or `bonita-target-version` if target version is 7.3.n): customization, libs etc.
-1. <a id="compound-permission-migration" /> **If your Bonita BPM version is 7.3 or above before migrating, you can skip this point.**In the case where deployed resources have required dedicated [authorizations to use the REST API](resource-management.md#permissions), these authorizations are not automatically migrated.
-    Some manual operations have to be done on files that are  located in the extracted `platform_conf/current` folder (see [Update Bonita BPM Platform configuration](BonitaBPM_platform_setup.md#update_platform_conf) for more information). You need to:
+
+1. **If your Bonita BPM version is 7.3 or above before migrating, you can skip this point.** <a id="compound-permission-migration" />   
+In the case where deployed resources have required dedicated [authorizations to use the REST API](resource-management.md#permissions), these authorizations are not automatically migrated.  
+Some manual operations have to be done on files that are  located in the extracted `platform_conf/current` folder (see [Update Bonita BPM Platform configuration](BonitaBPM_platform_setup.md#update_platform_conf) for more information). You need to:
     
     * Perform a diff between the version before migration and the version after migration of `tenants/[TENANT_ID]/conf/compound-permissions-mapping.properties` and put the additional lines into the file `tenants/[TENANT_ID]/conf/compound-permissions-mapping-custom.properties`
     * Perform a diff between the version before migration and the version after migration of `tenants/[TENANT_ID]/conf/resources-permissions-mapping.properties` and put the additional lines into the file `tenants/[TENANT_ID]/conf/resources-permissions-mapping-custom.properties`


### PR DESCRIPTION
Migration from a version before 7.3 with custom pages and REST API is tricky because you have to report the changes to the permission files manually. It was already the case before 7.5. It's just the name of the files to edit that changed. This PR gives the right file names and procedure.
Covers [BS-18497](https://bonitasoft.atlassian.net/browse/BS-18497)