### PR TITLE
fix(Custom Deployment): add warning about tomcat libraries

### DIFF
--- a/md/custom-deployment.md
+++ b/md/custom-deployment.md
@@ -34,7 +34,7 @@ Copy, from the bundle into your Tomcat server:
 :::warning
 Some of the libraries copied from the bundle `server/lib/bonita` may already exist (albeit in a different version) in your Tomcat server `lib` folder. e.g.:
 * bundle (Tomcat 8.5.40): `server/lib/bonita/tomcat-dbcp-9.0.16.jar`
-* Tomcat server (Tomcat 8.0.36): `lib/tomcat-dbcp-8.0.36.jar` and `lib/tomcat-dbcp.jar`
+* Tomcat server (Tomcat 8.0.36): `lib/tomcat-dbcp-8.0.36.jar` and `lib/tomcat-dbcp.jar`  
 For such libraries, you should only keep the ones copied from the bundle under `lib/bonita`, or else the Bonita server may encounter `NoSuchMethodError`-type of issues.
 :::
 :::warning

--- a/md/custom-deployment.md
+++ b/md/custom-deployment.md
@@ -32,6 +32,12 @@ Copy, from the bundle into your Tomcat server:
 * The entirety of the `tools/request_key_utils-`. Includes script files to generate license request keys.
 
 :::warning
+Some of the libraries copied from the bundle `server/lib/bonita` may already exist (albeit in a different version) in your Tomcat server `lib` folder. e.g.:
+* bundle (Tomcat 8.5.40): `server/lib/bonita/tomcat-dbcp-9.0.16.jar`
+* Tomcat server (Tomcat 8.0.36): `lib/tomcat-dbcp-8.0.36.jar` and `lib/tomcat-dbcp.jar`
+For such libraries, you should only keep the ones copied from the bundle under `lib/bonita`, or else the Bonita server may encounter `NoSuchMethodError`-type of issues.
+:::
+:::warning
 Some configuration files from the bundle will overwrite some default tomcat configuration files. Proceed
 with care in a tomcat where other applications are already installed.
 :::

--- a/md/custom-deployment.md
+++ b/md/custom-deployment.md
@@ -33,8 +33,10 @@ Copy, from the bundle into your Tomcat server:
 
 :::warning
 Some of the libraries copied from the bundle `server/lib/bonita` may already exist (albeit in a different version) in your Tomcat server `lib` folder. e.g.:
+
 * bundle (Tomcat 8.5.40): `server/lib/bonita/tomcat-dbcp-9.0.16.jar`
-* Tomcat server (Tomcat 8.0.36): `lib/tomcat-dbcp-8.0.36.jar` and `lib/tomcat-dbcp.jar`  
+* Tomcat server (Tomcat 8.0.36): `lib/tomcat-dbcp-8.0.36.jar` and `lib/tomcat-dbcp.jar`
+
 For such libraries, you should only keep the ones copied from the bundle under `lib/bonita`, or else the Bonita server may encounter `NoSuchMethodError`-type of issues.
 :::
 :::warning


### PR DESCRIPTION
Versions: 7.9, 7.10

Add a warning about the fact that there may be a discrepancy between the tomcat libraries copied from the bundle's lib/bonita and the target Tomcat's lib.
