### PR TITLE
fix(rel_notes): migration info for V6 forms

### DIFF
--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -182,15 +182,15 @@ This means that, in the studio, there is no more:
   - In the _Execution > Form_ tab, the "Legacy 6.x" option is no longer available.
 In a repository/project, there is no more "Application resources" folder.
 
-Importing a .bos will not import such forms.
-Cloning a Git repository or migrating a SVN repository will remove such forms.
+Importing a .bos will not import such forms.  
+Cloning a Git repository or migrating a SVN repository will remove such forms.  
 Lastly, deploying a process (.bar file) containing forms/pages developped using Google Web Toolkit is not possible anymore.
 
 Before you migrate your production to Bonita 7.8, make sure you use Bonita Studio in a version older than 7.8.0 to [replace such forms/pages](migrate-form-from-6.x.md) by forms/pages created with more recent technologies and newer concepts, offered since Bonita 7.0: [UI Designer](ui-designer-overview.md) and [contract and context](contracts-and-contexts.md). 
 The migration will also handle the attempt to migrate projects with GWT forms/overview page:
    - If no GWT forms or overview page is found, migration is performed
    - If one process with GWT forms is enabled and/or has open cases, migration will not be performed at all
-   - If all processes with GWT forms are archived and disabled, migration will be performed. If a GWT case overview page is found, it is replaced by the default Bonita overview page. 
+   - If all processes with GWT forms are archived and disabled, migration will be performed. If a GWT case overview page is found, it is replaced by the default Bonita overview page.   
    With the Enterprise edition, the Administrator or Process Manager can replace it with a compliant page in the process details.
 
 <a id="bar-importer"/>


### PR DESCRIPTION
* a few line breaks

Please read the whole migration paragraph, as I screwed up my first PR (not merged to the right branch, sorry: Github doesn't like using the browser "back" button in the middle of a PR creation)
