### PR TITLE
doc(login) redirect parameter is now optional in 7.12

### DIFF
--- a/md/multi-tenancy-and-tenant-configuration.md
+++ b/md/multi-tenancy-and-tenant-configuration.md
@@ -78,7 +78,7 @@ NOTE: this is to be done only once.
 
     $ curl -v -c saved_cookies.txt -X POST --url 'http://localhost:8080/bonita/platformloginservice' \
     --header 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
-    -d 'password=platform&redirect=false&username=platformAdmin' -O /dev/null
+    -d 'username=platformAdmin&password=platform' -O /dev/null
 
 The response to this REST API call (HTTP) generates 2 cookies, which must be transfered with each subsequent calls.
 One of the cookie is `X-Bonita-API-Token`.
@@ -137,7 +137,7 @@ The new tenant has the id `101` and its state is `DEACTIVATED`
 
 ##### Logout
 
-    $ curl -v -b saved_cookies.txt -X GET --url 'http://localhost:8080/bonita/platformlogoutservice?redirect=false'
+    $ curl -v -b saved_cookies.txt -X GET --url 'http://localhost:8080/bonita/platformlogoutservice'
 
 ### Java PlatformAPI
 This solution can be used when the portal is not needed.

--- a/md/platform-api.md
+++ b/md/platform-api.md
@@ -17,7 +17,6 @@ In order to get one, log in as the platform administrator using the platform log
 ```
 username=platformAdmin
 password=platform
-redirect=false
 ```
 
 In order to logout use the platform logout service as follow:

--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -37,10 +37,11 @@ It is now possible to create REST API Extensions in Java.
 
 #### REST API and portal login
 
-The redirect parameter is now optional when login in to the REST API using `/bonita/loginservice`
-This means it is no longer needed to put redirect=false in the request to log in using the API.
+The redirect parameter is now optional when logging in to the REST API using `/bonita/loginservice` as well as when logging out using `/bonita/logoutservice`
+This means it is no longer needed to put redirect=false in the request to log in/out using the API.
 However, previous login requests with a redirect URL will continue working as the redirect parameter is optional.  
-If you use a customised login page to log in to Bonita portal UI and don't specify any redirect URL (redirectURL parameter), then you need to make sure it passes a parameter redirect=true to the login service.
+If you use a customised login page to log in to Bonita portal UI and don't specify any redirect URL (`redirectUrl` parameter), then you need to make sure it passes a parameter `redirect=true` to the login service. same thing if you have a logout link in a custom page that does not passes a `loginUrl` or a `redirectUrl` parameter.  
+If you use Bonita layout version 5 or a customize version of it in your applications, make sure you upgrate to version 6 when migrating. Otherwisthe the logout button will not redirect to the login page when clicked.
 
 ## Bundle changes
 

--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -37,7 +37,7 @@ It is now possible to create REST API Extensions in Java.
 
 #### REST API and portal login
 
-The redirect parameter is now optional when logging in to the REST API using `/bonita/loginservice` as well as when logging out using `/bonita/logoutservice`
+The redirect parameter is now optional when logging in to the REST API using `/bonita/loginservice` as well as when logging out using `/bonita/logoutservice`.  
 This means it is no longer needed to put redirect=false in the request to log in/out using the API.
 However, previous login requests with a redirect URL will continue working as the redirect parameter is optional.  
 If you use a customised login page to log in to Bonita portal UI and don't specify any redirect URL (`redirectUrl` parameter), then you need to make sure it passes a parameter `redirect=true` to the login service. same thing if you have a logout link in a custom page that does not passes a `loginUrl` or a `redirectUrl` parameter.  

--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -35,6 +35,13 @@ It is now possible to create REST API Extensions in Java.
 
 ### Runtime changes
 
+#### REST API and portal login
+
+The redirect parameter is now optional when login in to the REST API using `/bonita/loginservice`
+This means it is no longer needed to put redirect=false in the request to log in using the API.
+However, previous login requests with a redirect URL will continue working as the redirect parameter is optional.  
+If you use a customised login page to log in to Bonita portal UI and don't specify any redirect URL (redirectURL parameter), then you need to make sure it passes a parameter redirect=true to the login service.
+
 ## Bundle changes
 
 ## API Removal

--- a/md/rest-api-authentication.md
+++ b/md/rest-api-authentication.md
@@ -9,7 +9,7 @@ To log in, use the following request:
 | Request URL | `http://host:port/bonita/loginservice`|
 | Request Method | POST|
 | Content-Type | application/x-www-form-urlencoded|
-| Form Data | username: a username<br/>password: a password <br/>redirect: `true` or `false`. `false` is the default value if the redirect parameter is not specified. It indicates that the service should not redirect to Bonita Portal (after a successful login) or to the login page (after a login failure).<br/>redirectURL: the URL of the page to be displayed after a succesful login. If it is specified, then the a redirection after the login will be performed even if the redircet parameter is not present in the request.<br/>tenant: the tenant to log in to (optional for Performance edition, not supported for Community, Teamwork and Efficiency editions)|
+| Form Data | username: a username<br/>password: a password <br/>redirect: `true` or `false`. `false` is the default value if the redirect parameter is not specified. It indicates that the service should not redirect to Bonita Portal (after a successful login) or to the login page (after a login failure).<br/>redirectUrl: the URL of the page to be displayed after a succesful login. If it is specified, then the a redirection after the login will be performed even if the redircet parameter is not present in the request.<br/>tenant: the tenant to log in to (optional for Performance edition, not supported for Community, Teamwork and Efficiency editions)|
 
 The response to this call generates cookies.
 The `JSESSIONID` must be transfered with each subsequent calls. If the REST API is used in an application running in a web browser, this is handled automatically by the web browser.

--- a/md/rest-api-authentication.md
+++ b/md/rest-api-authentication.md
@@ -9,7 +9,7 @@ To log in, use the following request:
 | Request URL | `http://host:port/bonita/loginservice`|
 | Request Method | POST|
 | Content-Type | application/x-www-form-urlencoded|
-| Form Data | username: a username<br/>password: a password <br/>redirect: true or false. false indicates that the service should not redirect to Bonita Portal (after a successful login) or to the login page (after a login failure).<br/>redirectURL: the URL of the page to be displayed after login <br/>tenant: the tenant to log in to (optional for Performance edition, not supported for Community, Teamwork and Efficiency editions)|
+| Form Data | username: a username<br/>password: a password <br/>redirect: `true` or `false`. `false` is the default value if the redirect parameter is not specified. It indicates that the service should not redirect to Bonita Portal (after a successful login) or to the login page (after a login failure).<br/>redirectURL: the URL of the page to be displayed after a succesful login. If it is specified, then the a redirection after the login will be performed even if the redircet parameter is not present in the request.<br/>tenant: the tenant to log in to (optional for Performance edition, not supported for Community, Teamwork and Efficiency editions)|
 
 The response to this call generates cookies.
 The `JSESSIONID` must be transfered with each subsequent calls. If the REST API is used in an application running in a web browser, this is handled automatically by the web browser.
@@ -27,7 +27,7 @@ This security relies on `X-Bonita-API-Token` information. The `X-Bonita-API-Toke
 #### Login
     $ curl -v -c saved_cookies.txt -X POST --url 'http://localhost:8080/bonita/loginservice' \
     --header 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' -o /dev/null \
-    -d 'username=walter.bates&password=bpm&redirect=false&redirectURL='
+    -d 'username=walter.bates&password=bpm'
 
 The above `curl` command saved the cookies on the disk, in the `saved_cookies.txt` file.
 The cookies file must be reused with the REST API calls (HTTP requests) in order to provide session information.
@@ -57,9 +57,9 @@ To log out, use the following request:
 |:-|:-|
 | Request URL | `http://host:port/bonita/logoutservice`|
 | Request Method | GET|
-| Query parameter | redirect: true or false (default set to true)|
+| Query parameter | redirect: `true` or `false` (set to `false` by default)|
 
-Setting the redirect parameter to false indicates that the service should not redirect to the login page after logging out.
+Not setting then redirect parameter to `true` means that the service will not redirect to the login page after logging out.
 
 #### Troubleshooting
 ##### HTTP/1.1 401 Unauthorized
@@ -69,4 +69,3 @@ If the HTTP response's status is `401 Unauthorized`:
  - if one of the PUT, DELETE or POST method is used, make sure that the `X-Bonita-API-Token` header is included
  - if the X-Bonita-API-Token header is included, make sure that the value is the same as the one of the cookie generated during the last login
  - Maybe a logout was issued or the session has expired; try to log in again, and re run the request with the new cookies and the new value for the `X-Bonita-API-Token` header.
-

--- a/md/rest-api-authentication.md
+++ b/md/rest-api-authentication.md
@@ -59,7 +59,7 @@ To log out, use the following request:
 | Request Method | GET|
 | Query parameter | redirect: `true` or `false` (set to `false` by default)|
 
-Not setting then redirect parameter to `true` means that the service will not redirect to the login page after logging out.
+Not setting the redirect parameter to `true` means that the service will not redirect to the login page after logging out.
 
 #### Troubleshooting
 ##### HTTP/1.1 401 Unauthorized

--- a/md/rest-api-overview.md
+++ b/md/rest-api-overview.md
@@ -26,7 +26,7 @@ To log in, use the following request:
 | Request URL | `http://host:port/bonita/loginservice`| 
 | Request Method | POST| 
 | Content-Type | application/x-www-form-urlencoded|
-| Form Data | username: a username<br/>password: a password <br/>redirect: `true` or `false`. `false` is the default value if the redirect parameter is not specified. It indicates that the service should not redirect to Bonita Portal (after a successful login) or to the login page (after a login failure).<br/>redirectURL: the URL of the page to be displayed after a succesful login. If it is specified, then the a redirection after the login will be performed even if the redircet parameter is not present in the request.<br/>tenant: the tenant to log in to (optional for Enterprise and Performance editions, not supported for Community, Teamwork and Efficiency editions)|
+| Form Data | username: a username<br/>password: a password <br/>redirect: `true` or `false`. `false` is the default value if the redirect parameter is not specified. It indicates that the service should not redirect to Bonita Portal (after a successful login) or to the login page (after a login failure).<br/>redirectUrl: the URL of the page to be displayed after a succesful login. If it is specified, then the a redirection after the login will be performed even if the redircet parameter is not present in the request.<br/>tenant: the tenant to log in to (optional for Enterprise and Performance editions, not supported for Community, Teamwork and Efficiency editions)|
   
 The response to this call generates cookies.
 The `JSESSIONID` must be transfered with each subsequent calls. If the REST API is used in an application running in a web browser, this is handled automatically by the web browser.

--- a/md/rest-api-overview.md
+++ b/md/rest-api-overview.md
@@ -26,7 +26,7 @@ To log in, use the following request:
 | Request URL | `http://host:port/bonita/loginservice`| 
 | Request Method | POST| 
 | Content-Type | application/x-www-form-urlencoded|
-| Form Data | username: a username<br/>password: a password <br/>redirect: true or false. false indicates that the service should not redirect to Bonita Portal (after a successful login) or to the login page (after a login failure).<br/>redirectURL: the URL of the page to be displayed after login <br/>tenant: the tenant to log in to (optional for Enterprise and Performance editions, not supported for Community, Teamwork and Efficiency editions)|
+| Form Data | username: a username<br/>password: a password <br/>redirect: `true` or `false`. `false` is the default value if the redirect parameter is not specified. It indicates that the service should not redirect to Bonita Portal (after a successful login) or to the login page (after a login failure).<br/>redirectURL: the URL of the page to be displayed after a succesful login. If it is specified, then the a redirection after the login will be performed even if the redircet parameter is not present in the request.<br/>tenant: the tenant to log in to (optional for Enterprise and Performance editions, not supported for Community, Teamwork and Efficiency editions)|
   
 The response to this call generates cookies.
 The `JSESSIONID` must be transfered with each subsequent calls. If the REST API is used in an application running in a web browser, this is handled automatically by the web browser.
@@ -185,7 +185,7 @@ NOTE: this is to be done only once.
 
     $ curl -v -c saved_cookies.txt -X POST --url 'http://localhost:8080/bonita/loginservice' \
     --header 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' -O /dev/null \
-    -d 'username=walter.bates&password=bpm&redirect=false&redirectURL='
+    -d 'username=walter.bates&password=bpm'
 The above `curl` command saved the cookies on the disk, in the `saved_cookies.txt` file. 
 The cookies file must be reused with the REST API calls (HTTP requests) in order to provide session information.
 The value of X-Bonita-API-Token cookie must be passed also in the header of the subsequent REST API calls, when any of the POST, PUT or DELETE HTTP method is used.
@@ -241,7 +241,7 @@ The `Registration` process has a process definition id equal to `609024682951522
 
 #### Logout
 
-    $ curl -b saved_cookies.txt -X GET --url 'http://localhost:8080/bonita/logoutservice?redirect=false'
+    $ curl -b saved_cookies.txt -X GET --url 'http://localhost:8080/bonita/logoutservice'
     
 #### Troubleshooting
 ##### HTTP/1.1 401 Unauthorized
@@ -251,4 +251,3 @@ If the HTTP response's status is `401 Unauthorized`:
  - if one of the PUT, DELETE or POST method is used, make sure that the `X-Bonita-API-Token` header is included
  - if the X-Bonita-API-Token header is included, make sure that the value is the same as the one of the cookie generated during the last login
  - Maybe a logout was issued or the session has expired; try to log in again, and re run the request with the new cookies and the new value for the `X-Bonita-API-Token` header.
-


### PR DESCRIPTION
- If there is a redirect param in the request it is used. Otherwise 
check if there is a redirect URL
- update release note

This means it is no longer needed to put redirect=false in the request
to log in using the API. But previous login requests with a redirect URL
will continue working as the redirect parameter is optional

Covers [BPO-655](https://bonitasoft.atlassian.net/browse/BPO-655)

To be merged with bonitasoft/bonita-web-sp/pull/622