### PR TITLE
fix(doc): Remove debug mode in Studio

### DIFF
--- a/md/environments.md
+++ b/md/environments.md
@@ -6,14 +6,14 @@
 
 An environment is a set of configuration definitions for a project. You can configure a process for several environments. In this way, one process can run in several environments without any modification, because the information that is specific to an environment is set at configuration. In the Enterprise, Performance, Efficiency, and Teamwork editions, Bonita Studio proposes three environments, Local,  Production, and Qualification. You can also define custom environments.
 
-You can configure, run, and debug a process in a specific environment.
+You can configure and run a process in a specific environment.
 
-The default environment is the one most recently selected in the Configure, Run, or Debug menus in the Cool bar.
+The default environment is the one most recently selected in the Configure or Run menus in the Cool bar.
 
 ## Define a custom environment
 
 To define a custom environment for a process, open the process in Bonita Studio Enterprise, Performance, Efficiency, or Teamwork edition and 
-select the pool. Then choose **New environment...** from the **Configure**, **Run**, or **Debug** menu in the Cool bar, enter a name for the new environment, and click _**OK**_. The new environment will appear in the  **Configure**, **Run**, and **Debug** menus in the Cool bar.
+select the pool. Then choose **New environment...** from the **Configure** or **Run** menu in the Cool bar, enter a name for the new environment, and click _**OK**_. The new environment will appear in the  **Configure** and **Run** menus in the Cool bar.
 
 ## Configure a process in an environment
 
@@ -22,7 +22,3 @@ To configure a process for an environment, select the environment from the **Con
 ## Run a process in an environment
 
 To run a process from Bonita Studio in an environment, select the environment from the **Run** menu in the Cool bar. The process will be launched using the information configured for the specified environment.
-
-## Debug a process in an environment
-
-Use Debug in Bonita Studio to disconnect any connectors that you know cannot run successfully when you run the process in development or test mode. To debug a process from Bonita Studio in an environment, select the environment from the **Debug** menu in the Cool bar. Specify the connectors to be skipped, then click _**Debug**_. The process will be launched using the information configured for the specified environment but the specified connectors will be ignored.


### PR DESCRIPTION
fix(doc):Debug mode was removed from Studio 7.8, deleting its documentation information
See: https://documentation.bonitasoft.com/bonita/7.8/release-notes
> Debug action in Studio
> Debug, the option to run a diagram without its connectors, is not supported anymore, as its value proved to be too small.