### PR TITLE
fix: fix asciidoctor warnings and errors

### DIFF
--- a/modules/ROOT/pages/bonita-bpm-overview.adoc
+++ b/modules/ROOT/pages/bonita-bpm-overview.adoc
@@ -47,8 +47,6 @@ Bonita is provided in five different editions: Community, Teamwork, Efficiency, 
 
 Bonita 7.x provides new and improved features, including the xref:ui-designer-overview.adoc[UI Designer] for creating application pages and forms, as well as xref:contracts-and-contexts.adoc[contracts and context] to create a clear split between the process logic, the data, and the user views.
 
-====
-
 You will also find lots of familiar features, which continue to work as they did in 6.x.
 
 *Tell me about the documentation.*

--- a/modules/ROOT/pages/building-community-edition-from-source.adoc
+++ b/modules/ROOT/pages/building-community-edition-from-source.adoc
@@ -1,14 +1,10 @@
 = Build Bonita Community edition from the source
-:description: :doctype: book
-
-:doctype: book
+:description: How to build Bonita Community edition from the source
 
 Bonita is an opensource Digital Process Automation platform, you can therefore build Bonita Community edition from the source.
 
 All source code of Bonita is available from the https://github.com/bonitasoft[Bonitasoft GitHub organization]. Each Bonita component has
 a dedicated repository (e.g. https://github.com/bonitasoft/bonita-engine[Engine repository]).
-
-= Building Bonita
 
 == Manual Bonita build
 

--- a/modules/ROOT/pages/maintenance-operation.adoc
+++ b/modules/ROOT/pages/maintenance-operation.adoc
@@ -1,15 +1,13 @@
 = Bonita Runtime Maintenance Operation
-:description: :doctype: book
+:description: Describe some available maintenance operations
 
-:doctype: book
+Learn how maintenance operations can help to reduce disk space used by the Bonita Platform.
 
-Learn how maintenance operations can help reducing disk space used by the Bonita Platform.
-
-= Purge archive tables
+== Purge archive tables
 
 Archive tables contain the execution history of the Bonita Platform. Some of these tables can be purged to reduce size on disk.
 
-== Archive Contract Data
+=== Archive Contract Data
 
 Archive contract data table keeps the information of all contracts sent to execute tasks or instantiate processes.
 After of a lot of tasks or processes were executed, the `arch_contract_data` table could become very big and

--- a/modules/ROOT/pages/manage-a-process.adoc
+++ b/modules/ROOT/pages/manage-a-process.adoc
@@ -371,7 +371,6 @@ apiClient.getProcessAPI().disableAndDeleteProcessDefinition(processDefinitionId)
 
 [WARNING]
 ====
-
 Be aware that to be able to delete a process, you must ensure that all running process instances and all
 archived (finished) process instances are deleted first:
 
@@ -382,3 +381,4 @@ while (apiClient.getProcessAPI().deleteProcessInstances(processDefinitionId, 0, 
 // Delete all archived process instances:
 while (apiClient.getProcessAPI().deleteArchivedProcessInstances(processDefinitionId, 0, 100) > 0) { }
 ----
+====

--- a/modules/ROOT/pages/share-a-repository-on-github.adoc
+++ b/modules/ROOT/pages/share-a-repository-on-github.adoc
@@ -31,18 +31,18 @@ In all cases, the local Git repository is initialized, and a .gitignore file is 
 . Enter a commit message for the initial commit. If it is the first time you use Git, a dialog will prompt to ask for an identity (mail and name). This identity will be stored in the Git configuration and can be updated in preferences afterward. All your commits will be authored with this identity. Note that this is your Git identity, different from your GitHub credentials.
 . Click on "Commit and Push".
 . To push the project on the GitHub remote: +
-a.  On GitHub, navigate to the main page of the repository. Under the repository name, click on "Clone or download". In the Clone with HTTPs section, click on the icon to copy the clone URL for the repository. +
-b. In the studio, paste the URL in the URI text input +
-c. Do not select anything in the "Protocol" drop down list, nor write anything on the "Port" input field +
-c. If needed, enter your GitHub username and password in the Authentication form +
-d. Click on "Next" +
-e. By convention, the default Git branch is named `master`, but you can change this here. +
-f. You can also change the pulling strategy (default is `merge`) +
-g. Click on "Next" +
-h. Click on "Finish" (Push will be done in a background job, visible at the bottom right corner of the studio window) +
-i. When the Push is done, a push confirmation dialog is displayed
+..  On GitHub, navigate to the main page of the repository. Under the repository name, click on "Clone or download". In the Clone with HTTPs section, click on the icon to copy the clone URL for the repository. +
+.. In the studio, paste the URL in the URI text input +
+.. Do not select anything in the "Protocol" drop down list, nor write anything on the "Port" input field +
+.. If needed, enter your GitHub username and password in the Authentication form +
+.. Click on "Next" +
+.. By convention, the default Git branch is named `master`, but you can change this here. +
+.. You can also change the pulling strategy (default is `merge`) +
+.. Click on "Next" +
+.. Click on "Finish" (Push will be done in a background job, visible in the bottom right corner of the studio window) +
+.. When the Push is done, a push confirmation dialog is displayed
 +
-You might encounter some issues if the two factor authentiation is activated on your github account, see the xref:workspaces-and-repositories.adoc#git-troubleshooting[Git trouble shooting section].
+You might encounter some issues if the two-factor authentication is activated on your github account, see the xref:workspaces-and-repositories.adoc#git-troubleshooting[Git trouble shooting section].
 +
 . To validate that the push has actually been done, you can check your repository on GitHub
 

--- a/modules/ROOT/pages/single-sign-on-with-cas.adoc
+++ b/modules/ROOT/pages/single-sign-on-with-cas.adoc
@@ -34,7 +34,7 @@ The method https://docs.oracle.com/javaee/7/api/javax/servlet/http/HttpServletRe
 ====
 
 
-==== Example
+=== Example
 *Reverse proxy configuration:*  use the http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#proxypreservehost[ProxyPreserveHost] property (Apache 2.0.31 or greater).
 
 If you need more fine tuning or if you cannot update the reverse proxy configuration, you can consult the official documentation for https://tomcat.apache.org/connectors-doc/common_howto/proxy.html[Tomcat] or https://docs.jboss.org/author/display/WFLY10/Undertow+subsystem+configuration[WildFly].


### PR DESCRIPTION
They were mainly due to markdown to asciidoc conversion issues.

bonita-bpm-overview.adoc: remove empty header
building-community-edition-from-source.adoc: fix description and extra header
maintenance-operation.adoc: fix header levels + description
manage-a-process.adoc: fix unterminated admonition block
single-sign-on-with-cas.adoc: fix wrong header level
share-a-repository-on-github: fix ordered list
  - There was a wrong list item index (double alphanumeric declaration for c)
  - Now use nested list to let asciidoc manage the actual letters to be used

Issues related to attribute substitutions are fixed in #1471