### PR TITLE
fix(UI Designer variables): add warning on JavaScript expressions

### DIFF
--- a/md/variables.md
+++ b/md/variables.md
@@ -45,7 +45,10 @@ var result = $data.expenses * 2;
     return result;
 ```
 
-An expression often relies on other variables as dependencies. When one of these variables changes, the expression is reevaluated and the previous value is overwritten.   
+An expression often relies on other variables as dependencies. 
+::: warning
+**Warning:** Every time one of these variables changes, the whole JavaScript expression is re-evaluated and the previous value is overwritten.   
+:::
 For example, create a `login` expression variable: `return $data.firstname.toLowercase() + '-' + $data.lastname.toLowercase()`. Its dependencies are the two variables `firstname` and `lastname`.   
 Create two input widgets "First name" and "Last name" bound the two variables, and a text widget "Login" to display the result of the expression. When the user fills out the two input fields, the expression is updated. If the login value is manually edited before the user fills out the fields, then its value is overwritten.
 


### PR DESCRIPTION
Versions: 7.4, 7.5, 7.6, 7.7

Add a warning on UI Designer's JavaScript expression variables: they are re-evaluated every time some of the data they depend on are updatead.

Relates to [BS-18444](https://bonitasoft.atlassian.net/browse/BS-18444)
