### PR TITLE
feat(ReleaseNote): Add that the 7.9.0 migration tool will migrate connectors & correct the release note on the CMIS connector

### DIFF
--- a/md/migration-tool.md
+++ b/md/migration-tool.md
@@ -7,8 +7,12 @@ This change log must be read before [migrating to a newer version of Bonita](mig
 
 ## 2.40.0 - Jun. 6th, 2019 (Bonita 7.9.0)
 This version of the migration tool migrates Bonita up to version 7.9.0.
-It also migrates the CMIS, email and Webservice connectors, along with their dependencies, to allow the migrated platform to run on Java 11.
-If some of the connectors fail to migrate during this step, the platform will still be functionnal on java 8, but will not run on java 11, and will require a manual update.
+It also attempts to migrate the *CMIS*, *email* and *Webservice* connectors, along with their dependencies, to allow the migrated platform to run on Java 11.
+The step works at best effort:
+* It will try to upgrade all the connectors it can.
+* It will not upgrade connectors that have dependencies used by other connectors. Those connectors will still work on java 8, but not in java 11, and will require a manual update.
+* A detailed report of all the changes made is displayed at the end of the migration step.
+* Beware that if one of these connectors' removed dependencies was used in one your scripts, it will still be removed/updated, and therefor your scripts might not work anymore after migration. The full list of updated and deleted dependencies can be found [here](release-notes.md).
 
 ## 2.39.0 - Mar. 7th, 2019 (Bonita 7.8.3)
 This version of the migration tool migrates Bonita up to version 7.8.3.

--- a/md/migration-tool.md
+++ b/md/migration-tool.md
@@ -5,6 +5,11 @@ to the one delivered with the latest version of Bonita.
 This is due to the fact that improvements in any version of the Migration Tool can affect all supported version of Bonita.
 This change log must be read before [migrating to a newer version of Bonita](migrate-from-an-earlier-version-of-bonita-bpm.md).
 
+## 2.40.0 - Jun. 6th, 2019
+This version of the migration tool migrates Bonita up to version 7.9.0.
+It also migrates the CMIS, email and Webservice connectors, along with their dependencies, to allow the migrated platform to run on Java 11.
+If some of the connectors fail to migrate during this step, the platform will still be functionnal on java 8, but will not run on java 11, and will require a manual update.
+
 ## 2.39.0 - Mar. 7th, 2019 (Bonita 7.8.3)
 This version of the migration tool migrates Bonita up to version 7.8.3.
 Because some bugs in Bonita Development Suite have been found, this migration tool will not allow the migration to 7.8.0, 7.8.1, or 7.8.2.

--- a/md/migration-tool.md
+++ b/md/migration-tool.md
@@ -5,15 +5,6 @@ to the one delivered with the latest version of Bonita.
 This is due to the fact that improvements in any version of the Migration Tool can affect all supported version of Bonita.
 This change log must be read before [migrating to a newer version of Bonita](migrate-from-an-earlier-version-of-bonita-bpm.md).
 
-## 2.40.0 - Jun. 6th, 2019 (Bonita 7.9.0)
-This version of the migration tool migrates Bonita up to version 7.9.0.
-It also attempts to migrate the *CMIS*, *email* and *Webservice* connectors, along with their dependencies, to allow the migrated platform to run on Java 11.
-The step works at best effort:
-* It will try to upgrade all the connectors it can.
-* It will not upgrade connectors that have dependencies used by other connectors. Those connectors will still work on java 8, but not in java 11, and will require a manual update.
-* A detailed report of all the changes made is displayed at the end of the migration step.
-* Beware that if one of these connectors' removed dependencies was used in one your scripts, it will still be removed/updated, and therefor your scripts might not work anymore after migration. The full list of updated and deleted dependencies can be found [here](release-notes.md).
-
 ## 2.39.0 - Mar. 7th, 2019 (Bonita 7.8.3)
 This version of the migration tool migrates Bonita up to version 7.8.3.
 Because some bugs in Bonita Development Suite have been found, this migration tool will not allow the migration to 7.8.0, 7.8.1, or 7.8.2.

--- a/md/migration-tool.md
+++ b/md/migration-tool.md
@@ -5,7 +5,7 @@ to the one delivered with the latest version of Bonita.
 This is due to the fact that improvements in any version of the Migration Tool can affect all supported version of Bonita.
 This change log must be read before [migrating to a newer version of Bonita](migrate-from-an-earlier-version-of-bonita-bpm.md).
 
-## 2.40.0 - Jun. 6th, 2019
+## 2.40.0 - Jun. 6th, 2019 (Bonita 7.9.0)
 This version of the migration tool migrates Bonita up to version 7.9.0.
 It also migrates the CMIS, email and Webservice connectors, along with their dependencies, to allow the migrated platform to run on Java 11.
 If some of the connectors fail to migrate during this step, the platform will still be functionnal on java 8, but will not run on java 11, and will require a manual update.

--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -110,18 +110,38 @@ The following dependencies have been added, to ensure Java 11 compliance:
 
 #### CMIS connector
 
-The version of the _org.apache.chemistry.opencmis:chemistry-opencmis-client-impl_ dependency has been updated from _0.13.0_ to _1.1.0_
+The following dependencies were updated to ensure Java 11 compliance:
+- _org.apache.chemistry.opencmis:chemistry-opencmis-client-impl_ dependency has been updated from _0.13.0_ to _1.1.0_
+- _org.apache.chemistry.opencmis:chemistry-opencmis-client-api_ dependency has been updated from _0.13.0_ to _1.1.0_
+- _org.apache.chemistry.opencmis:chemistry-opencmis-commons-api_ dependency has been updated from _0.11.0_ to _1.1.0_
+- _org.apache.chemistry.opencmis:chemistry-opencmis-commons-impl_ dependency has been updated from _0.11.0_ to _1.1.0_
+- _org.apache.chemistry.opencmis:chemistry-opencmis-client-bindings_ dependency has been updated from _0.11.0_ to _1.1.0_
+- _org.apache.cxf:cxf-rt-bindings-xml_ dependency has been updated from _2.7.7_ to _3.0.12_
+- _org.apache.cxf:cxf-rt-frontend-simple_ dependency has been updated from _2.7.7_ to _3.0.12_
+- _org.apache.cxf:cxf-rt-core dependency_ dependency has been updated from _2.7.7_ to _3.0.12_
+- _org.apache.cxf:cxf-rt-transports-http_ dependency has been updated from _2.7.7_ to _3.0.12_
+- _org.apache.cxf:cxf-rt-ws-policy_ dependency has been updated from _2.7.7_ to _3.0.12_
+- _org.apache.cxf:cxf-rt-ws-addr_ dependency has been updated from _2.7.7_ to _3.0.12_
+- _org.apache.cxf:cxf-rt-bindings-soap_ dependency has been updated from _2.7.7_ to _3.0.12_
+- _org.apache.cxf:cxf-rt-databinding-jaxb_ dependency has been updated from _2.7.7_ to _3.0.12_
+- _org.apache.cxf:cxf-rt-frontend-jaxws_ dependency has been updated from _2.7.7_ to _3.0.12_
+- _org.apache.neethi:neethi_ dependency has been updated from _3.0.2_ to _3.0.3_
+- _org.apache.ws.xmlschema:xmlschema-core_ dependency has been updated from _2.0.3_ to _2.2.1_
+
 
 The following dependencies have been added to ensure Java 11 compliance:
 
-- _javax.xml.bind:jaxb-api:2.2.7_
-- _com.sun.xml.bind:jaxb-core:2.2.7_
-- _com.sun.xml.bind:jaxb-impl:2.2.7_
+- _org.apache.cxf:cxf-rt-wsdl-3.0.12_
 
 The following dependencies have been removed: 
 
-- _org.apache.cxf:cxf-rt-frontend-jaxws:2.7.7_
-- _org.apache.cxf:cxf-rt-transports-http:2.7.7_
+- _org.jvnet.mimepull:mimepull-1.9.4.jar_
+- _org.codehaus.woodstox:stax2-api-3.1.1.jar_
+- _org.apache.geronimo.javamail:geronimo-javamail_1.4_spec-1.7.1.jar_
+- _org.codehaus.woodstox:woodstox-core-asl-4.2.0.jar_
+- _org.apache.cxf:cxf-api-2.7.7.jar_
+
+In addition _bonita-connector-cmis-<specific Implementation>.jar_ and _bonita-connector-cmis-common-<version>.jar_ have been replaced by a single bonita-connector-cmis-<version>.jar
 
 #### Email connector
 

--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -92,6 +92,15 @@ The following Bonita dependencies have been upgraded to improve the Java 11 supp
 
 <a id="connector-dependency-updates"/>
 
+### Migration
+
+For Bonita 7.9.0, the migration step tries to migrate the *CMIS*, *Email* and *Webservice* connectors of the processes deployed on the platform, along with their dependencies, to allow the migrated platform to run on Java 11.
+The step works at best effort:
+* It will try to upgrade all the connectors it can.
+* It will not upgrade connectors that have dependencies used by other connectors. Those connectors will still work on java 8, but not in java 11, and will require a manual update.
+* A detailed report of all the changes made is displayed at the end of the migration step.
+* Beware that if one of these connectors' removed dependencies was used in one your scripts, it will still be removed/updated, and therefor your scripts might not work anymore after migration. The full list of updated and deleted dependencies can be found below.
+
 #### WebService connector
 
 The following dependencies have been added, to ensure Java 11 compliance:


### PR DESCRIPTION
Add that the 7.9.0 migration tool will migrate connectors
Correct the release note on the added/removed/updated dependencies of
the CMIS connector

Closes [BR-74](https://bonitasoft.atlassian.net/browse/BR-74)