### PR TITLE
chore(links): fix all dead links in 7.9 doc

### DIFF
--- a/md/bonita-layout.md
+++ b/md/bonita-layout.md
@@ -12,7 +12,7 @@ For the mobile version there is only one row that has the name of the applicatio
 
 ## Customizing this layout
 
-You can customize this layout by following the [customize-resource-layouts](customize-resource-layouts.md) steps.
+You can customize this layout by following the [customize layouts](customize-layouts.md) steps.
 
 ## Adding a logo to the layout
 

--- a/md/profiles-overview.md
+++ b/md/profiles-overview.md
@@ -39,7 +39,7 @@ An employee mapped to the **Process manager** profile has limited administration
 
 ## Custom profiles
 
-In addition to the default profiles, users of Enterprise, Performance and Efficiency editions can create **[custom profiles]**(custom-profiles.md).
+In addition to the default profiles, users of Enterprise, Performance and Efficiency editions can create [custom profiles](custom-profiles.md).
 If a custom profile is created to give access to custom content in the portal, its _Portal menu_ (navigation structure and pages) must also be defined in the profile.
 To create a custom profile, map it to entities of the organization, and create its portal menu, use the [profile editor](profileCreation.md) in the studio. 
 In a production environment, an Administrator must use the **Organization**>**Profiles** menu.

--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -125,7 +125,7 @@ Bugs were fixed to increase stability of the integration with Quartz:
 * BS-19239 Exception during Quartz Job execution leaves the associated flownode in WAITING state and the process execution is stopped
 * BR-56 Failure in a cron timer cancels future executions
 A [new page](timers-execution.md) was added to explain how Timers are executed and how to handle time execution failures. 
-Also details were added on how to configure Quartz for timers execution: [quartz performance tunning](performance-tunning.md#cron)
+Also details were added on how to configure Quartz for timers execution: [quartz performance tuning](performance-tuning.md#cron)
 
 #### Cluster locks
 

--- a/md/technical-logging.md
+++ b/md/technical-logging.md
@@ -27,8 +27,7 @@ See the [service interface](https://github.com/bonitasoft/bonita-engine/blob/7.4
 
 The technical logger
 [implementation](https://github.com/bonitasoft/bonita-engine/blob/7.4.3/services/bonita-log/bonita-log-technical-slf4j/src/main/java/org/bonitasoft/engine/log/technical/TechnicalLoggerSLF4JImpl.java)
-uses SLF4J to handle the log. SLF4J itself uses a back-end logging framework to write log messages. See the [logging
-overview](logging.md) for more details.
+uses SLF4J to handle the log. SLF4J itself uses a back-end logging framework to write log messages. See the [logging overview](logging.md) for more details.
 
 Logged messages are passed to SLF4J with appropriate logger information so the source of the message remains meaningful.
 

--- a/md/timers-execution.md
+++ b/md/timers-execution.md
@@ -39,4 +39,4 @@ Once this method is called (at least once) the `FailedJob`s for this timer will 
 ## Tune performance of timers execution
 
 If you notice that timers are executed significantly after the date they should be executed, you might suffer Quartz performance issues.
-Check [this page](performance-tunning.md#cron) to fine tune Quartz performance.
+Check [this page](performance-tuning.md#cron) to fine tune Quartz performance.


### PR DESCRIPTION
I used the following command to detect dead links:
`cat *.md | grep "\.md" | sed -E 's@.*\[.*\]\(([-_a-zA-Z1-9]*\.md)(#.*)?\).*@\1@g' | sort | uniq | while read fn; do if [ ! -f "${fn}" ]; then printf "%s\n" "${fn}" ; fi; done | grep -v "^_"`