### PR TITLE
fix: change version in docker images documentation

### DIFF
--- a/md/bonita-docker-installation.md
+++ b/md/bonita-docker-installation.md
@@ -14,9 +14,9 @@ To start the latest subscription release
 >Information on how to access Quay.io can be found <a href="https://customer.bonitasoft.com/download/request">here</a>
 ```
 docker login quay.io
-docker pull quay.io/bonitasoft/bonita-subscription:${varVersion}.0
+docker pull quay.io/bonitasoft/bonita-subscription:${varVersion}
 docker logout quay.io
-docker run --name=bonita -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}.0
+docker run --name=bonita -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}
 ```
 >Note: You need to provide a valid licence, [follow these steps](#section-StepByStep) in order to get and configure one. 
 
@@ -28,7 +28,7 @@ docker run --name=bonita -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:
 First generate a request key into a container with a specific hostname (-h):
 
 ```
-docker run --rm --name=bonita -h <hostname> -ti quay.io/bonitasoft/bonita-subscription:${varVersion}.0 /bin/bash ./generateRequestKey.sh
+docker run --rm --name=bonita -h <hostname> -ti quay.io/bonitasoft/bonita-subscription:${varVersion} /bin/bash ./generateRequestKey.sh
 ```
 Answer the questions related to the license you want. This will print out the request key and exit automatically from the running container.
 
@@ -45,7 +45,7 @@ Alternatively, you can create a named persistent volume in docker for keeping li
 Re-create a new Bonita container with the same hostname (-h) and this host directory mounted (-v) :
 
 ```
-docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}.0
+docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}
 ```
 
 
@@ -71,7 +71,7 @@ docker run --name mydbpostgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres
 ```
 See the official PostgreSQL documentation for more details.
 ```
-docker run --name bonita_postgres -h <hostname> -v bonita-lic:/opt/bonita_lic/ --link mydbpostgres:postgres -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}.0
+docker run --name bonita_postgres -h <hostname> -v bonita-lic:/opt/bonita_lic/ --link mydbpostgres:postgres -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}
 ```
 
 #### Using docker-compose
@@ -91,7 +91,7 @@ services:
       - -c
       - max_prepared_transactions=100
   bonita:
-    image: quay.io/bonitasoft/bonita-subscription:${varVersion}.0
+    image: quay.io/bonitasoft/bonita-subscription:${varVersion}
     hostname: <hostname>
     volumes:
       - ~/bonita-lic:/opt/bonita_lic/
@@ -150,12 +150,12 @@ BIZ_DB_PASS=custombusinesspass
 ```
 
 ```
-docker run --name=bonita -h <hostname> --env-file=env.txt -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}.0
+docker run --name=bonita -h <hostname> --env-file=env.txt -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}
 ```
 
 ### Start Bonita with custom security credentials
 ```
-docker run --name=bonita -v bonita-lic:/opt/bonita_lic/ -h <hostname> -e "TENANT_LOGIN=tech_user" -e "TENANT_PASSWORD=secret" -e "PLATFORM_LOGIN=pfadmin" -e "PLATFORM_PASSWORD=pfsecret" -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}.0
+docker run --name=bonita -v bonita-lic:/opt/bonita_lic/ -h <hostname> -e "TENANT_LOGIN=tech_user" -e "TENANT_PASSWORD=secret" -e "PLATFORM_LOGIN=pfadmin" -e "PLATFORM_PASSWORD=pfsecret" -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}
 ```
 Now you can access the Bonita Portal on localhost:8080/bonita and login using: tech_user / secret
 
@@ -163,7 +163,7 @@ Now you can access the Bonita Portal on localhost:8080/bonita and login using: t
 This docker image ensures to activate by default both static and dynamic authorization checks on [REST API](rest-api-authorization.md). To be coherent it also deactivates the HTTP API.
 But for specific needs you can override this behavior by setting HTTP_API to true and REST_API_DYN_AUTH_CHECKS to false :
 ```
-docker run  -e HTTP_API=true -e REST_API_DYN_AUTH_CHECKS=false --name bonita -v bonita-lic:/opt/bonita_lic/ -h <hostname> -d -p 8080:8080  quay.io/bonitasoft/bonita-subscription:${varVersion}.0
+docker run  -e HTTP_API=true -e REST_API_DYN_AUTH_CHECKS=false --name bonita -v bonita-lic:/opt/bonita_lic/ -h <hostname> -d -p 8080:8080  quay.io/bonitasoft/bonita-subscription:${varVersion}
 ```
 
 ## Environment variables


### PR DESCRIPTION
use `${varVersion}` instead of `${varVersion}.0`. It will result for 7.12 to have `7.12` instead of `7.12.0`. The tag with the `patch` digit is available starting from that version.
