### PR TITLE
fix(sap jco3): addition of sapjco3.jar lib details

### DIFF
--- a/md/sap-jco-3.md
+++ b/md/sap-jco-3.md
@@ -52,16 +52,17 @@ Contents of `sapjco-ntamd64-3.0.3.zip`
 
 Store the `sapjco.so` in the `/usr/lib` directory.
 
-#### 2. Configure the application server to make the classes, from the `sapjco3.jar` file, available for the Bonita Engine.
+#### 2. Configure the application server
 
 ##### Tomcat example (BonitaSubscription-7.8.3-Tomcat-8.5.34 bundle)
-It is assumed that both Tomcat and the Bonita Engine were already successfully started once.
+
+It is assumed that both the Tomcat and the Bonita Engine were already successfully started once.
 
 1. Stop Tomcat
 2. Copy the `sapjco3.jar` file into `BonitaSubscription-7.8.3-Tomcat-8.5.34\server\webapps\bonita\WEB-INF\lib` directory
 3. Start Tomcat
 
-#### Wildfly example (BonitaSubscription-7.8.3-wildfly-10.1.0.Final bundle)
+##### Wildfly example (BonitaSubscription-7.8.3-wildfly-10.1.0.Final bundle)
 
 1. Create the `sapjco3\main` directories under `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\modules\system\layers\base\com\` directory
 2. Copy the `sapjco3.jar` file into `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\modules\system\layers\base\com\sapjco3\main`
@@ -77,9 +78,10 @@ It is assumed that both Tomcat and the Bonita Engine were already successfully s
     </dependencies>
 </module>
 ```
-4. Edit the `standalone.xml` file and add these 3 lines under `subsystem xmlns="urn:jboss:domain:ee:4.0"`
+4. Edit the `standalone.xml` file
 When the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\start-bonita.bat` script is used to start Wildfly, then edit the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\setup\wildfly-templates\standalone.xml`.
 Otherwise edit the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\standalone\configuration\standalone.xml` file.
+Add these 3 lines under `subsystem xmlns="urn:jboss:domain:ee:4.0"`:
 ```xml
 <global-modules>      
     <module name="com.sapjco3" slot="main"/>

--- a/md/sap-jco-3.md
+++ b/md/sap-jco-3.md
@@ -39,21 +39,22 @@ Contents of `sapjco-ntamd64-3.0.3.zip`
 * `javadoc`: contains the .html help pages for installation
 * `examples`: contains some examples
 
-### How to use the contents of the .zip file with an application server
+### How to use the contents of the sapjco-ntamd64-3.0.3.zip file with an application server
 
-1. Extract the contents of the .zip file into a temporary directory, for example: `C:\temp\sapijco3`.
-2. Read the installation page provided with the sapjco distribution and follow the instructions.
-3. Put the `sapjco3.jar` file in the webapp libraries directory of the application server, so that the jar is in the classloader used by the Bonita Engine
-4. Put the `sapjco.dll` or `.so` libraries in the native library search path: `C:\windows\system32` for windows, or `/usr/lib` for Linux.
+#### 1. Extract the contents of the sapjco-ntamd64-3.0.3.zip file into a temporary directory, for example: `C:\temp\sapijco3`.
 
-#### Point 3. Tomcat example (BonitaSubscription-7.8.3-Tomcat-8.5.34 bundle)
+#### 2. Read the installation page provided with the sapjco distribution and follow the instructions.
+
+#### 3. Put the `sapjco3.jar` file in the webapp libraries directory of the application server, so that the jar is in the classloader used by the Bonita Engine
+
+##### Tomcat example (BonitaSubscription-7.8.3-Tomcat-8.5.34 bundle)
 It is assumed that Tomcat had been started once sucessfully, and the Bonita Engine already started once successfully.
 
 1. Stop Tomcat
 2. Copy the `sapjco3.jar` file into `BonitaSubscription-7.8.3-Tomcat-8.5.34\server\webapps\bonita\WEB-INF\lib` directory
 3. Start Tomcat
 
-#### Point 3. Wildfly example (BonitaSubscription-7.8.3-wildfly-10.1.0.Final bundle)
+#### Wildfly example (BonitaSubscription-7.8.3-wildfly-10.1.0.Final bundle)
 
 1. Create the `sapjco3\main` directories under `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\modules\system\layers\base\com\` directory
 2. Copy the `sapjco3.jar` file into `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\modules\system\layers\base\com\sapjco3\main`
@@ -70,7 +71,6 @@ It is assumed that Tomcat had been started once sucessfully, and the Bonita Engi
 </module>
 ```
 4. Edit the `standalone.xml` file and add these 3 lines under `subsystem xmlns="urn:jboss:domain:ee:4.0"`
-
 When the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\start-bonita.bat` script is used to start Wildfly, then edit the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\setup\wildfly-templates\standalone.xml`.
 
 Otherwise edit the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\standalone\configuration\standalone.xml` file.
@@ -80,11 +80,9 @@ Otherwise edit the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\standal
     <module name="com.sapjco3" slot="main"/>
 </global-modules> 
 ```
-
-
-
 5. Start Wildfly
 
+#### 4. Put the `sapjco.dll` or `.so` libraries in the native library search path: `C:\windows\system32` for windows, or `/usr/lib` for Linux.
 
 ### Studio: How to import the SAP JCo3 library and make a request with an example function using the graphic display
 

--- a/md/sap-jco-3.md
+++ b/md/sap-jco-3.md
@@ -43,12 +43,12 @@ Contents of `sapjco-ntamd64-3.0.3.zip`
 
 #### 1. Install the system library.
 
-##### Windows
+##### Windows
 
 1. Store the `sapjco.dll` file in the `C:\windows\system32` directory.
-2. Reboot
+2. Reboott
 
-##### Linux
+##### Linux
 
 Store the `sapjco.so` in the `/usr/lib` directory.
 
@@ -79,8 +79,11 @@ It is assumed that both the Tomcat and the Bonita Engine were already successful
 </module>
 ```
 4. Edit the `standalone.xml` file
-When the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\start-bonita.bat` script is used to start Wildfly, then edit the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\setup\wildfly-templates\standalone.xml`.
+
+When the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\start-bonita.bat` script is used to start Wildfly, then edit the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\setup\wildfly-templates\standalone.xml` file.
+
 Otherwise edit the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\standalone\configuration\standalone.xml` file.
+
 Add these 3 lines under `subsystem xmlns="urn:jboss:domain:ee:4.0"`:
 ```xml
 <global-modules>      

--- a/md/sap-jco-3.md
+++ b/md/sap-jco-3.md
@@ -32,8 +32,8 @@ JCo 3: `sapjco3-ntamd64-3.0.3`
 Contents of `sapjco-ntamd64-3.0.3.zip`
 
 * `Readme.txt`: contains instructions
-* `sapjco3.jar`: must be installed in the `/endorsed` directory of your Bonita Studio installation and in class path of the bonita webapp.
-* `sapjcorfc.dll` (`sapjcorfc.so`): must be installed in the native library search path:
+* `sapjco3.jar`: must be installed in the `/endorsed` directory of your Bonita Studio installation and in class path of the bonita web server.
+* `sapjco3.dll` (`libspajco3.so`): must be installed in the native library search path:
   * Windows: usually the dll file is stored in `C:\windows\system32`
   * Linux: usually the dll file is stored in `/usr/lib`
 * `javadoc`: contains the .html help pages for installation
@@ -46,11 +46,11 @@ Contents of `sapjco-ntamd64-3.0.3.zip`
 ##### Windows
 
 1. Store the `sapjco.dll` file in the `C:\windows\system32` directory.
-2. Reboott
+2. Reboot
 
 ##### Linux
 
-Store the `sapjco.so` in the `/usr/lib` directory.
+Store the `libsapjco3.so` in the `/usr/lib` directory.
 
 #### 2. Configure the application server
 
@@ -59,7 +59,7 @@ Store the `sapjco.so` in the `/usr/lib` directory.
 It is assumed that both the Tomcat and the Bonita Engine were already successfully started once.
 
 1. Stop Tomcat
-2. Copy the `sapjco3.jar` file into `BonitaSubscription-7.8.3-Tomcat-8.5.34\server\webapps\bonita\WEB-INF\lib` directory
+2. Copy the `sapjco3.jar` file into `BonitaSubscription-7.8.3-Tomcat-8.5.34\server\lib` directory
 3. Start Tomcat
 
 ##### Wildfly example (BonitaSubscription-7.8.3-wildfly-10.1.0.Final bundle)

--- a/md/sap-jco-3.md
+++ b/md/sap-jco-3.md
@@ -32,7 +32,7 @@ JCo 3: `sapjco3-ntamd64-3.0.3`
 Contents of `sapjco-ntamd64-3.0.3.zip`
 
 * `Readme.txt`: contains instructions
-* `sapjco3.jar`: must be installed in the `/endorsed` directory of your Bonita Studio installation and in the webapp libraries directory of the application server.
+* `sapjco3.jar`: must be installed in the `/endorsed` directory of your Bonita Studio installation and in class path of the bonita webapp.
 * `sapjcorfc.dll` (`sapjcorfc.so`): must be installed in the native library search path:
   * Windows: usually the dll file is stored in `C:\windows\system32`
   * Linux: usually the dll file is stored in `/usr/lib`
@@ -43,8 +43,41 @@ Contents of `sapjco-ntamd64-3.0.3.zip`
 
 1. Extract the contents of the .zip file into a temporary directory, for example: `C:\temp\sapijco3`.
 2. Read the installation page provided with the sapjco distribution and follow the instructions.
-3. Put the `sapjco3.jar` file in the webapp libraries directory of the application server, so that the jar is in the classloader used by the Bonita Engine.
+3. Put the `sapjco3.jar` file in the webapp libraries directory of the application server, so that the jar is in the classloader used by the Bonita Engine
 4. Put the `sapjco.dll` or `.so` libraries in the native library search path: `C:\windows\system32` for windows, or `/usr/lib` for Linux.
+
+#### Point 3. Tomcat example (BonitaSubscription-7.8.3-Tomcat-8.5.34 bundle)
+It is assumed that Tomcat had been started once sucessfully, and the Bonita Engine already started once successfully.
+
+1. Stop Tomcat
+2. Copy the `sapjco3.jar` file into `BonitaSubscription-7.8.3-Tomcat-8.5.34\server\webapps\bonita\WEB-INF\lib` directory
+3. Start Tomcat
+
+#### Point 3. Wildfly example (BonitaSubscription-7.8.3-wildfly-10.1.0.Final bundle)
+It is assumed that the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\start-bonita.bat` script is used to start Wildfly.
+
+1. Create the `sapjco3\main` directories under `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\modules\system\layers\base\com\` directory
+2. Copy the `sapjco3.jar` file into `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\modules\system\layers\base\com\sapjco3\main`
+3. Create the `module.xml` file in the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\modules\system\layers\base\com\sapjco3\main` directory, with the content below:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.0" name="com.sapjco3">
+    <resources>
+        <resource-root path="sapjco3.jar" />
+    </resources>
+    <dependencies>
+       <module name="sun.jdk"/>
+    </dependencies>
+</module>
+```
+4. Edit the `BonitaBPMSubscription-7.5.4-wildfly-10.1.0.Final\setup\wildfly-templates\standalone.xml`, add these 3 lines under `subsystem xmlns="urn:jboss:domain:ee:4.0"`
+```xml
+<global-modules>      
+    <module name="com.sapjco3" slot="main"/>
+</global-modules> 
+``` 
+5. Start Wildfly
+
 
 ### Studio: How to import the SAP JCo3 library and make a request with an example function using the graphic display
 

--- a/md/sap-jco-3.md
+++ b/md/sap-jco-3.md
@@ -39,13 +39,20 @@ Contents of `sapjco-ntamd64-3.0.3.zip`
 * `javadoc`: contains the .html help pages for installation
 * `examples`: contains some examples
 
-### How to use the contents of the sapjco-ntamd64-3.0.3.zip file with an application server
+### How to use the contents of the sapjco-ntamd64-3.0.3.zip file with an application server?
 
-#### 1. Extract the contents of the sapjco-ntamd64-3.0.3.zip file into a temporary directory, for example: `C:\temp\sapijco3`.
+#### 1. Install the system library.
 
-#### 2. Read the installation page provided with the sapjco distribution and follow the instructions.
+##### Windows
 
-#### 3. Put the `sapjco3.jar` file in a class path, so that the classes are available for the Bonita Engine.
+1. Store the `sapjco.dll` file in the `C:\windows\system32` directory.
+2. Reboot
+
+##### Linux
+
+Store the `sapjco.so` in the `/usr/lib` directory.
+
+#### 2. Configure the application server to make the classes, from the `sapjco3.jar` file, available for the Bonita Engine.
 
 ##### Tomcat example (BonitaSubscription-7.8.3-Tomcat-8.5.34 bundle)
 It is assumed that both Tomcat and the Bonita Engine were already successfully started once.
@@ -72,17 +79,13 @@ It is assumed that both Tomcat and the Bonita Engine were already successfully s
 ```
 4. Edit the `standalone.xml` file and add these 3 lines under `subsystem xmlns="urn:jboss:domain:ee:4.0"`
 When the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\start-bonita.bat` script is used to start Wildfly, then edit the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\setup\wildfly-templates\standalone.xml`.
-
 Otherwise edit the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\standalone\configuration\standalone.xml` file.
-
 ```xml
 <global-modules>      
     <module name="com.sapjco3" slot="main"/>
 </global-modules> 
 ```
 5. Start Wildfly
-
-#### 4. Put the `sapjco.dll` or `.so` libraries in the native library search path: `C:\windows\system32` for windows, or `/usr/lib` for Linux.
 
 ### Studio: How to import the SAP JCo3 library and make a request with an example function using the graphic display
 

--- a/md/sap-jco-3.md
+++ b/md/sap-jco-3.md
@@ -45,10 +45,10 @@ Contents of `sapjco-ntamd64-3.0.3.zip`
 
 #### 2. Read the installation page provided with the sapjco distribution and follow the instructions.
 
-#### 3. Put the `sapjco3.jar` file in the webapp libraries directory of the application server, so that the jar is in the classloader used by the Bonita Engine
+#### 3. Put the `sapjco3.jar` file in a class path, so that the classes are available for the Bonita Engine.
 
 ##### Tomcat example (BonitaSubscription-7.8.3-Tomcat-8.5.34 bundle)
-It is assumed that Tomcat had been started once sucessfully, and the Bonita Engine already started once successfully.
+It is assumed that both Tomcat and the Bonita Engine were already successfully started once.
 
 1. Stop Tomcat
 2. Copy the `sapjco3.jar` file into `BonitaSubscription-7.8.3-Tomcat-8.5.34\server\webapps\bonita\WEB-INF\lib` directory

--- a/md/sap-jco-3.md
+++ b/md/sap-jco-3.md
@@ -54,7 +54,6 @@ It is assumed that Tomcat had been started once sucessfully, and the Bonita Engi
 3. Start Tomcat
 
 #### Point 3. Wildfly example (BonitaSubscription-7.8.3-wildfly-10.1.0.Final bundle)
-It is assumed that the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\start-bonita.bat` script is used to start Wildfly.
 
 1. Create the `sapjco3\main` directories under `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\modules\system\layers\base\com\` directory
 2. Copy the `sapjco3.jar` file into `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\modules\system\layers\base\com\sapjco3\main`
@@ -70,12 +69,20 @@ It is assumed that the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\start-boni
     </dependencies>
 </module>
 ```
-4. Edit the `BonitaBPMSubscription-7.5.4-wildfly-10.1.0.Final\setup\wildfly-templates\standalone.xml`, add these 3 lines under `subsystem xmlns="urn:jboss:domain:ee:4.0"`
+4. Edit the `standalone.xml` file and add these 3 lines under `subsystem xmlns="urn:jboss:domain:ee:4.0"`
+
+When the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\start-bonita.bat` script is used to start Wildfly, then edit the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\setup\wildfly-templates\standalone.xml`.
+
+Otherwise edit the `BonitaSubscription-7.8.3-wildfly-10.1.0.Final\server\standalone\configuration\standalone.xml` file.
+
 ```xml
 <global-modules>      
     <module name="com.sapjco3" slot="main"/>
 </global-modules> 
-``` 
+```
+
+
+
 5. Start Wildfly
 
 


### PR DESCRIPTION
Addition of examples with both Tomcat and Wildfly bundles, that show how to make the classes of the sapjco3.jar lib available to the bonita engine.

Versions: 7.4, 7.5, 7.6, 7.7, 7.8
