### PR TITLE
feat(ssl): use TLS v1.2

### DIFF
--- a/md/ssl.md
+++ b/md/ssl.md
@@ -49,7 +49,7 @@ SSLCertificateFile="$ {catalina.base}/conf/ssl/test.bonitasoft.net.pem"
 SSLCertificateKeyFile="${catalina.base}
 /conf/ssl/test.bonitasoft.net.key"
 SSLVerifyClient="optional" 
-SSLProtocol="TLSv1"></Connector>
+SSLProtocol="TLSv1.2"></Connector>
 ```
 5. Install the Tomcat native library, which contains APR: `sudo apt-get install libtcnative-1`
 6. Edit `TOMCAT_HOME/webapps/bonita/WEB-INF/web.xml` and add the following security definition:
@@ -90,7 +90,7 @@ URIEncoding="UTF-8"
 keystoreFile="$ {catalina.base}/conf/ssl/keystore" 
 keystorePass="password!"
 SSLVerifyClient="optional" 
-SSLProtocol="TLSv1"></Connector>
+SSLProtocol="TLSv1.2"></Connector>
 ```
 4. Edit `TOMCAT_HOME/webapps/bonita/WEB-INF/web.xml` and add the following security definition:
 ```xml


### PR DESCRIPTION
TLS v1 as shown in example is deprecated (see https://www.chromestatus.com/feature/5654791610957824)
TLS v1.3 is not yet supported without activating specific options in browsers

TLS v1.2 has been tested on a regular Bonita tomcat bundle with chrome and firefox