### PR TITLE
fix(software requirements): add explicit reference to Oracle required

### DIFF
--- a/md/hardware-and-software-requirements.md
+++ b/md/hardware-and-software-requirements.md
@@ -33,10 +33,10 @@ Software required for Bonita BPM Platform (Bonita BPM Engine and Bonita BPM Port
 | MySQL | 5.5.27 and higher in the 5.5.x line (see note 3) |
 | PostgreSQL | 9.3 and higher |
 | SQL Server | 2012 (see note 4) |
-| Oracle  | 11gR2 (11.2.0.x) and 12c (12.1.0.x.y) |
+| Oracle  | 11gR2 (11.2.0.x) and 12c (12.1.0.x.y) (see note 5)|
 | **Browser** |
 | Mozilla Firefox | latest version |
-| Google Chrome | latest version (see note 5) |
+| Google Chrome | latest version (see note 6) |
 | Microsoft Edge | latest version |
 | Internet Explorer | 11.0.x |
 
@@ -47,7 +47,8 @@ Notes:
 4. There is a known issue between Bitronix (the transaction manager shipped by Bonitasoft for the Tomcat bundle and inside the Deploy bundle for Tomcat) and Microsoft SQL Server JDBC driver
 (refer to: [MSDN note](https://msdn.microsoft.com/en-us/library/aa342335.aspx), [Bitronix note](http://bitronix-transaction-manager.10986.n7.nabble.com/Failed-to-recover-SQL-Server-Restart-td148.html)).
 Therefore, using Bitronix as a transaction manager with SQL Server does not work and is not supported. To use SQL Server database requires that you use the WildFly bundle provided by Bonitasoft.
-5. Chrome version 60.0.3112 introduced an incompatibility impacting the functionality of Bonita BPM Portal. So from that Chrome version onwards, once Bonita BPM Platform is installed, apply the following procedure to resolve this issue:
+5. Oracle must be configured using AL32UTF8 character set to store properly all *Char* data
+6. Chrome version 60.0.3112 introduced an incompatibility impacting the functionality of Bonita BPM Portal. So from that Chrome version onwards, once Bonita BPM Platform is installed, apply the following procedure to resolve this issue:
 
 ### Fixing procedure
 


### PR DESCRIPTION
explain AL32UTF8 is the recommended charset for Oracle
