### PR TITLE
chore(2021.1): change the way we trigger the documentation-site workflow

### DIFF
--- a/.github/workflows/push-content.yml
+++ b/.github/workflows/push-content.yml
@@ -4,20 +4,19 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 7.12_asciidoc
+      - 2021.1
     paths:
-      - 'modules/ROOT/**'
+      - 'modules/**'
       - 'antora.yml'
       - '.github/workflows/push-content.yml'
 jobs:
   triggerJob:
     runs-on: ubuntu-20.04
     steps:
-      - name: Workflow Dispatch
-        uses: benc-uk/workflow-dispatch@v1.1
+      - name: Notify content changes
+        uses: peter-evans/repository-dispatch@v1
         with:
-          workflow: Generate documentation
           token: ${{secrets.GH_TOKEN_DOC_TRIGGER_WF}}
-          ref: master
-          repo: bonitasoft/bonitasoft.github.io
-          inputs: '{ "component": "bonita", "branch": "7.12_asciidoc" }'
+          repository: bonitasoft/bonita-documentation-site
+          event-type: source_documentation_change
+          client-payload: '{ "component": "bonita", "branch": "2021.1" }'


### PR DESCRIPTION
We are now using a repository_dispatch event to reduce adherence with the
targeted repository.

In addition, use the new bonita-documentation-site repository name
trigger on content change on all modules changes not only ROOT
