### PR TITLE
feat(JDK) update macos Studio prerequisite

### DIFF
--- a/md/bonita-bpm-studio-installation.md
+++ b/md/bonita-bpm-studio-installation.md
@@ -18,7 +18,7 @@ Both Windows and Mac have default security settings that will prevent execution 
 
 **Note for users of macOS 10.12.x and above** : There is an known issue on macOS Sierra and Java about the slowness of   java.net.InetAddress getLocalHost() which results in a slowness of the Bonita Studio (find more info on [thoeni](https://thoeni.io/post/macos-sierra-java/) or [plumbr](https://plumbr.eu/blog/java/macos-sierra-problems-with-java-net-inetaddress-getlocalhost)). To resolve this issue you shoud add your computer name to your /etc/hosts file : In a terminal, edit your `/etc/hosts` with sudo privilege, add your computer name to the local IP addresses `127.0.0.1 localhost <mycomputername.local>` and `::1 localhost <mycomputername.local>` (To find your macOS computer name, look at [Apple support dedicated page](https://support.apple.com/kb/PH25076)).
 
-**Note for users of macOs Catalina 10.15 and above**: Since Catalina 10.15, only **installed JDK** are accepted by the macOs _gatekeeper_.  
+**Note for users of macOS Catalina 10.15 and above**: Since Catalina 10.15, only **installed JDK** are accepted by the macOS _gatekeeper_.  
 If you try to use a JDK directly downloaded, you will get this kind of error: _jdk-11.0.5 can’t be opened because it is from an unidentified developer._  
 The solution is to use an installer to install properly the JDK. The easiest way is to tape the following commands:  
 ```

--- a/md/bonita-bpm-studio-installation.md
+++ b/md/bonita-bpm-studio-installation.md
@@ -18,8 +18,14 @@ Both Windows and Mac have default security settings that will prevent execution 
 
 **Note for users of macOS 10.12.x and above** : There is an known issue on macOS Sierra and Java about the slowness of   java.net.InetAddress getLocalHost() which results in a slowness of the Bonita Studio (find more info on [thoeni](https://thoeni.io/post/macos-sierra-java/) or [plumbr](https://plumbr.eu/blog/java/macos-sierra-problems-with-java-net-inetaddress-getlocalhost)). To resolve this issue you shoud add your computer name to your /etc/hosts file : In a terminal, edit your `/etc/hosts` with sudo privilege, add your computer name to the local IP addresses `127.0.0.1 localhost <mycomputername.local>` and `::1 localhost <mycomputername.local>` (To find your macOS computer name, look at [Apple support dedicated page](https://support.apple.com/kb/PH25076)).
 
-**Note for users of OS X 10.7.5 and above**: a new security feature called **Gatekeeper** prevents the installation of software that is not officially recognized by Apple.  
-For more information and details of how to install Bonita Studio on a system running Gatekeeper, see the [Apple support site](https://support.apple.com/en-us/HT202491).
+**Note for users of macOs Catalina 10.15 and above**: Since Catalina 10.15, only **installed JDK** are accepted by the macOs _gatekeeper_.  
+If you try to use a JDK directly downloaded, you will get this kind of error: _jdk-11.0.5 can’t be opened because it is from an unidentified developer._  
+The solution is to use an installer to install properly the JDK. The easiest way is to tape the following commands:  
+```
+brew tap homebrew/cask-versions
+brew cask install java11
+```  
+An other solution is to download and execute manually the installer, [here for example](https://adoptopenjdk.net/index.html). 
 
 **Not for users of Windows 10**: the security feature called **SmartScreen** prevents execution of Bonita Studio installer.  When you get the "Windows protect your PC" pop up window, click on "More info" link and click on "Run anyway" button.
 

--- a/md/bonita-bpm-studio-installation.md
+++ b/md/bonita-bpm-studio-installation.md
@@ -1,3 +1,4 @@
+
 # Bonita Studio installation
 
 How to install a Bonita Studio on Windows, Linux, or Mac operating systems. An OS-independent archive can also be used.
@@ -21,7 +22,11 @@ Both Windows and Mac have default security settings that will prevent execution 
 **Note for users of macOS Catalina 10.15 and above**: Since Catalina 10.15, only **installed JDK** are accepted by the macOS _gatekeeper_.  
 If you try to use a JDK directly downloaded, you will get this kind of error: _jdk-11.0.5 can’t be opened because it is from an unidentified developer._  
 The solution is to use an installer to install properly the JDK. The easiest way is to tape the following commands:  
-```
+``` bash
+# Install brew first if it is not installed yet, more details here: [https://brew.sh/index_fr](https://brew.sh/index_fr) 
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+# Use brew to install a JDK
 brew tap homebrew/cask-versions
 brew cask install java11
 ```  

--- a/md/bonita-bpm-studio-installation.md
+++ b/md/bonita-bpm-studio-installation.md
@@ -23,7 +23,7 @@ Both Windows and Mac have default security settings that will prevent execution 
 If you try to use a JDK directly downloaded, you will get this kind of error: _jdk-11.0.5 can’t be opened because it is from an unidentified developer._  
 The solution is to use an installer to install properly the JDK. The easiest way is to tape the following commands:  
 ``` bash
-# Install brew first if it is not installed yet, more details here: [https://brew.sh/index_fr](https://brew.sh/index_fr) 
+# Install brew first if it is not installed yet, more details here: https://brew.sh
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
 # Use brew to install a JDK


### PR DESCRIPTION
* Since macOs catalina 10.15, users must use an installed JDk,
downloaded jdk are not accepted anymore by the macos gatekeeper.

[BST-689](https://bonitasoft.atlassian.net/browse/BST-689)