### PR TITLE
fix(2021.1): fix remaining asciidoc warnings

### DIFF
--- a/modules/ROOT/pages/api-extensions.adoc
+++ b/modules/ROOT/pages/api-extensions.adoc
@@ -60,7 +60,6 @@ REST API permissions are stored in the user's session and new permissions will o
 == Live update
 In Bonita Studio, the debug mode is disabled by default. In debug mode, you can see changes on your REST API Extensions without importing a new zip archive, but it means the classloader of the extension is recreated at each request. +
 If you want to enable the debug mode, you can activate it in the Studio server preferences.
-====
 
 == REST API Extensions examples
 

--- a/modules/ROOT/pages/bdm-management-in-bonita-bpm-portal.adoc
+++ b/modules/ROOT/pages/bdm-management-in-bonita-bpm-portal.adoc
@@ -83,7 +83,6 @@ This limitation is well known and will be addressed in a future Bonita version.
 For Enterprise, Performance, and Efficiency editions only.
 ====
 +
-[#installAccessControl]
 It is possible to define Business Data Model access control rules in Bonita Studio and import them in Bonita Portal. +
 The Access control rules must match the Business Data model.
 +


### PR DESCRIPTION
Remaining warnings introduced by the conversion from markdown to asciidoc
  - api-extensions.adoc: fix 'unterminated example block'
  - bdm-management-in-bonita-bpm-portal.adoc: remove duplicate block id