### PR TITLE
fix(7.11): set ref to getting started in index page

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -45,7 +45,7 @@ xref:release-notes.adoc#uipath-cloud[[.card-title]#UiPath RPA connector, now in 
 == Getting started
 [.card.card-index]
 --
-xref:getting-started-tutorial.adoc[[.card-title]#Getting started tutorial# [.card-body.card-content-overflow]#pass:q[A step-by-step creation of a first simple Living Application to learn about all the concepts in Bonita.]#]
+xref:tutorial-overview.adoc[[.card-title]#Getting started tutorial# [.card-body.card-content-overflow]#pass:q[A step-by-step creation of a first simple Living Application to learn about all the concepts in Bonita.]#]
 --
 
 [.card.card-index]


### PR DESCRIPTION
This has already been fixed for 7.9 and 7.10 with #1449 but the getting started home page has changed in 7.11 (see https://github.com/bonitasoft/bonita-doc/pull/1448#discussion_r592548536).