### PR TITLE
chore(7.10): change the way we trigger the documentation-site workflow

### DIFF
--- a/.github/workflows/build-pr-preview.yml 
+++ b/.github/workflows/build-pr-preview.yml 
@@ -1,0 +1,42 @@
+name: Build PR preview
+
+on:
+  pull_request:
+    # To manage 'surge-preview' action teardown, add default event types + closed event type
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'modules/ROOT/**'
+      - 'antora.yml'
+      - '.github/workflows/build-pr-preview.yml'
+jobs:
+  build_preview:
+    runs-on: ubuntu-20.04
+    env:
+      COMPONENT_NAME: bonita
+      # Except if you want to test in progress work that your content depends on, keep it set to master
+      DOC_SITE_BRANCH: master
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Get documentation site source code
+        if: github.event.action != 'closed'
+        run: |
+          # Remove existing .git directory
+          rm -rf *
+          git clone --depth 1 --single-branch --branch ${DOC_SITE_BRANCH} https://github.com/bonitasoft/bonitasoft.github.io.git .
+      - name: Compute environment variables
+        run: |
+          echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
+          # the surge-preview action generates https://{{repository.owner}}-{{repository.name}}-{{job.name}}-pr-{{pr.number}}.surge.sh
+          repo_owner_and_name=$(echo "${{github.repository}}" | sed 's/\//-/g')
+          echo PREVIEW_URL=https://$repo_owner_and_name-"${{github.job}}"-pr-$PR_NUMBER.surge.sh >> $GITHUB_ENV
+      - name: Publish preview
+        uses: afc163/surge-preview@v1
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN_DOC }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dist: build/site
+          failOnError: true
+          teardown: 'true'
+          build: |
+            ./build-preview.bash --branch "${{ env.BRANCH_NAME }}" --component "${{ env.COMPONENT_NAME }}" --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
+            ls -lh build/site

--- a/.github/workflows/push-content.yml
+++ b/.github/workflows/push-content.yml
@@ -1,0 +1,22 @@
+name: Push content
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 7.10
+    paths:
+      - 'modules/**'
+      - 'antora.yml'
+      - '.github/workflows/push-content.yml'
+jobs:
+  triggerJob:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Notify content changes
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{secrets.GH_TOKEN_DOC_TRIGGER_WF}}
+          repository: bonitasoft/bonita-documentation-site
+          event-type: source_documentation_change
+          client-payload: '{ "component": "bonita", "branch": "7.10" }'


### PR DESCRIPTION
We are now using a repository_dispatch event to reduce adherence with the
targeted repository.

In addition

* use the new bonita-documentation-site repository name
trigger on content change on all modules changes not only ROOT
covers bonitasoft/bonita-documentation-site#167

* add build pr preview action
