### PR TITLE
doc(7.9): inform which version supports mysql with utf8-mb4

### DIFF
--- a/md/release-notes.md
+++ b/md/release-notes.md
@@ -321,8 +321,8 @@ From Bonita 7.9, the supported version of MySQL database is **8.0 (8.0.x)**
 To migrate to Bonita 7.9+ from an earlier version, you need to run the [Bonita Migration Tool](migrate-from-an-earlier-version-of-bonita-bpm.md), so that the database and configuration is updated. Then you must upgrade MySQL to version 8.0. See [Migrating to Bonita 7.9+ using MySQL](migrate-from-an-earlier-version-of-bonita-bpm.md#mysql8) for more details.
 
 ::: info
-**Note:** Bonita requires MySQL to use [UTF-8 encoding](database-configuration.md#utf8_requirement), which is an alias for 'utf8mb3', now deprecated by MySQL. 
-The [official MySQL recommendation is to use 'utf8mb4'](https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8.html). Bonitasoft will handles this change in a later release.
+**Note:** Up to 7.9 version Bonita requires MySQL to use [UTF-8 encoding](database-configuration.md#utf8_requirement), which is an alias for 'utf8mb3', now deprecated by MySQL. 
+The [official MySQL recommendation is to use 'utf8mb4'](https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8.html). 'utf8mb4' is supported on Bonita starting from version 7.10.
 :::
 
 <a id="other-dependencies"/>


### PR DESCRIPTION
Change info on mysql encoding. `utf8mb4` is supported starting from 7.10

Relates to [BR-79](https://bonitasoft.atlassian.net/browse/BR-79)