### PR TITLE
update BCD version link

### DIFF
--- a/md/automating-builds.md
+++ b/md/automating-builds.md
@@ -6,7 +6,7 @@
 
 ::: warning
 **Warning:**
-* The solution described here relies on the `Workspace API`/`BonitaStudioBuilder`, which has been deprecated since Bonita 7.7.0. Instead, we strongly encourage you to use the LA builder included in the tooling suite of [*Bonita Continuous Delivery* add-on](https://documentation.bonitasoft.com/bcd/2.0/) add-on. One added-value is that LA builder does not need a studio to be installed.
+* The solution described here relies on the `Workspace API`/`BonitaStudioBuilder`, which has been deprecated since Bonita 7.7.0. Instead, we strongly encourage you to use the LA builder included in the tooling suite of [*Bonita Continuous Delivery* add-on](https://documentation.bonitasoft.com/bcd/3.1/) add-on. One added-value is that LA builder does not need a studio to be installed.
 :::
 
 ## Overview


### PR DESCRIPTION
If we are in the Bonita 7.9 doc and we have a link to the BCD, it should refer to 3.1 and not to 2.0 version of BCD
Applies to 7.9