### PR TITLE
Improve Studio installation doc (by cleaning stuff :) )

### DIFF
--- a/modules/ROOT/pages/bonita-bpm-studio-installation.adoc
+++ b/modules/ROOT/pages/bonita-bpm-studio-installation.adoc
@@ -110,7 +110,7 @@ When you launch Bonita Studio for the first time, you need to install a license:
 
 == Configure Bonita Studio to use a specific JVM
 
-Bonita Studio 7.8 only support Java 8. If you have multiple versions of Java installed on your computer you might need to specify which Java Virtual Machine (JVM) to use.
+Bonita Studio only support Java 8 or 11. If you have multiple versions of Java installed on your computer you might need to specify which Java Virtual Machine (JVM) to use.
 
 To specify the JVM version use to run the Studio you first need to identify the appropriate file to edit. For example if you launch the Studio using `BonitaStudioCommunity.exe`, the file to edit will be `BonitaStudioCommunity.ini`. This file is located in your Studio installation folder.
 

--- a/modules/ROOT/pages/bonita-bpm-studio-installation.adoc
+++ b/modules/ROOT/pages/bonita-bpm-studio-installation.adoc
@@ -7,12 +7,6 @@ How to install a Bonita Studio on Windows, Linux, or Mac operating systems. An O
 
 Check the xref:hardware-and-software-requirements.adoc[hardware and software requirements].
 
-Before you download Bonita Studio, make sure that you know whether you are using a using a 32 or 64-bit system, and that you have the appropriate Java version installed:
-
-* For Linux, to find out whether you are using a 32 or 64 bit Linux, run the following command: `getconf LONG_BIT`, which returns either 32 or 64.
-* For Windows, see the http://windows.microsoft.com/en-us/windows/32-bit-and-64-bit-windows[32 and 64 bit Windows FAQ].
-* For Mac, 32-bit Java is no longer supported, so there is no 32-bit version of Bonita for Mac systems.
-
 === Macos specific prerequisites
 
 [IMPORTANT]
@@ -145,18 +139,6 @@ C:\progra~1\Java\jre1.8.0_112\bin\javaw.exe
 -Dgreclipse.nonlocking=true
 -Djava.endorsed.dirs=endorsed
 ----
-
-== Cache configuration
-
-By default xref:cache-configuration-and-policy.adoc[cache] is disable for the web server embedded by Bonita studio, as it is more comfortable to realise development without cache.
-But you can decide to activate cache, to be closer to the production display time. To do this, you need to follow those steps.
-
-. Close your Bonita Studio if he's up.
-. Go in the studio installation folder.
-. Open `BonitaStudioSubscription.ini`.
-. Change `-Dtomcat.extra.params=-DnoCacheCustomPage=true` to `-Dtomcat.extra.params=-DnoCacheCustomPage=false`.
-. Save file.
-. Start your Bonita studio. Now you have a cache for your living application and your custom page.
 
 == Troubleshooting
 

--- a/modules/ROOT/pages/bonita-bpm-studio-installation.adoc
+++ b/modules/ROOT/pages/bonita-bpm-studio-installation.adoc
@@ -13,26 +13,11 @@ Before you download Bonita Studio, make sure that you know whether you are using
 * For Windows, see the http://windows.microsoft.com/en-us/windows/32-bit-and-64-bit-windows[32 and 64 bit Windows FAQ].
 * For Mac, 32-bit Java is no longer supported, so there is no 32-bit version of Bonita for Mac systems.
 
+=== Macos specific prerequisites
+
 [IMPORTANT]
 ====
-
-Both Windows and Mac have default security settings that will prevent execution of Bonita. See below for further details about what you can do to bypass those security protections
-====
-
-*Note for users of macOS 10.12.x and above* : There is an known issue on macOS Sierra and Java about the slowness of   java.net.InetAddress getLocalHost() which results in a slowness of the Bonita Studio (find more info on https://thoeni.io/post/macos-sierra-java/[thoeni] or https://plumbr.eu/blog/java/macos-sierra-problems-with-java-net-inetaddress-getlocalhost[plumbr]). To resolve this issue you shoud add your computer name to your /etc/hosts file : In a terminal, edit your `/etc/hosts` with sudo privilege, add your computer name to the local IP addresses `127.0.0.1 localhost <mycomputername.local>` and `::1 localhost <mycomputername.local>` (To find your macOS computer name, look at https://support.apple.com/kb/PH25076[Apple support dedicated page]).
-
-*Notes for users of macOS Catalina 10.15 and above*:
-[IMPORTANT]
-====
-
-Only version 7.7.5 and upwards are compatible
-====
-
-*Notes for users of macOS Big Sur 11.0 and above*:
-[IMPORTANT]
-====
-
-Only version 7.11.4 and upwards are compatible
+For users of macOS Big Sur 11.0 and above: Only version 7.11.4 and upwards are compatible
 ====
 
 Only *installed JDK* are accepted by the macOS _gatekeeper_. +

--- a/modules/ROOT/pages/hardware-and-software-requirements.adoc
+++ b/modules/ROOT/pages/hardware-and-software-requirements.adoc
@@ -5,7 +5,7 @@ This page describes the suggested hardware and software requirements to install 
 
 == Hardware
 
-[NOTE]
+[CAUTION]
 ====
 
 The hardware recommended for Bonita Platform is strongly dependent on your environment and


### PR DESCRIPTION
Remove outdated admonitions: 
- Since binaries are signed, there is no more 'security settings that will prevent execution of Bonita'
- macos 10.12.x doesn't exist anymore. And even if a user still has this version on its computer, nothing will work. 
- Bonita 7.7 isn't supported anymore -> All supported Bonita versions are compatible with macos Catalina (which is deprecated by Apple). 

Creation of a dedicated section for macos prerequisites, in order to improve the lisibility of this page (which was pretty bad).