### PR TITLE
fix(log): remove reference to sfl4j version

### DIFF
--- a/md/logging.md
+++ b/md/logging.md
@@ -12,7 +12,7 @@ All the Engine services call the [technical logger service](technical-logging.md
 
 ### Bonita BPM Portal
 
-The Portal uses the [Java Util Logging](http://docs.oracle.com/javase/6/docs/api/java/util/logging/package-summary.html) (JUL) directly to log messages.
+The Portal uses the [Java Util Logging](http://docs.oracle.com/javase/8/docs/api/java/util/logging/package-summary.html) (JUL) directly to log messages.
 
 ### Bonita BPM Studio
 
@@ -24,7 +24,8 @@ The Bonita BPM Studio provides direct access to the log written by the embedded 
 
 ### Bonita BPM Engine and Bonita BPM Portal
 
-The [technical logger service](technical-logging.md) uses SLF4J (version 1.6.1) to create the log. SLF4J is also used directly by Bonita dependencies such as Hibernate, Quartz and Ehcache.
+The [technical logger service](technical-logging.md) uses SLF4J to create the log as well as some Bonita dependencies
+such as Quartz and Ehcache.
 
 SLF4J is a facade for various logging frameworks, and a logging framework must be available as the back-end. By default, Bonita BPM uses JUL (Java Util Logging) as a the back-end to SLF4J. This is defined by including the `slf4j-jdk14-1.6.1.jar` in the `bonita.war WEB-INF/lib` folder.
 

--- a/md/technical-logging.md
+++ b/md/technical-logging.md
@@ -11,7 +11,8 @@ The logged messages are not intended to be accessible through the Engine API (se
 ## Usage
 
 If you are creating a custom implementation of a service, you might be interested in using the technical logging
-service. Refer to the implementations of existing services for examples of technical logging service usage (for example the [AuthenticationServiceImpl](https://github.com/bonitasoft/bonita-engine/blob/master/services/bonita-authentication/bonita-authentication-api-impl/src/main/java/org/bonitasoft/engine/authentication/impl/AuthenticationServiceImpl.java)).
+service. Refer to the implementations of existing services for examples of technical logging service usage (for example
+the [AuthenticationServiceImpl](https://github.com/bonitasoft/bonita-engine/blob/7.4.3/services/bonita-authentication/bonita-authentication-api-impl/src/main/java/org/bonitasoft/engine/authentication/impl/AuthenticationServiceImpl.java)).
 
 Basically, the technical logging service exposes a method that receives the following parameters: 
 
@@ -20,18 +21,16 @@ Basically, the technical logging service exposes a method that receives the foll
 * throwable (when message is associated with an exception)
 * severity
 
-See the [service
-interface](https://github.com/bonitasoft/bonita-engine/blob/master/services/bonita-log/bonita-log-technical-api/src/main/java/org/bonitasoft/engine/log/technical/TechnicalLoggerService.java) for details.
+See the [service interface](https://github.com/bonitasoft/bonita-engine/blob/7.4.3/services/bonita-log/bonita-log-technical-api/src/main/java/org/bonitasoft/engine/log/technical/TechnicalLoggerService.java) for details.
 
 ## Implementation details
 
-The technical logger 
-[implementation](https://github.com/bonitasoft/bonita-engine/blob/master/services/bonita-log/bonita-log-technical-slf4j/src/main/java/org/bonitasoft/engine/log/technical/TechnicalLoggerSLF4JImpl.java)
-uses SLF4J version 1.6.1 to handle the log. SLF4J itself uses a back-end logging framework to write log messages. See the [logging
+The technical logger
+[implementation](https://github.com/bonitasoft/bonita-engine/blob/7.4.3/services/bonita-log/bonita-log-technical-slf4j/src/main/java/org/bonitasoft/engine/log/technical/TechnicalLoggerSLF4JImpl.java)
+uses SLF4J to handle the log. SLF4J itself uses a back-end logging framework to write log messages. See the [logging
 overview](logging.md) for more details.
 
-Logged messages are passed to SLF4J with appropriate logger information so the source of the message remains
-meaningful.
+Logged messages are passed to SLF4J with appropriate logger information so the source of the message remains meaningful.
 
 ## Example
 


### PR DESCRIPTION
It is wrong and we do not want to have to maintain it in the documentation.
Also fix some broken link to the Bonita Engine source code.