### PR TITLE
doc (wildfly): Fix typos remove useless instr

### DIFF
--- a/md/convert-wildfly-into-tomcat.md
+++ b/md/convert-wildfly-into-tomcat.md
@@ -4,7 +4,7 @@ Learn how to convert a Bonita installation based on WildFly to a one based on To
 
 ## Overview
 
-Bonita 7.10 does not provide nor support any WildFly anymore. As a consequence, it is necessary when updating
+Bonita 7.10 does not provide nor support WildFly anymore. As a consequence, it is necessary when updating
 Bonita to version 7.10 or superior to convert the installation so that it works the same way under tomcat.
 
 ## Conversion steps to Bonita Tomcat bundle

--- a/md/convert-wildfly-into-tomcat.md
+++ b/md/convert-wildfly-into-tomcat.md
@@ -4,22 +4,21 @@ Learn how to convert a Bonita installation based on WildFly to a one based on To
 
 ## Overview
 
-Bonita 7.10 does not provide nor support any WildFly bundle anymore. As a consequence, it is necessary when updating
+Bonita 7.10 does not provide nor support any WildFly anymore. As a consequence, it is necessary when updating
 Bonita to version 7.10 or superior to convert the installation so that it works the same way under tomcat.
 
-## Conversion steps
+## Conversion steps to Bonita Tomcat bundle
 * unzip the last Bonita Tomcat bundle 7.10+
 * configure `setup/database.properties` to point to the same database server as WildFly did (it should be the exact same `database.properties` file)
 * run `setup/setup.sh pull` to retrieve the current configuration from database
 * update your license file by putting the new one into `setup/platform_conf/licenses` (and by removing any old license file)
 * run `setup/setup.sh push` to update the new license file (and optional changed configuration) to the database
 * start your new Bonita Tomcat bundle with `./start-bonita.sh`
-* (delete your old WildFly installation by removing the Bonita WildFly root folder)
 
 ## Specific configuration
 If you are using specific configuration that you set up in file `wildfly/server/standalone/configuration/standalone.xml`,
-report you equivalent configuration into Tomcat.  
-For instance, if you use Bonita datasource connector, and your configured it to access to a datasource defined in WildFly
-`standalon.xml` file, report your datasource configuration in Tomcat file `server/conf/Catalina/localhost/bonita.xml`.  
+report your equivalent configuration into Tomcat.  
+For instance, if you use Bonita datasource connector, and you configured it to access to a datasource defined in WildFly
+`standalone.xml` file, report your datasource configuration in Tomcat file `server/conf/Catalina/localhost/bonita.xml`.  
 Be aware that the JNDI name of the datasource does not have the same prefix: `java:jboss/datasources/` from WildFly,
 for `java:comp/env/` Tomcat.


### PR DESCRIPTION
I don't think that the following step is necessary, especially if the user aren't using the bonita bundle. Unless it actually breaks the tomcat install? Deleting the old wildfly isn't a useful step to mention IMO: 
* (delete your old WildFly installation by removing the Bonita WildFly root folder)
We don't support wildFly, period, we don't need to say Wildfly bundle. 
+ Fix several typos.