### PR TITLE
fix (workspaces-and-repositories.md):note on shared repositories

### DIFF
--- a/md/workspaces-and-repositories.md
+++ b/md/workspaces-and-repositories.md
@@ -84,6 +84,10 @@ If the list does not contain the name of the repository you want to use, check t
 
 ## Use a shared repository
 
+::: info
+If you want to re-use an existent shared repository (Git or Svn), be aware that importing the old workspace will result in having a local repository instead of a shared one. In this case, it’s advised to clone it from the remote repository.
+:::
+
 <a id="git"/>
 
 ### Git


### PR DESCRIPTION
Versions 7.7, 7.8
Alert users that in order to keep working on a shared repository (in the context of a migration or a new studio). They have to clone it rather than using a simple import.
Relates to : BS-19105