### PR TITLE
fix(handle-a-failed-activity) fix typo title

### DIFF
--- a/modules/ROOT/pages/handle-a-failed-activity.adoc
+++ b/modules/ROOT/pages/handle-a-failed-activity.adoc
@@ -1,4 +1,4 @@
-= Task errors managmenent
+= Task errors management
 :description: Learn how to handle errors happening on a task.
 
 Learn how to handle errors happening on a task.


### PR DESCRIPTION
* replace title "Task errors managmenent"  by "Task errors management"
* to be pushed up to latest documentation version