### PR TITLE
Clarification for login and X-Bonita-API-Token usage.

### DIFF
--- a/md/rest-api-overview.md
+++ b/md/rest-api-overview.md
@@ -23,17 +23,20 @@ To log in, use the following request:
 |:-|:-|
 | Request URL | `http://host:port/bonita/loginservice`| 
 | Request Method | POST| 
-| Form Data | username: a username<br/>password: a password <br/>redirect: true or false<br/>redirectURL: the URL of the page to be displayed after login <br/>tenant: the tenant to log in to (optional for Performance edition, not supported for Community, Teamwork and Efficiency editions)| 
+| Content-Type | application/x-www-form-urlencoded| 
+| Form Data | username: a username<br/>password: a password <br/>redirect: true or false. false indicates that the service should not redirect to Bonita BPM Portal (after a successful login) or to the login page (after a login failure).<br/>redirectURL: the URL of the page to be displayed after login <br/>tenant: the tenant to log in to (optional for Performance edition, not supported for Community, Teamwork and Efficiency editions)| 
   
-The response to this call generates cookies, which must be transfered with each subsequent calls. If the REST API is used in an application running in a web browser, this is handled automatically by the browser. 
+The response to this call generates cookies.
+The `JSESSIONID` must be transfered with each subsequent calls. If the REST API is used in an application running in a web browser, this is handled automatically by the web browser.
+For usage of the `X-Bonita-API-Token` see below.
 
-#### X-Bonita-API-Token cookie
+#### X-Bonita-API-Token cookie and HTTP header
 
-The security against CSRF attacks is enabled by default for all fresh installations. the subsequence REST API calls using DELETE, POST, or PUT HTTP methods must contain the header below:
+The security against CSRF attacks is enabled by default for all fresh installations.
+
+This security relies on `X-Bonita-API-Token` information. The `X-Bonita-API-Token` value can be found in the cookie named: `X-Bonita-API-Token`. All the subsequence REST API calls using DELETE, POST, or PUT HTTP methods must contain the **HTTP header** below:
 
     X-Bonita-API-Token: example-dummy-not-be-used-value
-
-Setting the redirect parameter to false indicates that the service should not redirect to Bonita BPM Portal (after a successful login) or to the login page (after a login failure).
 
 ### Execute REST calls and integrate the results in your application
 


### PR DESCRIPTION
The content type to use was missing and if you use a tool such as Postman, default content type (form-data) will lead to unsuccessful login.

The title "X-Bonita-API-Token cookie" is confusing because the value can be retrieve in a cookie but need to be used in an header.
Rephrasing the title and adding an extra sentence to clarify what need to be done should probably help users to correctly use this feature.