### PR TITLE
doc(build community): remove prerequisites

### DIFF
--- a/md/building-community-edition-from-source.md
+++ b/md/building-community-edition-from-source.md
@@ -6,16 +6,6 @@ All source code of Bonita is available from the [Bonitasoft GitHub organization]
 a dedicated repository (e.g. [Engine repository](https://github.com/bonitasoft/bonita-engine)).
 
 
-# Prerequisites
-
-To build Bonita, you need the following:
-
-* Internet connection
-* Git
-* JDK 1.8
-* Apache Maven 3.5.x
-
-
 # Building Bonita
 
 ## Manual Bonita build


### PR DESCRIPTION
Prerequisites are documented in the GitHub repositories of all Bonita components and in the 'Build Bonita' repository.
So removing them from this page to reduce maintenance effort and out of date documentation