### PR TITLE
feat(packaging): Deploy Bundle removal & cas & LDAP synchronizer move

### DIFF
--- a/md/BonitaBPM_platform_setup.md
+++ b/md/BonitaBPM_platform_setup.md
@@ -18,7 +18,7 @@ The *Platform setup tool* handles:
   - The management of Bonita Platform configuration (stored in the database)
   - The management of licenses (also stored in the database)
 
-It is located in both [Tomcat](tomcat-bundle.md) and [WildFly](wildfly-bundle.md) bundles, and also in the [deploy bundle](deploy-bundle.md). In Tomcat and WildFly bundles, you can find the tool in the `setup` folder.
+It is located in both [Tomcat](tomcat-bundle.md) and [WildFly](wildfly-bundle.md) bundles. You can find the tool in the `setup` folder.
 
 ### Structure
 

--- a/md/bonita-as-windows-service.md
+++ b/md/bonita-as-windows-service.md
@@ -20,16 +20,16 @@ Please verify the supported version from the Support page
 
 ![Tomcat home page](images/bonita-as-windows-service/tomcatHome.png)
 
-* **_Download_** the bundle BonitaSubscription-x.y.z-deploy.zip (or BonitaCommunity-x.y.z-deploy.zip for the community edition)
-* **_Unzip_** the bundle in a folder that we'll call: %BONITA_DEPLOY%
-* **_Move_** the setup tool %BONITA_DEPLOY%/setup into another folder, for example %TOMCAT_INSTALL_FOLDER%/setup
+* **_Download_** the bundle BonitaSubscription-x.y.z-tomcat.zip (or BonitaCommunity-x.y.z-tomcat.zip for the community edition)
+* **_Unzip_** the bundle in a folder that we'll call: %TOMCAT_BUNDLE%
+* **_Move_** the setup tool %TOMCAT_BUNDLE%/setup into another folder, for example %TOMCAT_INSTALL_FOLDER%/setup
 This last step is not mandatory since the setup tool is independent from Tomcat, you can place it wherever you want.
 
 ## Get the license (In case of Subscription edition)
 
-* **_Execute_** %BONITA_DEPLOY%/request_key_utils/generateRequestKey.bat
-* **_Use_** the generated key to get a license from the customer portal. The license shouldn't be a development license.
-* **_Move_** the license file into the folder %TOMCAT_INSTALL_FOLDER%/setup/platform_conf/licenses
+* **_Execute_** %TOMCAT_BUNDLE%/tools/request_key_utils/generateRequestKey.bat
+* **_Use_** the generated key to get a license from the customer portal. The license should not be a development license.
+* **_Move_** the received license file into the folder %TOMCAT_INSTALL_FOLDER%/setup/platform_conf/licenses
 
 ## Database configuration
 
@@ -46,21 +46,21 @@ Check your Database provider documentation in order to get the proper driver ver
 
 ## Server configuration
 
-* **_Move_** the folder %BONITA_DEPLOY%/Tomcat-x.y.z/server/lib to %TOMCAT_INSTALL_FOLDER%/lib
+* **_Move_** the folder %TOMCAT_BUNDLE%/server/lib to %TOMCAT_INSTALL_FOLDER%/lib
 * **_Add_** your database driver to %TOMCAT_INSTALL_FOLDER%/lib
-* **_Move_** the folder %BONITA_DEPLOY%/Tomcat-x.y.z/server/conf to %TOMCAT_INSTALL_FOLDER%/conf
-* **_Move_** the folder %BONITA_DEPLOY%/Tomcat-x.y.z/server/webapps to %TOMCAT_INSTALL_FOLDER%/webapps
+* **_Move_** the folder %TOMCAT_BUNDLE%/server/conf to %TOMCAT_INSTALL_FOLDER%/conf
+* **_Move_** the folder %TOMCAT_BUNDLE%/server/webapps to %TOMCAT_INSTALL_FOLDER%/webapps
 * **_Configure_** %TOMCAT_INSTALL_FOLDER%/conf/Catalina/localhost/bonita.xml
 
 ![datasource configuration](images/bonita-as-windows-service/bonitaXml.png)
 
 ## Configure JVM properties
 
-* The file %BONITA_DEPLOY%/Tomcat-x.y.z/server/bin/setenv.bat contains all JVM parameters to use in the new installation.
+* The file %TOMCAT_BUNDLE%/server/bin/setenv.bat contains all JVM parameters to use in the new installation.
 * Update this file to change the database provider (for example postgresql).
 * In this file update all the references to %CATALINA_HOME% with %TOMCAT_INSTALL_FOLDER%
 In this example %TOMCAT_INSTALL_FOLDER% = C:\Program Files\Apache Software Foundation\Tomcat x.y
-* Extract all the JVM properties of the file %BONITA_DEPLOY%/Tomcat-x.y.z/server/bin/setenv.bat 
+* Extract all the JVM properties of the file %TOMCAT_BUNDLE%/server/bin/setenv.bat 
 
 * The properties should be the following ones:
 

--- a/md/bonita-bpm-installation-overview.md
+++ b/md/bonita-bpm-installation-overview.md
@@ -29,7 +29,7 @@ Bonita Platform can be installed in several ways:
 * If you want to do a fresh install, get one of our prepackaged bundles that include an Application Server
     * [Tomcat + Bonita](tomcat-bundle.md)
     * [WildFly + Bonita](wildfly-bundle.md)
-* If you want to do a custom installation, use the [Deploy bundle](deploy-bundle.md).
+* If you want to do a custom installation, see [Custom Deployment](deploy-bundle.md).
 
 
 For all options, you will need to [configure](database-configuration.md) Bonita Engine to work with the database of your choice (e.g. PostgreSQL or Oracle).

--- a/md/configure-client-of-bonita-bpm-engine.md
+++ b/md/configure-client-of-bonita-bpm-engine.md
@@ -135,7 +135,7 @@ Finally, you can edit the file `<bonita-subscription>/server/webapps/bonita/WEB-
 
 ### Server configuration to accept HTTP Connection
 
-By default [Tomcat](tomcat-bundle.md) and [WildFly](wildfly-bundle.md) bundles along with the `bonita.war` from the [deploy bundle](deploy-bundle.md) are configured to accept connection for HTTP connections.
+By default [Tomcat](tomcat-bundle.md) and [WildFly](wildfly-bundle.md) bundles are configured to accept connection for HTTP connections.
 
 It is configured in the `web.xml` file of the web application like this:
 

--- a/md/deploy-bundle.md
+++ b/md/deploy-bundle.md
@@ -29,7 +29,7 @@ Copy, from the bundle into your Tomcat server:
 * The entirety of the bundle `server/lib/bonita` folder to `lib/bonita`
 * The `server/webapps/bonita.war` and `webapps/ROOT/favicon.ico` to `webapps` and `webapps/ROOT/`
 * The entirety of the `setup` directory at the root of your tomcat server.
-* The entirety of the `server/Request_key_utils-`. Includes script files to generate license request keys.
+* The entirety of the `tools/request_key_utils-`. Includes script files to generate license request keys.
 
 :::warning
 Some configuration files from the bundle will overwrite some default tomcat configuration files. Proceed

--- a/md/deploy-bundle.md
+++ b/md/deploy-bundle.md
@@ -1,10 +1,4 @@
-# Deploy bundle
-
-## What is the purpose of the Bonita Deploy bundle?
-
-* The Bonita Deploy bundle is used if you have **already installed a Java EE Application Server**.
-* The Bonita Deploy bundle is a way of setting up a Bonita Platform. You'll be able to get a setup quite similar to WildFly or Tomcat bundle.
-* It's also used to package other tools such as the LDAP synchronizer.
+# Custom Deployment
 
 :::warning
 This installation procedure only specifically targets the Java EE application Servers that have been installed under a single root folder (typically, from a .zip file).
@@ -17,41 +11,33 @@ Remember that the recommended way of installing Bonita is to use the provided [T
 It saves you from doing all the following configuration at hand, as the setup tool included handles it automatically.
 :::
 
-
-## Deploy bundle content
-
-* `Tomcat-`_`version`_: a folder/file structure to be merged with an existing setup of Apache Tomcat, in order to install Bonita Portal and Bonita Engine.
-* `Wildfly-`_`version`_: a folder/file structure to be merged with an existing setup of WildFly in order to install Bonita Portal and Bonita Engine.
-<a id="platform_setup_tool" />
-* `setup`: a command-line tool that creates the Bonita Platform before it can be run. It creates the Bonita Platform internal database, and stores the runtime configuration.
-It is useful to update the configuration, locally or from a remote computer.
-* `Request_key_utils-`_`key_utils.version`_: include script files to generate license request keys.
-* `BonitaSubscription`-_`LDAPSync.version`_-`LDAP-Synchronizer` : LDAP synchronizer to synchronize your organization in Bonita with your LDAP
-* `cas-`_`cas.version`_`-module`: Module files and description to enable CAS dependency to bonita EAR.
-* `License`: license files that apply to Bonita components.
-* `README.TXT`: See this file for more details about the `deploy.zip` contents and structure. 
-
 ## Installation
 
-1. Download the deploy.zip file from the [Bonitasoft download page](http://www.bonitasoft.com/downloads-v2) for the Community edition 
+1. Download the Tomcat bundle file from the [Bonitasoft download page](http://www.bonitasoft.com/downloads-v2) for the Community edition 
 or from the [Customer Portal](https://customer.bonitasoft.com/download/request) for Subscription editions.
-2. Unzip the `deploy.zip` into a temporary folder (DEPLOY_ZIP_HOME).
-4. Follow the [Tomcat bundle steps](#tomcat-installation) or [WildFly bundle steps](#wildfly-installation)
+2. Unzip it into a temporary folder (BUNDLE_DIRECTORY).
+3. Follow the [Tomcat bundle steps](#tomcat-installation).
 
 <a id="tomcat-installation" />
 
 ## Tomcat installation
 ### Install Bonita Platform in Tomcat
 
-Copy all files and directories from DEPLOY_ZIP_HOME/Tomcat-8.5.34/server to your Tomcat root directory (TOMCAT_HOME).
+Copy, from the bundle into your Tomcat server:
+* `server/bin/setenv.sh` or `server/bin/setenv.bat`, depending if you are on Unix or Windows, to `bin`
+* The entirety of the bundle `server/conf` folder to `conf`
+* The entirety of the bundle `server/lib/bonita` folder to `lib/bonita`
+* The `server/webapps/bonita.war` and `webapps/ROOT/favicon.ico` to `webapps` and `webapps/ROOT/`
+* The entirety of the `setup` directory at the root of your tomcat server.
+* The entirety of the `server/Request_key_utils-`. Includes script files to generate license request keys.
+
 :::warning
-Some configuration files from the deploy zip will overwrite some default tomcat configuration files. Proceed
+Some configuration files from the bundle will overwrite some default tomcat configuration files. Proceed
 with care in a tomcat where other applications are already installed.
 :::
 :::warning
 There is an [issue on tomcat 8.0.32](https://bz.apache.org/bugzilla/show_bug.cgi?id=58999) preventing the portal Look & feel to be compiled. If you deploy bonita on an existing tomcat installation, make sure it is a different version of tomcat (preferably 8.5.x with x>=23).
 :::
-
 
 ### Configure data sources
 
@@ -73,62 +59,23 @@ There is an [issue on tomcat 8.0.32](https://bz.apache.org/bugzilla/show_bug.cgi
 
 ### Add Jdbc driver
 You need to add your jdbc driver in TOMCAT_HOME/lib. 
-MySQL, PostgreSQL and Microsoft SQL Server drivers can be found in deploy bundle under DEPLOY_ZIP_HOME/setup/lib directory. For Oracle, 
+MySQL, PostgreSQL and Microsoft SQL Server drivers can be found in the Tomcat bundle under DEPLOY_ZIP_HOME/setup/lib directory. For Oracle, 
 use the [jdbc driver](database-configuration.md#proprietary_jdbc_drivers) provided by Oracle.
-
-<a id="wildfly-installation" />
-
-## Wildfly installation
-
-::: warning
-**WARNING:** Starting from Bonita 7.9.0 the Wildfly bundle is deprecated. It will be removed in a future release. Check the [Release Note](release-notes.md) for more details.
-:::
-### Install Bonita Platform in Wildfly
-Copy all files and directories from DEPLOY_ZIP_HOME/wildfly-10.1.0.Final/server to your Wildfly root directory (WILDFLY_HOME).
-
-### Configure data sources
-1. Open the file WILDFLY_HOME/standalone/configuration/standalone.xml
-2. For Bonita Standard data source, remove or comment out the default definition for h2.
-3. Uncomment the settings matching your RDBMS vendor.
-4. Modify the values of the following settings to your configuration: server address, server port, database name, user name and password.
-5. Repeat operations 2. to 4. for Business Data data source
-
-### Configure RDBMS vendor
-1. Open WILDFLY_HOME/standalone/configuration/standalone.xml and look for `system-properties` tag
-2. Set the value for sysprop.bonita.db.vendor (Bonita Platform database vendor)
-3. Set the value for sysprop.bonita.bdm.db.vendor (Business Data database vendor)
-
-### Add Jdbc driver
-1. Create a folder structure under WILDFLY_HOME/modules folder. Refer to the table below to identify the folders to create. 
-The last folder is named `main` for all JDBC drivers.
-
-| Database vendor | Module folders              | Module description file                                 |
-| --------------- | --------------------------- | ------------------------------------------------------- |
-| PostgreSQL      | modules/org/postgresql/main | [module.xml](images/special_code/postgresql/module.xml) |
-| Oracle          | modules/com/oracle/main     | [module.xml](images/special_code/oracle/module.xml)     |
-| SQL Server      | modules/com/sqlserver/main  | [module.xml](images/special_code/sqlserver/module.xml)  |
-| MySQL           | modules/com/mysql/main      | [module.xml](images/special_code/mysql/module.xml)      |
-
-2. Put the driver jar file in the relevant main folder.
-3. In the same folder as the driver, add the module description file, `module.xml`. This file describes the dependencies 
-the module has and the content it exports. It must describe the driver jar and the JVM packages that Wildfly does not 
-provide automatically. The exact details of what must be included depend on the driver jar. 
-**Caution**: you might need to edit the module.xml in order to match exactly the JDBC driver jar file name.
 
 
 ## License installation
 
 If you are installing a Subscription edition, you need to [request a license](licenses.md). 
 
-When you receive your license, copy the file to the `DEPLOY_ZIP_HOME/setup/platform_conf/licenses` folder of your application server.
+When you receive your license, copy the file to the `TOMCAT_DIRECTORY/setup/platform_conf/licenses` folder of your application server.
 
 ## Database initialization
 We assume here that the database has already been [created and configured for Bonita](database-configuration.md#database_creation).
-Once created and configured you need to initialize it using the setup tool provided in the deploy bundle archive.
+Once created and configured you need to initialize it using the setup tool provided in the bundle.
 This will create database schema and initial values.
-1. In DEPLOY_ZIP_HOME/setup folder, edit the file database.properties with properties matching your rdbms. Beware of [backslash characters](BonitaBPM_platform_setup.md#backslash_support).
-2. In DEPLOY_ZIP_HOME/setup/lib add your jdbc driver if needed (only for Oracle, see [proprietary jdbc drivers](database-configuration.md#proprietary_jdbc_drivers))
-3. In DEPLOY_ZIP_HOME/setup folder, run `setup.(sh|bat) init`
+1. In TOMCAT_DIRECTORY/setup folder, edit the file database.properties with properties matching your rdbms. Beware of [backslash characters](BonitaBPM_platform_setup.md#backslash_support).
+2. In TOMCAT_DIRECTORY/setup/lib add your jdbc driver if needed (only for Oracle, see [proprietary jdbc drivers](database-configuration.md#proprietary_jdbc_drivers))
+3. In TOMCAT_DIRECTORY/setup folder, run `setup.(sh|bat) init`
 
 ## Next steps
 You're done with Bonita installation. You can now start your application server as usual.

--- a/md/ldap-synchronizer.md
+++ b/md/ldap-synchronizer.md
@@ -32,7 +32,7 @@ The tool supports LDAP groups of the following classes:
 
 ## Installation
 
-To install the synchronizer, unzip the provided deploy.zip file and configure the files located under the conf directory. 
+To install the synchronizer, unzip the Tomcat bundle and configure the files located under the tools/BonitaSubscriptionLDAPSynchronizer/conf directory. 
 This directory contains a sample configuration in the `conf/default` subfolder which is used to perform LDAP synchronization
 on the default tenant. This is also possible to perform the synchronization on a [non default tentant](#non-default-tenant)
 which requires dedicated configuration.

--- a/md/licenses.md
+++ b/md/licenses.md
@@ -36,7 +36,7 @@ If this is the first time you generate a license, you need to generate a request
 ### Generate the request key
 
 On the server where you installed Bonita Platform:  
-1. Go to the `request_key_utils` folder
+1. Go to the `tools/request_key_utils` folder
 2. Run the `generateRequestKey.bat` script (for Windows) or the `generateRequestKey.sh` script (for other operating systems)
 
 ### Generate the new license

--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -44,14 +44,22 @@ An edition form can now be generated to edit a Business data or a Document from 
 ### New embedded AngularJS filter to resolve business object lazy references
 More info on how to use it [here](variables.md).
 
+
 ## Industrialization
 
 ### Theme projects integrated in Bonita project (Subscription only)
 More info on how to use it [here](customize-living-application-theme.md).
 
+
 ## Packaging
 ### Bundles
 Tomcat and Wildfly bundles have been renamed. The Wildfly and Tomcat version are no longer specified in their name.
+
+### LDAP synchronizer & CAS single sign-on module
+The LDAP synchronizer & CAS single sign-on module are now provided with the Bonita Subscription bundles, in the `tools/` sub-directory.
+
+### License Request Key generator
+Within Tomcat and WildFly bundles, the License Request Key generator tool has been moved from the `server/` sub-directory to the `tools/` sub-directory.
 
 ## Miscellaneous
 
@@ -78,6 +86,11 @@ The Wildfly bundle was mainly used with the SQL server database. The Tomcat bund
 
 ### 32 bits installers
 32 bits installers for all platforms are no longer provided.
+
+### Deploy zip
+The BonitaSubscription-x.y.z-deploy.zip is no longer provided starting from Bonita 7.9.
+Please use the Tomcat bundle instead, or see the [Custom Deployment](deploy-bundle.md) page for more specific needs.
+
 
 ## Technology updates
 

--- a/md/single-sign-on-with-cas.md
+++ b/md/single-sign-on-with-cas.md
@@ -12,12 +12,113 @@ CAS configuration is at tenant level. Each tenant can use a different CAS servic
 Note: On a system using CAS to manage logins, if a user who is not already logged in tries to access a page in the Portal by clicking on a URL link, they are re-directed to the login page. 
 After logging in, the requested page is not displayed automatically. The user must click the link again. 
 
+
+## Configure Bonita Engine and Tomcat for CAS
+
+
+1. The CAS implementation relies on JAAS, and is defined in the BonitaAuthentication module of the JAAS configuration file.  
+   Set the Java system property `java.security.auth.login.config` in the Tomcat startup script to point to the JAAS configuration file, [`TOMCAT_HOME/server/conf/jaas-standard.cfg`](BonitaBPM_platform_setup.md). 
+
+   For example, on Linux, edit `TOMCAT_HOME/setup/tomcat-templates/setenv.sh`, uncomment the line that defines `SECURITY_OPTS`, and insert the variable `SECURITY_OPTS` in the line `CATALINA_OPTS=..`. 
+ 
+   The `TOMCAT_HOME/server/conf/jaas-standard.cfg` file contains the following (replace `ip_address:port` with the relevant IP addresses and port numbers, in two places): 
+   ```
+   BonitaAuthentication-1 {
+     org.jasig.cas.client.jaas.CasLoginModule required
+       ticketValidatorClass="org.jasig.cas.client.validation.Cas20ServiceTicketValidator"
+       casServerUrlPrefix="http://ip_address:port/cas"
+       tolerance="20000"
+       service="http://ip_address:port/bonita/loginservice"
+       defaultRoles="admin,operator"
+       roleAttributeNames="memberOf,eduPersonAffiliation"
+       principalGroupName="CallerPrincipal"
+       roleGroupName="Roles"
+       cacheAssertions="true"
+       cacheTimeout="480";
+   };
+   ```
+   ::: warning
+   **Warning**: module names must be unique (from the example above, BonitaAuthentication-1 is the module name). Therefore, remove the unecessary ones
+   :::
+ 
+   The JAAS configuration file, `jaas-standard.cfg`, is sorted by sets of authentication modules. For Bonita, each set matches a tenant configuration and the name is prefixed with _BonitaAuthentication-`<tenant-id>`_. Make sure there is a set of authentication modules for each tenant in your platform. For each tenant, set the CAS service to point to the application login page and set `casServerUrlPrefix` to point to the CAS server.
+
+2. In the `CasLoginModule` configuration, check that the `principalGroupName` property is set to `CallerPrincipal`.  
+   This is required to retrieve the username from the Bonita application.
+   Bonita uses the CAS LoginModule in the JASIG implementation, so see the CAS LoginModule section of the [Jasig documentation](https://wiki.jasig.org/display/CASC/JAAS+Integration) for more information.
+3. Copy `cas-client-core-x.x.x.jar` from `BonitaSubscription-x.x.x-tomcat/tools/cas-x.x.x-module/org/jasig/cas/main` into the `TOMCAT_HOME/server/lib` directory.
+4. Copy `commons-logging-x.x.x.jar` from `BonitaSubscription-x.x.x-tomcat/tools//BonitaSubscription-x.x.x-LDAP-Synchronizer/BonitaSubscription-x.x.x-LDAP-Synchronizer/lib` into the `TOMCAT_HOME/server/lib` directory.
+5. Update `bonita-tenant-sp-custom.properties` from `setup/platform_conf/initial/tenant_template_engine/` if platform has not been initialized yet or `setup/platform_conf/current/tenants/[TENANT_ID]/tenant_engine/` and `setup/platform_conf/current/tenant_template_engine/`.
+::: info
+If the platform has already been initialized, every update to the configuration files under `setup/platform_conf/current` must be done using the `setup` tool:  
+- `setup pull`  
+- edit configuration file(s)  
+- `setup push`
+:::
+   1. Remove the comment flags from these lines:
+      `authentication.service.ref.name=jaasAuthenticationService`
+   2. **Optionally**, to enable anonymous user to access a process, uncomment this lines:
+      ```
+      authenticator.delegate=casAuthenticatorDelegate
+      authentication.delegate.cas.server.url.prefix=http://ip_address:port
+      authentication.delegate.cas.service.url=http://ip_address:port/bonita/loginservice
+      ```
+      Specify the relevant IP address and port number.
+
+#### Configure the Bonita Portal for CAS SSO
+
+1. For each tenant, edit `authenticationManager-config.properties` to enable the CASRemoteAuthenticationManager and its properties.
+Edit the `authenticationManager-config.properties` located in `platform_conf/initial/tenant_template_portal` for not initialized platform or `platform_conf/current/tenant_template_portal` and `platform_conf/current/tenants/[TENANT_ID]/tenant_portal/`.
+::: info
+If the platform has already been initialized, every update to the configuration files under `setup/platform_conf/current` must be done using the `setup` tool:  
+- `setup pull`
+- edit configuration file(s)  
+- `setup push`
+:::
+
+Make sure that `auth.AuthenticationManager` property is set to `org.bonitasoft.console.common.server.auth.impl.jaas.cas.CASRemoteAuthenticationManagerImpl`
+Uncomment `Cas.serverUrlPrefix` and `Cas.bonitaServiceURL` properties as shown below (specify the relevant IP addresses and ports):
+
+```
+#auth.AuthenticationManager = org.bonitasoft.console.common.server.auth.impl.standard.StandardAuthenticationManagerImplExt
+#auth.AuthenticationManager = org.bonitasoft.console.common.server.auth.impl.oauth.OAuthAuthenticationManagerImplExt
+# OAuth.serviceProvider = LinkedIn
+# OAuth.consumerKey = ove2vcdjptar
+# OAuth.consumerSecret = vdaBrCmHvkgJoYz1
+# OAuth.callbackURL = http://ip_address:port/loginservice
+auth.AuthenticationManager = org.bonitasoft.console.common.server.auth.impl.jaas.cas.CASRemoteAuthenticationManagerImpl
+Cas.serverUrlPrefix = http://ip_address:port/cas
+Cas.bonitaServiceURL = http://ip_address:port/bonita/portal/homepage
+logout.link.hidden=true
+```
+
+#### CAS SSO and Java client application
+
+To enable a Java client application to access the engine using CAS autentication, the simplest way is to enable [REST authentication on CAS server](https://apereo.github.io/cas/4.0.x/protocol/REST-Protocol.html) and have the Java client [retrieve the `ticket` for the bonita `service` URL](#cas-rest-api).  
+Then, use the [`LoginAPI`](http://documentation.bonitasoft.com/javadoc/api/${varVersion}/org/bonitasoft/engine/api/LoginAPI.html#login(java.util.Map)) with the `java.util.Map` having the `ticket` and `service`.
+
+#### Cluster considerations and bonita webapp for Tomcat
+
+If you are configuring Bonita and Tomcat in a cluster environment for CAS, there are some extra steps to do:
+
+1. Copy `commons-logging-x.x.x.jar` from `BonitaSubscription-x.x.x-tomcat/tools/BonitaSubscription-x.x.x-LDAP-Synchronizer/BonitaSubscription-x.x.x-LDAP-Synchronizer/lib` into the `TOMCAT_HOME/server/lib` directory.
+2. Remove the `WEB-INF/lib/commons-logging-x.x.x.jar` file from the `TOMCAT_HOME/server/webapps/bonita.war`.
+3. Remove the `TOMCAT_HOME/server/webapps/bonita/WEB-INF/lib/commons-logging-x.x.x.jar` file (if it is present).
+
+### Troubleshoot
+
+To troubleshoote SSO login issues, you need to increase the [log level](logging.md) to `ALL` in order for errors to be displayed in the log files (by default, they are not).
+
 ## Configure Bonita Engine and WildFly for CAS
+
+::: warning
+**WARNING:** Starting from Bonita 7.9.0 the Wildfly bundle is deprecated. It will be removed in a future release. Check the [Release Note](release-notes.md) for more details.
+:::
 
 The deploy bundle contains the files needed to use CAS with Bonita platform and a WildFly 10 application server.  
 They are contained in `cas-3.3.1-module`. 
 
-You can use this folder to configure CAS for a platform deployed from the WildFly bundle or from the deploy bundle.  
+You can use this folder to configure CAS for a platform deployed from the WildFly bundle.  
 The `cas-3.3.1-module` folder contains some jar files that are required. 
 
 It also contains a configuration file for the module, `module.xml`, which defines the jar files to be loaded from the module itself and the dependencies of the module. For example:
@@ -52,8 +153,8 @@ For a standard installation, it is not necessary to modify this file.
 
 To configure Bonita Engine for CAS:
 
-1. If you do not already have it, download the Subscription edition deploy zip from the customer portal.
-2. Add the CAS module. To do this, copy `BonitaSubscription-x.x.x-deploy/cas-x.x.x-module/org` to `WILDFLY_HOME/server/modules` to merge the CAS module with the existing modules.
+1. If you do not already have it, download the Subscription edition Wildfly bundle from the customer portal.
+2. Add the CAS module. To do this, copy `BonitaSubscription-x.x.x-wildfly/tools/cas-x.x.x-module/org` to `WILDFLY_HOME/server/modules` to merge the CAS module with the existing modules.
 3. Make the CAS module global so that it can be used by any application. To do this, edit `WILDFLY_HOME/setup/wildfly-templates/standalone.xml` and change the definition of the `ee` subsystem to the following:
 
 ```xml
@@ -108,103 +209,7 @@ If the platform has already been initialized, every update to the configuration 
       authentication.delegate.cas.server.url.prefix=http://ip_address:port
       authentication.delegate.cas.service.url=http://ip_address:port/bonita/loginservice
       ```
-
-## Configure Bonita Engine and Tomcat for CAS
-
-
-1. The CAS implementation relies on JAAS, and is defined in the BonitaAuthentication module of the JAAS configuration file.  
-   Set the Java system property `java.security.auth.login.config` in the Tomcat startup script to point to the JAAS configuration file, [`TOMCAT_HOME/server/conf/jaas-standard.cfg`](BonitaBPM_platform_setup.md). 
-
-   For example, on Linux, edit `TOMCAT_HOME/setup/tomcat-templates/setenv.sh`, uncomment the line that defines `SECURITY_OPTS`, and insert the variable `SECURITY_OPTS` in the line `CATALINA_OPTS=..`. 
- 
-   The `TOMCAT_HOME/server/conf/jaas-standard.cfg` file contains the following (replace `ip_address:port` with the relevant IP addresses and port numbers, in two places): 
-   ```
-   BonitaAuthentication-1 {
-     org.jasig.cas.client.jaas.CasLoginModule required
-       ticketValidatorClass="org.jasig.cas.client.validation.Cas20ServiceTicketValidator"
-       casServerUrlPrefix="http://ip_address:port/cas"
-       tolerance="20000"
-       service="http://ip_address:port/bonita/loginservice"
-       defaultRoles="admin,operator"
-       roleAttributeNames="memberOf,eduPersonAffiliation"
-       principalGroupName="CallerPrincipal"
-       roleGroupName="Roles"
-       cacheAssertions="true"
-       cacheTimeout="480";
-   };
-   ```
-   ::: warning
-   **Warning**: module names must be unique (from the example above, BonitaAuthentication-1 is the module name). Therefore, remove the unecessary ones
-   :::
- 
-   The JAAS configuration file, `jaas-standard.cfg`, is sorted by sets of authentication modules. For Bonita, each set matches a tenant configuration and the name is prefixed with _BonitaAuthentication-`<tenant-id>`_. Make sure there is a set of authentication modules for each tenant in your platform. For each tenant, set the CAS service to point to the application login page and set `casServerUrlPrefix` to point to the CAS server.
-
-2. In the `CasLoginModule` configuration, check that the `principalGroupName` property is set to `CallerPrincipal`.  
-   This is required to retrieve the username from the Bonita application.
-   Bonita uses the CAS LoginModule in the JASIG implementation, so see the CAS LoginModule section of the [Jasig documentation](https://wiki.jasig.org/display/CASC/JAAS+Integration) for more information.
-3. Copy `cas-client-core-x.x.x.jar` from `BonitaSubscription-x.x.x-deploy/cas-x.x.x-module/org/jasig/cas/main` into the `TOMCAT_HOME/server/lib` directory.
-4. Copy `commons-logging-x.x.x.jar` from `BonitaSubscription-x.x.x-deploy/BonitaSubscription-x.x.x-LDAP-Synchronizer/BonitaSubscription-x.x.x-LDAP-Synchronizer/lib` into the `TOMCAT_HOME/server/lib` directory.
-5. Update `bonita-tenant-sp-custom.properties` from `setup/platform_conf/initial/tenant_template_engine/` if platform has not been initialized yet or `setup/platform_conf/current/tenants/[TENANT_ID]/tenant_engine/` and `setup/platform_conf/current/tenant_template_engine/`.
-::: info
-If the platform has already been initialized, every update to the configuration files under `setup/platform_conf/current` must be done using the `setup` tool:  
-- `setup pull`  
-- edit configuration file(s)  
-- `setup push`
-:::
-   1. Remove the comment flags from these lines:
-      `authentication.service.ref.name=jaasAuthenticationService`
-   2. **Optionally**, to enable anonymous user to access a process, uncomment this lines:
-      ```
-      authenticator.delegate=casAuthenticatorDelegate
-      authentication.delegate.cas.server.url.prefix=http://ip_address:port
-      authentication.delegate.cas.service.url=http://ip_address:port/bonita/loginservice
-      ```
-      Specify the relevant IP address and port number.
-
-#### Configure the Bonita Portal for CAS SSO
-
-1. For each tenant, edit `authenticationManager-config.properties` to enable the CASRemoteAuthenticationManager and its properties.
-Edit the `authenticationManager-config.properties` located in `platform_conf/initial/tenant_template_portal` for not initialized platform or `platform_conf/current/tenant_template_portal` and `platform_conf/current/tenants/[TENANT_ID]/tenant_portal/`.
-::: info
-If the platform has already been initialized, every update to the configuration files under `setup/platform_conf/current` must be done using the `setup` tool:  
-- `setup pull`
-- edit configuration file(s)  
-- `setup push`
-:::
-
-Make sure that `auth.AuthenticationManager` property is set to `org.bonitasoft.console.common.server.auth.impl.jaas.cas.CASRemoteAuthenticationManagerImpl`
-Uncomment `Cas.serverUrlPrefix` and `Cas.bonitaServiceURL` properties as shown below (specify the relevant IP addresses and ports):
-
-```
-#auth.AuthenticationManager = org.bonitasoft.console.common.server.auth.impl.standard.StandardAuthenticationManagerImplExt
-#auth.AuthenticationManager = org.bonitasoft.console.common.server.auth.impl.oauth.OAuthAuthenticationManagerImplExt
-# OAuth.serviceProvider = LinkedIn
-# OAuth.consumerKey = ove2vcdjptar
-# OAuth.consumerSecret = vdaBrCmHvkgJoYz1
-# OAuth.callbackURL = http://ip_address:port/loginservice
-auth.AuthenticationManager = org.bonitasoft.console.common.server.auth.impl.jaas.cas.CASRemoteAuthenticationManagerImpl
-Cas.serverUrlPrefix = http://ip_address:port/cas
-Cas.bonitaServiceURL = http://ip_address:port/bonita/portal/homepage
-logout.link.hidden=true
-```
-
-#### CAS SSO and Java client application
-
-To enable a Java client application to access the engine using CAS autentication, the simplest way is to enable [REST authentication on CAS server](https://apereo.github.io/cas/4.0.x/protocol/REST-Protocol.html) and have the Java client [retrieve the `ticket` for the bonita `service` URL](#cas-rest-api).  
-Then, use the [`LoginAPI`](http://documentation.bonitasoft.com/javadoc/api/${varVersion}/org/bonitasoft/engine/api/LoginAPI.html#login(java.util.Map)) with the `java.util.Map` having the `ticket` and `service`.
-
-#### Cluster considerations and bonita webapp for Tomcat
-
-If you are configuring Bonita and Tomcat in a cluster environment for CAS, there are some extra steps to do:
-
-1. Copy `commons-logging-x.x.x.jar` from `BonitaSubscription-x.x.x-deploy/BonitaSubscription-x.x.x-LDAP-Synchronizer/BonitaSubscription-x.x.x-LDAP-Synchronizer/lib` into the `TOMCAT_HOME/server/lib` directory.
-2. Remove the `WEB-INF/lib/commons-logging-x.x.x.jar` file from the `TOMCAT_HOME/server/webapps/bonita.war`.
-3. Remove the `TOMCAT_HOME/server/webapps/bonita/WEB-INF/lib/commons-logging-x.x.x.jar` file (if it is present).
-
-### Troubleshoot
-
-To troubleshoote SSO login issues, you need to increase the [log level](logging.md) to `ALL` in order for errors to be displayed in the log files (by default, they are not).
-
+      
 ## Configure logout behaviour
 
 #### Bonita Portal

--- a/md/single-sign-on-with-cas.md
+++ b/md/single-sign-on-with-cas.md
@@ -47,7 +47,7 @@ After logging in, the requested page is not displayed automatically. The user mu
    This is required to retrieve the username from the Bonita application.
    Bonita uses the CAS LoginModule in the JASIG implementation, so see the CAS LoginModule section of the [Jasig documentation](https://wiki.jasig.org/display/CASC/JAAS+Integration) for more information.
 3. Copy `cas-client-core-x.x.x.jar` from `BonitaSubscription-x.x.x-tomcat/tools/cas-x.x.x-module/org/jasig/cas/main` into the `TOMCAT_HOME/server/lib` directory.
-4. Copy `commons-logging-x.x.x.jar` from `BonitaSubscription-x.x.x-tomcat/tools//BonitaSubscription-x.x.x-LDAP-Synchronizer/BonitaSubscription-x.x.x-LDAP-Synchronizer/lib` into the `TOMCAT_HOME/server/lib` directory.
+4. Copy `commons-logging-x.x.x.jar` from `BonitaSubscription-x.x.x-tomcat/tools//BonitaSubscription-x.x.x-LDAP-Synchronizer/lib` into the `TOMCAT_HOME/server/lib` directory.
 5. Update `bonita-tenant-sp-custom.properties` from `setup/platform_conf/initial/tenant_template_engine/` if platform has not been initialized yet or `setup/platform_conf/current/tenants/[TENANT_ID]/tenant_engine/` and `setup/platform_conf/current/tenant_template_engine/`.
 ::: info
 If the platform has already been initialized, every update to the configuration files under `setup/platform_conf/current` must be done using the `setup` tool:  
@@ -101,7 +101,7 @@ Then, use the [`LoginAPI`](http://documentation.bonitasoft.com/javadoc/api/${var
 
 If you are configuring Bonita and Tomcat in a cluster environment for CAS, there are some extra steps to do:
 
-1. Copy `commons-logging-x.x.x.jar` from `BonitaSubscription-x.x.x-tomcat/tools/BonitaSubscription-x.x.x-LDAP-Synchronizer/BonitaSubscription-x.x.x-LDAP-Synchronizer/lib` into the `TOMCAT_HOME/server/lib` directory.
+1. Copy `commons-logging-x.x.x.jar` from `BonitaSubscription-x.x.x-tomcat/tools/BonitaSubscription-x.x.x-LDAP-Synchronizer/lib` into the `TOMCAT_HOME/server/lib` directory.
 2. Remove the `WEB-INF/lib/commons-logging-x.x.x.jar` file from the `TOMCAT_HOME/server/webapps/bonita.war`.
 3. Remove the `TOMCAT_HOME/server/webapps/bonita/WEB-INF/lib/commons-logging-x.x.x.jar` file (if it is present).
 

--- a/md/tomcat-bundle.md
+++ b/md/tomcat-bundle.md
@@ -45,9 +45,11 @@ The Tomcat bundle is based on a standard Tomcat installation with the following 
 * `server/conf/server.xml`: modified to add listener for Narayana and h2 (see below for modification needed if you want to switch to another RDBMS).
 * `server/conf/jbossts-properties.xml`: configuration files for Narayana transaction manager.
 * `server/lib/bonita`: extra libraries needed by Bonita. The following libraries are included: Narayana JTA Transaction Manager, h2, SLF4J.
-* `server/request_key_utils`: folder containing script to generate license request keys (Subscription editions only).
 * `server/webapps/bonita.war`: the Bonita web application.
 * `setup/`: a tool to manage Bonita Platform configuration, stored in database instead of filesystem. Also ships a tool to centralize all the required Tomcat bundle configuration.
+* `tools/request_key_utils-`_`key_utils.version`_: folder containing the script to generate license request keys (Subscription editions only).
+* `tools/BonitaSubscription-x.y.z`-`LDAP-Synchronizer` : folder containing the tool to synchronize your organization in Bonita with your LDAP (Subscription editions only).
+* `tools/cas-`_`cas.version`_`-module`: folder containing module files and description to enable CAS dependency to bonita EAR (Subscription editions only).
 * `start-bonita.bat`: script to start the bundle on Windows.
 * `start-bonita.sh`: script to start the bundle on Linux.
 * `stop-bonita.bat`: script to stop the bundle on Windows.
@@ -67,7 +69,7 @@ If this is the first time you generate a license, you need to generate a request
 #### Generate the request key
 
 On the server where you installed Bonita Platform:
-1. Go to the request_key_utils folder
+1. Go to the `tools/request_key_utils` folder
 2. Run the `generateRequestKey.bat` script (for Windows) or the `generateRequestKey.sh` script (for Linux)
     
 #### Request the new license

--- a/md/ubuntu-openjdk-tomcat-postgresql.md
+++ b/md/ubuntu-openjdk-tomcat-postgresql.md
@@ -7,16 +7,16 @@ includes the following set of components:
 
 Simply follow a standard Ubuntu installation procedure. You won't need any specific settings here.
 
-Note: make sure you got a text editor installed such as `nano`. In order to install it: `sudo apt-get install nano`
+Note: make sure you got a text editor installed such as `nano`. In order to install it: `sudo apt install nano`
 
-Note: we use `aptitude` command line tool to install packages such as OpenJDK or PostgreSQL. You can also use different tool such
-as `apt-get` or a graphical package manager such as `synaptic`.
+Note: we use `apt` command line tool to install packages such as OpenJDK or PostgreSQL. You can also use different tool such
+as `apt` or a graphical package manager such as `synaptic`.
 
 ## Java Virtual Machine
 
 To install the OpenJDK JVM you need to install the `openjdk-8-jre-headless` package:
 
-* Run the following command line: `sudo aptitude install openjdk-8-jre-headless`
+* Run the following command line: `sudo apt install openjdk-8-jre-headless`
 * If needed, type your Ubuntu user password
 * Type _**Enter**_ to confirm that you want to continue installation
 
@@ -34,7 +34,7 @@ OpenJDK 64-Bit Server VM (build 25.111-b14, mixed mode)
 
 To install PostgreSQL 11 you need to install the `postgres-11` package:
 
-* Run the following command line: `sudo aptitude install postgresql-11`
+* Run the following command line: `sudo apt install postgresql-11`
 * If needed, type your Ubuntu user password
 * Type _**Enter**_ to confirm that you want to continue installation
 
@@ -74,7 +74,7 @@ Prepared transactions is disabled by default in PostgreSQL. You need to enable i
 
 Run the following command lines:
 
-* `sudo aptitude install curl`
+* `sudo apt install curl`
 * `cd /tmp/`
 * `wget http://apache.mirrors.ionfish.org/tomcat/tomcat-8/v8.5.40/bin/apache-tomcat-8.5.40.tar.gz`
 * `sudo tar xzvf apache-tomcat-8.5.40.tar.gz -C /usr/share/tomcat8 --strip-components=1`
@@ -121,30 +121,28 @@ In case of problems with this part refer to the documentations pages [How to Ins
 You need to include JDBC driver in Tomcat classpath:
 
 * Change to Tomcat libraries directory: `cd /usr/share/tomcat8/lib`
-* Install `wget` tool in order to be able to download JDBC driver: `sudo aptitude install wget`
+* Install `wget` tool in order to be able to download JDBC driver: `sudo apt install wget`
 * Download the JDBC driver: `sudo wget http://jdbc.postgresql.org/download/postgresql-42.2.5.jar`
 
 ## Bonita Platform
 
 ### Download and unzip the Bonita deploy bundle
 
-Download the Bonita deploy bundle from the [Customer Portal](https://customer.bonitasoft.com/)
-(Subscription editions) or get the [Community edtion](http://www.bonitasoft.com/downloads-v2). Instructions
-below will be given for Bonita Subscription Pack. You can easily adapt files and folder names to your edition.
+Download the Bonita Tomcat bundle from the [Customer Portal](https://customer.bonitasoft.com/)
+(Subscription editions) or get the [Community edition](http://www.bonitasoft.com/downloads-v2). Instructions
+below will be given for Bonita Subscription. You can easily adapt files and folder names to the Community edition.
 
 * Go to Bonitasoft [Customer Portal](https://customer.bonitasoft.com/)
 * In **Download** menu, click on _**Request a download**_
 * Select your version and click on _**Access download page**_ button
 * On the download page, go to the **Deploying Server Components** section
-* Click on _**Download BonitaSubscription-x.y.z-deploy.zip**_ link. If your server only has a terminal available
+* Click on _**Download BonitaSubscription-x.y.z-tomcat.zip**_ link. If your server only has a terminal available
 you can copy the link and use `wget` to download the file or use SSH with `scp` command to copy
 the file from another computer.
-* Make sure that the `BonitaSubscription-x.y.z-deploy.zip` is located in your home folder (e.g. `/home/osuser`).
+* Make sure that the `BonitaSubscription-x.y.z-tomcat.zip` file is located in your home folder (e.g. `/home/osuser`).
 If you type `cd ~ && ls` you should see the file listed.
-* Make sure the `unzip` command is installed: `sudo aptitude install unzip`
-* Unzip the deploy bundle: `unzip -q BonitaSubscription-x.y.z-deploy.zip`
-
-Finally, make sure that the user that runs the Tomcat server, is the owner of all Bonita "home" files:
+* Make sure the `unzip` command is installed: `sudo apt install unzip`
+* Unzip the Tomcat bundle: `unzip -q BonitaSubscription-x.y.z-tomcat.zip`
 
 * Change folders and files ownership: `sudo chown -R tomcat8:tomcat8 /opt/bonita`
 
@@ -152,7 +150,7 @@ Finally, make sure that the user that runs the Tomcat server, is the owner of al
 
 To define JVM system properties, you need to use a new file named `setenv.sh`:
 
-* Copy the file from deploy bundle to Tomcat `bin` folder: `sudo cp ~/BonitaSubscription-x.y.z-deploy/Tomcat-8.5.z/bin/setenv.sh /usr/share/tomcat8/bin/`, where "x.y.z" stands for your current product version.
+* Copy the file from Tomcat bundle to Tomcat installation `bin` folder: `sudo cp ~/BonitaSubscription-x.y.z-tomcat/server/bin/setenv.sh /usr/share/tomcat8/bin/`, where "x.y.z" stands for your current product version.
 * Make the file executable: `sudo chmod +x /usr/share/tomcat8/bin/setenv.sh`
 * Edit `setenv.sh` file: `sudo nano /usr/share/tomcat8/bin/setenv.sh`
 * Change `sysprop.bonita.db.vendor` from `h2` to `postgres`
@@ -172,15 +170,23 @@ You need to configure the data source for Bonita Engine.
 
 Warning: make sure you stop Tomcat before performing following operations: `sudo service tomcat8 stop`
 
-* Copy the `bonita.xml` file (Bonita web app context configuration): `sudo cp ~/BonitaSubscription-x.y.z-deploy/Tomcat-8.5.z/conf/Catalina/localhost/bonita.xml /etc/tomcat8/Catalina/localhost/`
-* Edit the `bonita.xml` file by commenting the h2 datasource configuration (using ),
-uncomment PostgreSQL example and update username, password and DB name (bonita in the URL property) to match your
+* Create new folders in order to store Arjuna configuration and work files: `sudo mkdir -p /opt/bonita/conf && sudo mkdir -p /opt/bonita/arjuna/tx-object-store`
+* Set the ownership of the Arjuna configuration folder: `sudo chown -R tomcat8:tomcat8 /opt/bonita/arjuna/tx-object-store`
+* Copy the Arjuna configuration files to `/opt/bonita/conf` folder: `sudo cp ~/BonitaSubscription-x.y.z-tomcat/server/conf/jbossts-properties.xml /opt/bonita/conf/`
+* Edit `jbossts-properties.xml` file, and update the `objectStoreDir` property to point to Arjuna work dir (created above) by replacing:  
+  `<entry key="com.arjuna.ats.arjuna.objectstore.objectStoreDir">${catalina.base}/work/bonita-tx-object-store</entry>`  
+  by  
+  `<entry key="com.arjuna.ats.arjuna.objectstore.objectStoreDir">/opt/bonita/arjuna/tx-object-store</entry>`
+* Save and quit: `CTRL+X, Y, ENTER`
+* Copy the `bonita.xml` file (Bonita web app context configuration): `sudo cp ~/BonitaSubscription-x.y.z-tomcat/server/conf/Catalina/localhost/bonita.xml /etc/tomcat8/Catalina/localhost/`
+* Edit the `bonita.xml` file by commenting the h2 datasource configuration and
+uncomment PostgreSQL example and update username, password and database name (bonita in the URL property) to match your
 configuration (e.g. `bonita_db_user`, `bonita_db_password` and `bonita_db`): `sudo nano /etc/tomcat8/Catalina/localhost/bonita.xml`
 * Also in `bonita.xml` file update data base configuration for BDM to match your configuration (e.g. `bonita_db_user`, `bonita_db_password` and `bonita_bdm`)
 * Save and quit: `CTRL+X, Y, ENTER`
-* Copy and overwrite `logging.properties` file: `sudo cp ~/BonitaSubscription-x.y.z-deploy/Tomcat-8.5.z/conf/logging.properties /etc/tomcat8/logging.properties`
-* Copy and overwrite `context.xml` file: `sudo cp ~/BonitaSubscription-x.y.z-deploy/Tomcat-8.5.z/conf/context.xml /etc/tomcat8/context.xml`
-* Copy and overwrite `server.xml` file: `sudo cp ~/BonitaSubscription-x.y.z-deploy/Tomcat-8.5.z/conf/server.xml /etc/tomcat8/server.xml`
+* Copy and overwrite `logging.properties` file: `sudo cp ~/BonitaSubscription-x.y.z-tomcat/server/conf/logging.properties /etc/tomcat8/logging.properties`
+* Copy and overwrite `context.xml` file: `sudo cp ~/BonitaSubscription-x.y.z-tomcat/server/conf/context.xml /etc/tomcat8/context.xml`
+* Copy and overwrite `server.xml` file: `sudo cp ~/BonitaSubscription-x.y.z-tomcat/server/conf/server.xml /etc/tomcat8/server.xml`
 * Edit `server.xml` (`sudo nano /etc/tomcat8/server.xml`) and comment out h2 listener line
 * Fix ownership on the copied files: `sudo chown -R root:tomcat8 /etc/tomcat8`
 
@@ -189,8 +195,8 @@ configuration (e.g. `bonita_db_user`, `bonita_db_password` and `bonita_db`): `su
 If you run the Subscription Pack version, you will need a license:
 
 * Generate the key in order to get a license:
-  * Change the current directory to license generation scripts folder: `cd ~/BonitaSubscription-x.y.z-deploy/request_key_utils-x.y-z`
-  * Make the license generation script executable: `chmod u+x generateRequestKey.sh`
+  * Change the current directory to license generation scripts folder: `cd ~/BonitaSubscription-x.y.z-tomcat/tools/request_key_utils-x.y-z`
+  * Make sure the license generation script is executable: `chmod u+x generateRequestKey.sh`
   * Run the script: `./generateRequestKey.sh`
   * For `License type:`
     * enter `1` to select `1 - Case counter license.` if your subscription is case-based.
@@ -201,14 +207,14 @@ If you run the Subscription Pack version, you will need a license:
 * Go to Licenses \> **Request a license**
 * Fill in the license request forms
 * You should receive the license file by email
-* Copy the license file to the Bonita "home" folder: `sudo cp BonitaSubscription-x.y-Your_Name-ServerName-YYYYMMDD-YYYYMMDD.lic /opt/bonita/bonita_home-x.y.z/server/licenses/`
+* Copy the license file to the Bonita license folder: `sudo cp BonitaSubscription-x.y-Your_Name-ServerName-YYYYMMDD-YYYYMMDD.lic /opt/bonita/<SETUP_TOOL_FOLDER>/platform_conf/licenses/`
 * Change folders and files ownership: `sudo chown -R tomcat8:tomcat8 /opt/bonita`
 
 ### Deployment
 
 Deploy the Bonita web application:
 
-Copy `bonita.war` to Tomcat `webapps` folder: `sudo cp ~/BonitaSubscription-x.y.z-deploy/Tomcat-8.5.z/webapps/bonita.war /var/lib/tomcat8/webapps/`
+Copy `bonita.war` to Tomcat `webapps` folder: `sudo cp ~/BonitaSubscription-x.y.z-tomcat/server/webapps/bonita.war /var/lib/tomcat8/webapps/`
 
 Take care to set the proper owner: `sudo chown tomcat8:tomcat8 /var/lib/tomcat8/webapps/bonita.war`
 

--- a/md/wildfly-bundle.md
+++ b/md/wildfly-bundle.md
@@ -42,10 +42,12 @@ The WildFly bundle is based on a standard WildFly installation with the followin
 * `server/bin/standalone.conf`: script to configure JVM system properties on Linux systems.
 * `server/bin/standalone.conf.bat`: script to configure JVM system properties on Windows systems.
 * `server/modules/system/layers/base/sun/jdk/main/module.xml`: list of base jdk module necessary for WildFly and Bonita to execute.
-* `server/request_key_utils`: script to generate license request keys (Subscription editions only).
 * `server/standalone/deployments/bonita-all-in-one-[version].ear`: Bonita Portal (web application) and EJB3 API.
 * `setup/`: a tool to manage Bonita Platform configuration, stored in database instead of filesystem. Also ships a tool to centralize all the required WildFly bundle configuration.
 * `setup/wildfly-templates/standalone.xml`: WildFly context configuration for Bonita Portal. It defines data sources used by Bonita Engine.
+* `tools/request_key_utils-`_`key_utils.version`_: folder containing the script to generate license request keys (Subscription editions only).
+* `tools/BonitaSubscription-x.y.z`-`LDAP-Synchronizer` : folder containing the tool to synchronize your organization in Bonita with your LDAP (Subscription editions only).
+* `tools/cas-`_`cas.version`_`-module`: folder containing module files and description to enable CAS dependency to bonita EAR (Subscription editions only).
 * `start-bonita.bat`: script to start the bundle on Windows.
 * `start-bonita.sh`: script to start the bundle on Linux.
 
@@ -63,7 +65,7 @@ If this is the first time you generate a license, you need to generate a request
 #### Generate the request key
 
 On the server where you installed Bonita Platform:
-1. Go to the request_key_utils folder
+1. Go to the `tools/request_key_utils` folder
 2. Run the `generateRequestKey.bat` script (for Windows) or the `generateRequestKey.sh` script (for Linux)
     
 #### Request the new license


### PR DESCRIPTION
* Add to the release note that we removed the deploy.zip in 7.9
* Rewrite the deploy-bundle page to use a bundle instead of the deploy.zip.
* Add to the release note that LDAP & CAS are now packaged in the bundles.
* Rewrite the cas page to remove mentions of the deploy.zip.
* Rewrite the LDAP synchronizer page to remove mentions of the deploy zip.

Closes [BR-115](https://bonitasoft.atlassian.net/browse/BR-115)
Relates to [BR-114](https://bonitasoft.atlassian.net/browse/BR-114)
Relates to [BR-113](https://bonitasoft.atlassian.net/browse/BR-113)