### PR TITLE
fix(requirements): specific supported OS versions

### DIFF
--- a/md/hardware-and-software-requirements.md
+++ b/md/hardware-and-software-requirements.md
@@ -21,8 +21,8 @@ Software required for Bonita Platform (Bonita Engine and Bonita Portal).
 | :--------------------------------- | ------------------------------------------------ |
 | **Operating system**               |
 | Microsoft Windows Server           | 2016 64 bits                                     |
-| Red Hat Enterprise Linux           | 6.5 64 bits and higher                           |
-| Ubuntu                             | 16.04 LTS 64 bits and higher                     |
+| Red Hat Enterprise Linux           | 6.5 64 bits                                      |
+| Ubuntu                             | 16.04 LTS 64 bits                                |
 | **Java Virtual Machine**           |
 | Oracle Java SE Runtime Environment | 8 (see note 1)                                   |
 | OpenJDK                            | 8 (see note 1)                                   |

--- a/md/hardware-and-software-requirements.md
+++ b/md/hardware-and-software-requirements.md
@@ -20,7 +20,7 @@ Software required for Bonita Platform (Bonita Engine and Bonita Portal).
 |                                    | Version                                          |
 | :--------------------------------- | ------------------------------------------------ |
 | **Operating system**               |
-| Microsoft Windows Server           | 2016 64 bits and higher                          |
+| Microsoft Windows Server           | 2016 64 bits                                     |
 | Red Hat Enterprise Linux           | 6.5 64 bits and higher                           |
 | Ubuntu                             | 16.04 LTS 64 bits and higher                     |
 | **Java Virtual Machine**           |


### PR DESCRIPTION
Describe the only tested and supported versions. Bonita could eventually work with newer versions
but we cannot commit ourselves on it.
This removal is also done to avoid misunderstanding with end users.

For instance, Bonita 7.6 has been released on December 2017 and Windows Server 2019 on November 2018: at the Bonita release time, we didn't know that Bonita would work with this unreleased Windows version.