### PR TITLE
fix(oracle-drivers) Explicit drivers version

### DIFF
--- a/md/migrate-from-an-earlier-version-of-bonita-bpm.md
+++ b/md/migrate-from-an-earlier-version-of-bonita-bpm.md
@@ -37,6 +37,7 @@ The version targeted may not support the version of the database that is being m
 * If you need to upgrade your database:
    * Please make sure to apply all the [RDBMS customisations required by Bonita](database-configuration.md#specific_database_configuration) when setting up the new version.
    * Please make sure to use the [appropriate JDBC driver](database-configuration.md#proprietary_jdbc_drivers)
+   * Warning: **Oracle database** requires to use the official driver for each specific version. Make sure your driver's checksum matches the Oracle official one for your [database version](database-configuration.md#proprietary_jdbc_drivers) 
 :::
 
 **Community/Subscription edition:**
@@ -134,7 +135,7 @@ or from the [Customer Portal](https://customer.bonitasoft.com/download/request) 
 1. Check your current RDBMS version is compliant with the versions supported by the target version of Bonita (see [above](#rdbms_requirements))
 1. Unzip the migration tool zip file into a directory. In the steps below, this directory is called `bonita-migration`.
 1. If you use Oracle or Microsoft SQL Server, add the JDBC driver for your database type to `bonita-migration/lib`. This is the same driver as you have installed in
-your web server `lib` directory.
+your web server `lib` directory. **Warning**: For Oracle, make sure you double check that you use the official driver version that match your Database version. The correct driver is mandatory for a smooth migration: [Follow instructions for Oracle driver download.](database-configuration.md#proprietary_jdbc_drivers)
 1. Configure the database properties needed by the migration script, by editing `bonita-migration/Config.properties`.
 Specify the following information:
 


### PR DESCRIPTION
- Extra warning for oracle drivers version in RDBMS requirements
- Adding a warning for oracle driver in lib folder

Versions: 7.6, 7.7, 7.8, 7.9, 7.10