### PR TITLE
fix(Studio Preferences): document new Tomcat JVM args settings

### DIFF
--- a/md/bonita-bpm-studio-preferences.md
+++ b/md/bonita-bpm-studio-preferences.md
@@ -9,49 +9,49 @@ To configure Bonita Studio preferences, click _**Preferences**_ in the Cool bar.
 ### General preferences
 
 Database
-   Database clean-up: by default, the database (used by Bonita Engine) is purged when Bonita Studio exits, which is useful when you are testing processes. You can override this in order to preserve all data.  
-   Organization load: by default, the default organization is loaded with Bonita Studio starts. You can override this. 
+* Database clean-up: by default, the database (used by Bonita Engine) preserves all data when Bonita Studio exits. You can override this in order to purge all data instead, which may be useful when you are testing processes.
+* Organization load: by default, the default organization is loaded with Bonita Studio starts. You can override this. 
 
 Appearance
-    Coolbar size: Normal (default) or small.   
-    Grid options for process diagrams. You can choose to use a grid positioning for all new process diagrams
+* Coolbar size: Normal (default) or small.
+* Grid options for process diagrams. You can choose to use a grid positioning for all new process diagrams
+* Grid spacing (in centimeters). Default: 0.5
   
 Language
-   Bonita Studio language.  
-   Web applications language: the language to use by default when loading process forms and Bonita Portal  
+* Bonita Studio language.  
+* Web applications language: the language to use by default when loading process forms and Bonita Portal  
 
 Java
-   The JRE (Java Runtime Environment) to used by default. JRE will be used when compiling and running Java code  
+* The JRE (Java Runtime Environment) to used by default. JRE will be used when compiling and running Java code  
 
 ### Deployment preferences
 
 Run mode
-   Validation: whether to validate the process before it runs. We recommend to keep this option enabled.  
-   The default look & feel for application forms. Will be applied to any newly created process.
+* Validation: whether to validate the process before it runs. We recommend to keep this option enabled.  
 
 Server settings
-   Port number: Studio embedded Tomcat HTTP listening port.  
-   Log in: the username and password of the user who will be logged when Bonita Portal or an application is started from Bonita Studio. The password can be obscured.   
-   The default look & feel for the Portal  
+* Start engine server lazily: by default, the engine server is started when the Studio starts up. You may choose not to start the engine until it is actually needed, that is, when you first deploy a new process/organisation/BDM/... or when you launch the UI Designer for the first time.
+* Port number: Studio embedded Tomcat HTTP listening port.
+* Tomcat Maximum memory allocation (in Mb): the maximum memory allocation (Xmx) for the heap of the JVM running the Tomcat server. Default: 512
+* Tomcat JVM additional arguments: additional java arguments to be passed to the Tomcat JVM at startup time. e.g.: -XX:+HeapDumpOnOutOfMemory
 
 Database connectors  
-   Manage the JDBC drivers associated with database connectors. You should use that to include JDBC drivers for commercial DBMS (e.g. DB2)  
+* Manage the JDBC drivers associated with database connectors. You should use that to include JDBC drivers for commercial DBMS (e.g. DB2)  
 
 ### Web preferences
 
 Browser
-   Specify the web browser used when a web page is displayed. Note that some application might override this setting and use a different browser
+* Specify the web browser used when a web page is displayed. Note that some application might override this setting and use a different browser
 
 Proxy
-   HTTP Proxy settings for web access 
+* HTTP Proxy settings for web access 
 
 ### Other preferences
 
 Advanced
-   SVN connector: the SVN connector used if you are using a remote SVN ["repository](workspaces-and-repositories.md). Note: if you change this your local working copy might become unstable. To avoid this, commit any outstanding changes before you modify the connector setting, and reinitialize your local working copy after the update  
-
-6.x legacy
-   Controls whether the 6.x legacy features are shown are hidden 
+* Rename diagram the first time it is saved.
+* Do not show confirmation on connector definition edition.
+* SVN connector: the SVN connector used if you are using a remote SVN ["repository](workspaces-and-repositories.md). Note: if you change this your local working copy might become unstable. To avoid this, commit any outstanding changes before you modify the connector setting, and reinitialize your local working copy after the update  
 
 Eclipse
    Give access to all Eclipse settings (Bonita Studio is based on Eclipse)  


### PR DESCRIPTION
Version: 7.8

Document the new Studio Preferences that allow to set the Tomcat's JVM args.
Also, do some cleaning, as many of the documented settings are no longer there in the Studio Preferences. (Presumably, they have not been there for a few versions, now... So this cleaning should be backported to the documentation of previous versions.)

Relates to BS-18942
