### PR TITLE
fix(LDAP authentication): add warning for userProvider syntax

### DIFF
--- a/md/active-directory-or-ldap-authentication.md
+++ b/md/active-directory-or-ldap-authentication.md
@@ -56,11 +56,13 @@ Based on the information described in the "Before you start" section, you can id
 
 #### Values for LdapLoginModule attributes
 
-In this section we explain how to set `LdapLoginModule` attributes values.
+In this section we explain how to set `LdapLoginModule` attributes values. (For further information, check the [`LdapLoginModule` javadoc](https://docs.oracle.com/javase/8/docs/jre/api/security/jaas/spec/com/sun/security/auth/module/LdapLoginModule.html) page.)
 
 **`userProvider`**: set this to `ldap://<ldap server address>:<ldap server port>/<DN of the LDAP entry under which all users are located>`.
-
-For example: `ldap://localhost:389/CN=Users,DC=MyDomain,DC=com`
+::: warning
+**Warning:** Spaces in the distinguished name (DN) component of the URL must be escaped using the standard mechanism of percent character ('%') followed by two hexadecimal digits: replace them with '%20'. Query components must also be omitted from the URL.
+:::
+For example, if your users are under `CN=Bonita Users,DC=MyDomain,DC=com`: `ldap://localhost:389/CN=Bonita%20Users,DC=MyDomain,DC=com`
 
 **`userFilter`** (only if needed): the value must be a search request that will find your users in the LDAP server. The search request can be for example: `(&(objectClass=user)(userPrincipalName={USERNAME}@mydomain.com))`.
 Use an LDAP tool (such as Apache Directory Studio) to validate that the request returns the expected result if you replace {USERNAME} with an actual username.


### PR DESCRIPTION
Versions: 7.7, 7.8, 7.9, 7.10

Add link to LdapLoginModule javadoc + add warning for userProvider parameter when the DN contains whitespaces.

