### PR TITLE
fat(http): add info on http client connections

### DIFF
--- a/md/configure-client-of-bonita-bpm-engine.md
+++ b/md/configure-client-of-bonita-bpm-engine.md
@@ -37,7 +37,7 @@ You can set the system property `org.bonitasoft.engine.api-type` to `HTTP`, `EJB
    * `org.bonitasoft.engine.api-type.server.url`: it is the url of the server, e.g. for a engine on the same host it can be `http://localhost:8080`
    * `org.bonitasoft.engine.api-type.application.name`: it is the name of the web aplication on wich the engine HTTP API is deployed, e.g. `bonita`
 
-  In addition the number of connections used by the client can be configured with system property `org.bonitasoft.engine.api-type.connections.max`, the default is 20.
+  In addition, starting from version 7.9.4, the number of connections used by the client can be configured with system property `org.bonitasoft.engine.api-type.connections.max`, the default is 20.
 
 ::: warning
 We do not guarantee to keep the http protocol stable, so we strongly recommend that you use the same version for both

--- a/md/configure-client-of-bonita-bpm-engine.md
+++ b/md/configure-client-of-bonita-bpm-engine.md
@@ -37,6 +37,8 @@ You can set the system property `org.bonitasoft.engine.api-type` to `HTTP`, `EJB
    * `org.bonitasoft.engine.api-type.server.url`: it is the url of the server, e.g. for a engine on the same host it can be `http://localhost:8080`
    * `org.bonitasoft.engine.api-type.application.name`: it is the name of the web aplication on wich the engine HTTP API is deployed, e.g. `bonita`
 
+  In addition the number of connections used by the client can be configured with system property `org.bonitasoft.engine.api-type.connections.max`, the default is 20.
+
 ::: warning
 We do not guarantee to keep the http protocol stable, so we strongly recommend that you use the same version for both
 the client and the server
@@ -73,6 +75,7 @@ org.bonitasoft.engine.api-type = LOCAL
 #org.bonitasoft.engine.api-type = HTTP
 #server.url = http://localhost:8080
 #application.name = bonita
+#connections.max = 20
 
 # Remote: EJB3
 #org.bonitasoft.engine.api-type = EJB3

--- a/md/performance-tuning.md
+++ b/md/performance-tuning.md
@@ -105,9 +105,7 @@ This mode
 The bonita-client library
   * sends data over the network using the HTTP protocol using the [Apache HttpComponents](http://hc.apache.org/index.html).
 open source library
-  * uses `org.apache.http.impl.conn.PoolingClientConnectionManager` as connection manager .  Currently, there is no
-  configuration for this pool though this might be added in the future.  See the [HttpComponents documentation](http://hc.apache.org/httpcomponents-client-ga/tutorial/html/connmgmt.html)
-  for more information.
+  * uses a maximum of 20 connections. To change this value refer to the page [Configure connection to Bonita Engine](configure-client-of-bonita-bpm-engine.md).
 
 Data sent is serialized using a Java library called XStream. This serialization also has a cost.
 

--- a/md/two-main-types-of-deployment.md
+++ b/md/two-main-types-of-deployment.md
@@ -93,7 +93,7 @@ We suggest to define a `ENGINE_OPTS` variable and add its content to the `CATALI
 On Linux (setenv.sh)
 ```
 ENGINE_OPTS="-Dorg.bonitasoft.engine.api-type=HTTP -Dorg.bonitasoft.engine.api-type.server.url=http://localhost:8080"
-ENGINE_OPTS="${ENGINE_OPTS} -Dorg.bonitasoft.engine.api-type.application.name=bonita"
+ENGINE_OPTS="${ENGINE_OPTS} -Dorg.bonitasoft.engine.api-type.application.name=bonita -Dorg.bonitasoft.engine.api-type.connections.max=20"
 ENGINE_OPTS="${ENGINE_OPTS} -Dorg.bonitasoft.platform.username=platformAdmin -Dorg.bonitasoft.platform.password=platform"
 
 CATALINA_OPTS="${CATALINA_OPTS} ${ENGINE_OPTS} ${PLATFORM_SETUP} ..."
@@ -103,7 +103,7 @@ export CATALINA_OPTS
 On Windows (setenv.bat)
 ```
 set ENGINE_OPTS="-Dorg.bonitasoft.engine.api-type=HTTP" "-Dorg.bonitasoft.engine.api-type.server.url=http://localhost:8080"
-set ENGINE_OPTS=%ENGINE_OPTS% "-Dorg.bonitasoft.engine.api-type.application.name=bonita"
+set ENGINE_OPTS=%ENGINE_OPTS% "-Dorg.bonitasoft.engine.api-type.application.name=bonita -Dorg.bonitasoft.engine.api-type.connections.max=20"
 set ENGINE_OPTS=%ENGINE_OPTS% "-Dorg.bonitasoft.platform.username=platformAdmin" "-Dorg.bonitasoft.platform.password=platform"
 
 set CATALINA_OPTS=%CATALINA_OPTS% %ENGINE_OPTS% %PLATFORM_SETUP% ...
@@ -160,6 +160,7 @@ Configure the Engine Client
         <property name="org.bonitasoft.engine.api-type" value="HTTP" />
         <property name="org.bonitasoft.engine.api-type.server.url" value="http://localhost:8080" />
         <property name="org.bonitasoft.engine.api-type.application.name" value="bonita" />
+        <property name="org.bonitasoft.engine.api-type.connections.max" value="20" />
         <property name="org.bonitasoft.platform.username" value="platformAdmin" />
         <property name="org.bonitasoft.platform.password" value="platform" />
     </system-properties>


### PR DESCRIPTION
The java client in http mode has now a configurable maximum number of
connections. Add that to the documentation

Relates to [BS-19395](https://bonitasoft.atlassian.net/browse/BS-19395)