### PR TITLE
chore(2021.1): introduce a 'bonitaTechnicalVersion' attribute

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -4,6 +4,7 @@ version: 2021.1
 asciidoc:
   attributes:
     varVersion: 2021.1
+    bonitaTechnicalVersion: '7.12.1'
     javadocVersion: 7.12
     page-editable: true
     page-out-of-support: false

--- a/modules/ROOT/pages/create-your-first-project-with-the-engine-apis-and-maven.adoc
+++ b/modules/ROOT/pages/create-your-first-project-with-the-engine-apis-and-maven.adoc
@@ -21,7 +21,7 @@ In order to use the client APIs, you need to add a dependency to the `bonita-cli
 [source,xml,subs="+macros"]
 ----
 <properties>
-   <bonita.bpm.version>pass:a[{javadocVersion}].0</bonita.bpm.version>
+   <bonita.bpm.version>pass:a[{bonitaTechnicalVersion}]</bonita.bpm.version>
    ...
 </properties>
 

--- a/modules/ROOT/pages/custom-authorization-rule-mapping.adoc
+++ b/modules/ROOT/pages/custom-authorization-rule-mapping.adoc
@@ -51,7 +51,7 @@ In this example, Custom authorization rule is a maven-based java project that ne
         </dependency>
     </dependencies>
     <properties>
-        <bonita-server.version>[pass:a[{javadocVersion}].0,)</bonita-server.version>
+        <bonita-server.version>[pass:a[{bonitaTechnicalVersion}],)</bonita-server.version>
     </properties>
     <build>
         <plugins>

--- a/modules/ROOT/pages/event-handlers.adoc
+++ b/modules/ROOT/pages/event-handlers.adoc
@@ -66,7 +66,7 @@ pom.xml :
     <artifactId>event-handler-example</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <properties>
-        <bonita.version>pass:a[{javadocVersion}].0</bonita.version>
+        <bonita.version>pass:a[{bonitaTechnicalVersion}]</bonita.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
This let easily configure the version of the bonita jars used in examples.

