### PR TITLE
feat(RN): Update release-notes & ldap doc for bugfix.

### DIFF
--- a/md/ldap-synchronizer.md
+++ b/md/ldap-synchronizer.md
@@ -21,7 +21,7 @@ all output is written to a log file.
 The synchronizer will synchronize LDAP objects that inherit from the "person" class as users in Bonita.
 The synchronizer application does not support user meta data and cannot synchronize passwords. A new user password is initialized with the user name.
 
-The tool supports LDAP groups of the following classes:
+The tool supports LDAP groups of the following classes (all of the verifications are case-insensitive) :
 
 * group
 * groupOfURLs

--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -203,7 +203,4 @@ Use BPMN 2 importer for model exchange with third-party editors.
 * BPO-662 Expanding/collapsing the form resets input data
 * BPO-664 - Security risk: API/formsDocumentImage executes injected script
 * BR-454 - Sometimes CallActivity are left Completed without target process
-
-### Fixes in Bonita 7.12.1
-#### Fixes in Bonita Runtime (including Portal)
 * RUNTIME-50/BR-621 - All LDAP group objectclass checks are now case-insensitive.

--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -186,21 +186,21 @@ Use BPMN 2 importer for model exchange with third-party editors.
 * STUDIO-3694 - User password is not retrieved from the active organization when logging in Portal/App
 
 #### Fixes in Bonita Runtime (including Portal)
-* BS-17167 Live update of connector fails after BDM redeployment
-* BS-18685 Portal's task REPLAY says failed connector will be re-executed but it is not true if task's prev_state_id=4 (ready)
+* BS-17167 - Live update of connector fails after BDM redeployment
+* BS-18685 - Portal's task REPLAY says failed connector will be re-executed but it is not true if task's prev_state_id=4 (ready)
 * BS-19410 - Failed Flownodes after a database server restart
 * BS-19453 - no state found after AbortedFlowNodeStateImpl for flow node of type SBoundaryEventInstance
 * BS-19455 - Performance: 10 sec SQL request on ARCH_FLOWNODE_INSTANCE with 13500000 rows
 * BS-19497 - NullPointerException is generated after replaying a call activity in a failed state
 * BS-19534 - no state found after CancelledFlowNodeStateImpl for flow node of type SBoundaryEventInstance CANCELLING
 * BS-19538 - Cancel of process instance fails because MULTI element cancelled before all children call activities are cancelled
-* BS-19543 Cannot create case because hibernate_sequence table or sequence is missing after migration to 7.11
-* BPO-307 Process manager can assign a task and execute a task on behalf of a user which is not associated to the process in the actor mapping with our without Dynamic authorization checking
+* BS-19543 - Cannot create case because hibernate_sequence table or sequence is missing after migration to 7.11
+* BPO-307 - Process manager can assign a task and execute a task on behalf of a user which is not associated to the process in the actor mapping with our without Dynamic authorization checking
 * BPO-643 - Not all processes get disabled when multiple ones are selected in Portal - Administration - BPM - Processes page
-* BPO-645 Erroneous space at the end of property value breaks the standard authentication allowed functionality
+* BPO-645 - Erroneous space at the end of property value breaks the standard authentication allowed functionality
 * BPO-648 - Load more limitation when result is multiple of number per page
 * BPO-655 - LoginServlet redirect param should be optional and default to false
-* BPO-662 Expanding/collapsing the form resets input data
+* BPO-662 - Expanding/collapsing the form resets input data
 * BPO-664 - Security risk: API/formsDocumentImage executes injected script
 * BR-454 - Sometimes CallActivity are left Completed without target process
 * RUNTIME-50/BR-621 - All LDAP group objectclass checks are now case-insensitive.

--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -203,3 +203,7 @@ Use BPMN 2 importer for model exchange with third-party editors.
 * BPO-662 Expanding/collapsing the form resets input data
 * BPO-664 - Security risk: API/formsDocumentImage executes injected script
 * BR-454 - Sometimes CallActivity are left Completed without target process
+
+### Fixes in Bonita 7.12.1
+#### Fixes in Bonita Runtime (including Portal)
+* RUNTIME-50/BR-621 - All LDAP group objectclass checks are now case-insensitive.


### PR DESCRIPTION
LDAP group objectclass check are all case insensitive.
Updated RN for 7.12.1
Added a note in LDAP doc.

cf [RUNTIME-50](https://bonitasoft.atlassian.net/browse/RUNTIME-50)