### PR TITLE
fix(doc): remove header charset=utf-8

### DIFF
--- a/md/rest-api-authentication.md
+++ b/md/rest-api-authentication.md
@@ -33,7 +33,7 @@ X-Bonita-API-Token: example-dummy-not-be-used-value
 
 ```bash
 $ curl -v -c saved_cookies.txt -X POST --url 'http://localhost:8080/bonita/loginservice' \
---header 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' -o /dev/null \
+--header 'Content-Type: application/x-www-form-urlencoded' -o /dev/null \
 -d 'username=walter.bates&password=bpm&redirect=false&redirectURL='
 ```
 


### PR DESCRIPTION
* The curl example doesn't work with charset=utf-8.