### PR TITLE
fix(bundle): path to request_key_utils

### DIFF
--- a/md/tomcat-bundle.md
+++ b/md/tomcat-bundle.md
@@ -47,7 +47,7 @@ The Tomcat bundle is based on a standard Tomcat installation with the following 
 * `server/lib/bonita`: extra libraries needed by Bonita. The following libraries are included: Narayana JTA Transaction Manager, h2, SLF4J.
 * `server/webapps/bonita.war`: the Bonita web application.
 * `setup/`: a tool to manage Bonita Platform configuration, stored in database instead of filesystem. Also ships a tool to centralize all the required Tomcat bundle configuration.
-* `tools/request_key_utils-`_`key_utils.version`_: folder containing the script to generate license request keys (Subscription editions only).
+* `tools/request_key_utils: folder containing the script to generate license request keys (Subscription editions only).
 * `tools/BonitaSubscription-x.y.z`-`LDAP-Synchronizer` : folder containing the tool to synchronize your organization in Bonita with your LDAP (Subscription editions only).
 * `tools/cas-`_`cas.version`_`-module`: folder containing module files and description to enable CAS dependency to bonita EAR (Subscription editions only).
 * `start-bonita.bat`: script to start the bundle on Windows.

--- a/md/wildfly-bundle.md
+++ b/md/wildfly-bundle.md
@@ -45,7 +45,7 @@ The WildFly bundle is based on a standard WildFly installation with the followin
 * `server/standalone/deployments/bonita-all-in-one-[version].ear`: Bonita Portal (web application) and EJB3 API.
 * `setup/`: a tool to manage Bonita Platform configuration, stored in database instead of filesystem. Also ships a tool to centralize all the required WildFly bundle configuration.
 * `setup/wildfly-templates/standalone.xml`: WildFly context configuration for Bonita Portal. It defines data sources used by Bonita Engine.
-* `tools/request_key_utils-`_`key_utils.version`_: folder containing the script to generate license request keys (Subscription editions only).
+* `tools/request_key_utils: folder containing the script to generate license request keys (Subscription editions only).
 * `tools/BonitaSubscription-x.y.z`-`LDAP-Synchronizer` : folder containing the tool to synchronize your organization in Bonita with your LDAP (Subscription editions only).
 * `tools/cas-`_`cas.version`_`-module`: folder containing module files and description to enable CAS dependency to bonita EAR (Subscription editions only).
 * `start-bonita.bat`: script to start the bundle on Windows.


### PR DESCRIPTION
The tool version has been removed from the path in GA but the doc still mention it