### PR TITLE
chore(links): fix all dead links in 7.8 doc

### DIFF
--- a/md/bonita-bpm-studio-preferences.md
+++ b/md/bonita-bpm-studio-preferences.md
@@ -51,7 +51,7 @@ Proxy
 Advanced
 * Rename diagram the first time it is saved.
 * Do not show confirmation on connector definition edition.
-* SVN connector: the SVN connector used if you are using a remote SVN ["repository](workspaces-and-projects.md). Note: if you change this your local working copy might become unstable. To avoid this, commit any outstanding changes before you modify the connector setting, and reinitialize your local working copy after the update  
+* SVN connector: the SVN connector used if you are using a remote SVN [repository](workspaces-and-repositories.md). Note: if you change this your local working copy might become unstable. To avoid this, commit any outstanding changes before you modify the connector setting, and reinitialize your local working copy after the update  
 
 Eclipse
    Give access to all Eclipse settings (Bonita Studio is based on Eclipse)  


### PR DESCRIPTION
I used the following command to detect dead links:
`cat *.md | grep "\.md" | sed -E 's@.*\[.*\]\(([-_a-zA-Z1-9]*\.md)(#.*)?\).*@\1@g' | sort | uniq | while read fn; do if [ ! -f "${fn}" ]; then printf "%s\n" "${fn}" ; fi; done | grep -v "^_"`