### PR TITLE
fix(7.9): fix broken links

### DIFF
--- a/modules/ROOT/pages/api-glossary.adoc
+++ b/modules/ROOT/pages/api-glossary.adoc
@@ -59,4 +59,4 @@ Use to represent an instance of a none start event, user task, call activity, mu
 For a complete description of the different elements, check out the following pages:
 
 * on the engine side, the http://documentation.bonitasoft.com/javadoc/api/{varVersion}/index.html[Javadoc] page
-* on the web site, the xref:_rest-api.adoc[REST API page] page
+* on the web site, the xref:rest-api-overview.adoc[REST API page] page

--- a/modules/ROOT/pages/comparison-of-7-x-and-6-x.adoc
+++ b/modules/ROOT/pages/comparison-of-7-x-and-6-x.adoc
@@ -128,7 +128,7 @@ See the xref:bonita-bpm-installation-overview.adoc[Installation overview].
 
 | Subtasks
 | A subtask is a part of an existing task. The assignee can create a subtask (to request a missing information for example) and must assign it to a specific person, by name. The assignee can be the creator
-| Supported up to 7.2.4. No more substasks can be created starting from 7.3.0, but open process instances execute them correctly. See xref:subtasks.adoc[Manage a subtask]
+| Supported up to 7.2.4. No more substasks can be created starting from 7.3.0, but open process instances execute them correctly
 
 | Replay tasks and connectors in error
 | It is now possible for the administrator to replay a task or a connector that is in error. This enables a resolution of failed tasks and better service to end users. and connectors in error

--- a/modules/ROOT/pages/connectors-overview.adoc
+++ b/modules/ROOT/pages/connectors-overview.adoc
@@ -3,7 +3,7 @@
 
 Description of the structure, definition, implementation and test of custom connectors in Bonita.
 
-A connector is an element in a process that accesses an external system to read or write information. If the xref:_connectivity.adoc[default connectors in Bonita] are not suitable, you can implement your own connector.
+A connector is an element in a process that accesses an external system to read or write information. If the default connectors in Bonita are not suitable, you can implement your own connector.
 It's recommended to use the xref:connector-archetype.adoc[maven connector archetype] to create new connector project.
 Otherwise, you can define a new connector definition or implementation in Bonita Studio,
 using the wizards started from the *Development* menu, *Connectors* submenu.

--- a/modules/ROOT/pages/data-handling-overview.adoc
+++ b/modules/ROOT/pages/data-handling-overview.adoc
@@ -34,5 +34,5 @@ An application page accesses business data using the xref:bdm-api.adoc[bdm REST 
 
 The data that is passed from a form to a process is defined using a xref:contracts-and-contexts.adoc[contract]. Define a contract for process instantiation and for each human task.
 These contracts are part of the process definition.
-A form has access to business data and documents using the xref:contracts-and-contexts.adoc[context] and the xref:_rest-api.adoc[REST API].
+A form has access to business data and documents using the xref:contracts-and-contexts.adoc[context] and the xref:rest-api-overview.adoc[REST API].
 A form also contains form xref:variables.adoc[variables], which have no meaning outside the form.

--- a/modules/ROOT/pages/database-configuration.adoc
+++ b/modules/ROOT/pages/database-configuration.adoc
@@ -25,7 +25,7 @@ However, H2 is only suitable for testing purposes. When building a production en
 ====
 
 Please note this procedure cannot be performed using the Bonita Studio. The Bonita Studio can run only on the H2 Database.
-To use Bonita on another RDBMS, please use a xref:_basic-bonita-platform-installation.adoc[bundle] or set up a xref:custom-deployment.adoc[standalone server].
+To use Bonita on another RDBMS, please use a xref:tomcat-bundle.adoc[bundle] or set up a xref:custom-deployment.adoc[standalone server].
 ====
 
 Here are the steps to follow. They are the same for the engine database and the business data database:

--- a/modules/ROOT/pages/first-steps-after-setup.adoc
+++ b/modules/ROOT/pages/first-steps-after-setup.adoc
@@ -90,7 +90,7 @@ Authentication is the process of verification that an individual, entity or webs
 
 Input validation is performed to ensure only properly formed data is entering the workflow in an information system, preventing malformed data from persisting in the database and triggering malfunction of various downstream components.If you use BonitaStudio for developing your forms, then define authorized min and max values, max length and type for input fields.
 
-For more information, please take look at the xref:rest-api-authorization.adoc[REST API authorization] and the other features relating to xref:_security-and-authentication.adoc[security and authentication] that are available in Bonita and in your operating system, and update your platform as required for your production environment.
+For more information, please take look at the xref:rest-api-authorization.adoc[REST API authorization] and the other features relating to xref:user-authentication-overview.adoc[security and authentication] that are available in Bonita and in your operating system, and update your platform as required for your production environment.
 
 == Create a Bonita Portal administrator
 

--- a/modules/ROOT/pages/list-of-documents.adoc
+++ b/modules/ROOT/pages/list-of-documents.adoc
@@ -12,7 +12,7 @@ Manage a list of documents through a process means add / edit / remove documents
 [WARNING]
 ====
 
-This tutorial assume that you are already familiar with Bonita. If not you might want to read the xref:getting-started-tutorial.adoc[Getting started] first.
+This tutorial assume that you are already familiar with Bonita. If not you might want to read the xref:what-is-bonita.adoc[Getting started] first.
 ====
 
 This exemple shows how to easily create a document validation process using Bonita Studio. +

--- a/modules/ROOT/pages/manage-control-in-forms.adoc
+++ b/modules/ROOT/pages/manage-control-in-forms.adoc
@@ -101,8 +101,6 @@ AngularJS sets these different CSS classes on HTML input elements depending on t
 
 ==== Using AngularJS form control CSS classes
 
-NOTE: A tutorial about xref:uid-modal-tutorial.adoc[creating modal windows using CSS in the UI Designer] is available. We recommend to read it before you go further in this tutorial.
-
 So, to alert users about the invalidity of inputs they just edited, you need to use _ng-invalid_ and _ng-dirty_ classes on those elements: +
 In your favorite editor, create a _validationStyle.css_ file containing the class below:
 

--- a/modules/ROOT/pages/multi-language-pages.adoc
+++ b/modules/ROOT/pages/multi-language-pages.adoc
@@ -49,7 +49,7 @@ In production, a page, layout or form is displayed in the language specified by 
 
 == Tutorial: creating a multi-language page
 
-This tutorial explains how to create a multi-language version of the Travel Tool application page from the xref:getting-started-tutorial.adoc[getting started tutorial], adding french and russian text to the page, initially developped in US-english. It assumes that you have already created the Travel Tool page following the instructions in the xref:getting-started-tutorial.adoc[getting started tutorial].
+This tutorial explains how to create a multi-language version of the Travel Tool application page from the xref:what-is-bonita.adoc[getting started tutorial], adding french and russian text to the page, initially developped in US-english. It assumes that you have already created the Travel Tool page following the instructions in the xref:design-application-page.adoc[getting started tutorial].
 French is supported by default in Bonita, along with US-english and Spanish. Russian is not.
 
 === Translate the text
@@ -155,7 +155,7 @@ NOTE: Always update the localization.json file as an asset and then export your 
 
 === Deploy
 
-To put a multi-language page into production in an application, follow the same steps as for a single-language page: xref:resource-management.adoc[upload the page to the Portal] and then xref:applications.adoc[add it to the application]. You can follow the steps for xref:getting-started-tutorial.adoc[building the application] from the getting started tutorial.
+To put a multi-language page into production in an application, follow the same steps as for a single-language page: xref:resource-management.adoc[upload the page to the Portal] and then xref:applications.adoc[add it to the application]. You can follow the steps for xref:create-application.adoc[creating an application] from the getting started tutorial.
 
 After deployment, an application user will see the page in the language configured for their Bonita web applications. A user can set this by selecting the language in the Bonita Portal. If the selected language is not supported by the page localization.json file, the untranslated keys are displayed.
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -67,7 +67,7 @@ This is different from Bonita Portal Task List where the user needs to click on 
 From the Studio, the theme can now be created as any other part of a Living Application, from the Development Menu and from the Project Explorer "New" option.
 It is packaged as a Maven project, just like the REST API extensions, and is nested in the Bonita project.
 A theme created in the Studio can be deployed to the Portal, and managed (open, edit, delete) as any other element of the application.
-The theme is taken into account in xref:bonita-continuous-delivery-doc/md/index.adoc[Bonita Continuous Delivery Add-on], through the builder and the deployer.
+The theme is taken into account in xref:bcd::index.adoc[Bonita Continuous Delivery], through the builder and the deployer.
 For more information on how to use it, go to the xref:customize-living-application-theme.adoc[dedicated documentation].
 
 ==== View a UI Designer artifact within an application theme while developing
@@ -141,7 +141,7 @@ See xref:work-execution-audit.adoc[Work execution audit page].
 The Bonita Runtime is now up to 10x more performant in a context of slow connectors, allowing more tasks to be executed and avoiding and SPOC (single point of contention).
 
 * Connectors are executed in an asynchrous manner. In earlier versions each work was waiting for the connector to end before processing other workload. This resulted in degraded performance if few connectors had a long execution time.
-* Worker threads are now released as soon as the execution of the connector is triggered. see [connector execution page](connectors-execution.md) for more details.
+* Worker threads are now released as soon as the execution of the connector is triggered. see xref:connectors-execution.adoc[connector execution page] for more details.
 As a consequence, in a context of connectors taking a lot of time (connecting to slow third party services, high computing, ...) the usual job executions are not blocking and can continue.
 
 ==== Timer execution
@@ -150,8 +150,8 @@ Bugs were fixed to increase stability of the integration with Quartz:
 
 * BS-19239 Exception during Quartz Job execution leaves the associated flownode in WAITING state and the process execution is stopped
 * BR-56 Failure in a cron timer cancels future executions
-A [new page](timers-execution.md) was added to explain how Timers are executed and how to handle time execution failures.
-Also details were added on how to configure Quartz for timers execution: [quartz performance tuning](performance-tuning.md#cron)
+A xref:timers-execution.adoc[new page] was added to explain how Timers are executed and how to handle time execution failures.
+Also details were added on how to configure Quartz for timers execution: xref:performance-tuning.adoc#cron[quartz performance tuning]
 
 ==== Cluster locks
 
@@ -263,7 +263,7 @@ The step works at best effort:
 * Beware that if one of these connectors' removed dependencies was used in one your scripts, it will still be removed/updated, and therefore your scripts might not work anymore after migration. The full list of updated and deleted dependencies can be found below.
 
 From Bonita 7.9+, the supported version of Oracle database is *12c (12.2.x.y)*
-To migrate to Bonita 7.9+ from an earlier version than Oracle 12c (12.2.x.y), see [Migrating to Bonita 7.9+ using Oracle](migrate-from-an-earlier-version-of-bonita-bpm.md#oracle12).
+To migrate to Bonita 7.9+ from an earlier version than Oracle 12c (12.2.x.y), see xref:migrate-from-an-earlier-version-of-bonita-bpm.adoc#oracle12[Migrating to Bonita 7.9+ using Oracle].
 
 ==== WebService connector
 
@@ -334,7 +334,7 @@ In Bonita 7.9.0, we replaced the JTA transaction manager used to handle XA trans
 This change should not impact the way to use Bonita.
 However, tuning Bonita transaction configuration is now a little different. If you wish to change the default transaction timeout,
 it is now done by changing the `defaultTimeout` property in file `server/conf/jbossts-properties.xml` instead of file `server/conf/bitronix-config.properties`
-More configuration info can be found [here](tomcat-bundle.md).
+More configuration info can be found xref:tomcat-bundle.adoc[here].
 
 === Databases supported
 
@@ -342,7 +342,7 @@ More configuration info can be found [here](tomcat-bundle.md).
 
 From Bonita 7.9, the supported version of Oracle database is *12c (12.2.x.y)*
 
-To migrate to Bonita 7.9+ from an earlier version, you need to run the [Bonita Migration Tool](migrate-from-an-earlier-version-of-bonita-bpm.md) once with the version 7.8.4 target, so that the database and configuration is updated. Then you must upgrade your Oracle database to version 12c (12.2.x.y). Then run the migration tool again to target version 7.9+. See [Migrating to Bonita 7.9+ using Oracle](migrate-from-an-earlier-version-of-bonita-bpm.md#oracle12) for more details.
+To migrate to Bonita 7.9+ from an earlier version, you need to run the xref:migrate-from-an-earlier-version-of-bonita-bpm.adoc[Bonita Migration Tool] once with the version 7.8.4 target, so that the database and configuration is updated. Then you must upgrade your Oracle database to version 12c (12.2.x.y). Then run the migration tool again to target version 7.9+. See xref:migrate-from-an-earlier-version-of-bonita-bpm.adoc#oracle12[Migrating to Bonita 7.9+ using Oracle] for more details.
 
 ==== PostgreSQL
 
@@ -358,12 +358,12 @@ Microsoft SQL Server *open-source drivers* are now provided by Bonita. There is 
 
 From Bonita 7.9, the supported version of MySQL database is *8.0 (8.0.x)*
 
-To migrate to Bonita 7.9+ from an earlier version, you need to run the [Bonita Migration Tool](migrate-from-an-earlier-version-of-bonita-bpm.md), so that the database and configuration is updated. Then you must upgrade MySQL to version 8.0. See [Migrating to Bonita 7.9+ using MySQL](migrate-from-an-earlier-version-of-bonita-bpm.md#mysql8) for more details.
+To migrate to Bonita 7.9+ from an earlier version, you need to run the xref:migrate-from-an-earlier-version-of-bonita-bpm.adoc[Bonita Migration Tool], so that the database and configuration is updated. Then you must upgrade MySQL to version 8.0. See xref:migrate-from-an-earlier-version-of-bonita-bpm.adoc#mysql8[Migrating to Bonita 7.9+ using MySQL] for more details.
 
 [NOTE]
 ====
 
-Up to 7.9 version Bonita requires MySQL to use [UTF-8 encoding](database-configuration.md#utf8_requirement), which is an alias for 'utf8mb3', now deprecated by MySQL.
+Up to 7.9 version Bonita requires MySQL to use xref:database-configuration.adoc#utf8_requirement[UTF-8 encoding], which is an alias for 'utf8mb3', now deprecated by MySQL.
 The link:http ://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8.html[official MySQL recommendation is to use 'utf8mb4']. 'utf8mb4' is supported on Bonita starting from version 7.10.
 ====
 
@@ -383,7 +383,7 @@ This can be done in two different ways:
 * using standard Spring Boot starter integration
 * programmatically, calling Bonita Engine code through Java, Kotlin, Groovy, or any other language running on JVM
 
-For more information, see [how to embed Bonita Engine](embed-engine.md).
+For more information, see xref:embed-engine.adoc[how to embed Bonita Engine].
 
 WARNING: This is a Lab feature and is subject to change without warning in any version. It is not recommended for production.
 
@@ -416,7 +416,7 @@ The SAP JCO2 connector is no longer available. SAP JCO3 connector is more recent
 ==== Deploy zip
 
 The BonitaSubscription-x.y.z-deploy.zip is no longer provided starting from Bonita 7.9.
-Please use the Tomcat bundle instead, or see the [Custom Deployment](deploy-bundle.md) page for more specific needs.
+Please use the Tomcat bundle instead, or see the xref:custom-deployment.adoc[Custom Deployment] page for more specific needs.
 
 ==== Dependency libraries
 

--- a/modules/ROOT/pages/set-up-kpis.adoc
+++ b/modules/ROOT/pages/set-up-kpis.adoc
@@ -101,6 +101,6 @@ This implementation option is better for performance and flexibility reasons:
 
 The disadvantage with this implementation option is that it requires basic SQL knowledge because you have to write insertion queries manually.
 
-To configure this option, use a xref:_database.adoc[database connector] to insert a row in the reporting database.
+To configure this option, use a xref:list-of-database-connectors.adoc[database connector] to insert a row in the reporting database.
 
 Use the datasource database connector with connection pooling for improved performance.

--- a/modules/ROOT/pages/software-extensibility.adoc
+++ b/modules/ROOT/pages/software-extensibility.adoc
@@ -18,7 +18,7 @@ These extension points are guaranteed to be stable across versions of Bonita 7: 
 
 In Community, Teamwork, Efficiency, Performance and Enterprise editions
 
-Bonita comes with more than 80 xref:_connectivity.adoc[standard connectors] to the major information system components: major databases (Oracle, Microsoft, Postgres, etc.), SOAP Webservice, Salesforce, Email, etc.
+Bonita comes with more than 80 xref:connectivity-overview.adoc[standard connectors] to the major information system components: major databases (Oracle, Microsoft, Postgres, etc.), SOAP Webservice, Salesforce, Email, etc.
 A new connector enables you to provide new connectivity capabilities for processes.
 To xref:connectors-overview.adoc[implement a new connector], you need to provide some XML description files and a
 Java class respecting the http://documentation.bonitasoft.com/javadoc/api/{varVersion}/index.html[Connector interface].

--- a/modules/ROOT/pages/tomcat-bundle.adoc
+++ b/modules/ROOT/pages/tomcat-bundle.adoc
@@ -143,7 +143,7 @@ If you just want to try Bonita Platform with the embedded H2 database (only for 
 For production, you are recommended to use one of the supported databases, with the following steps.
 ====
 
-. Make sure xref:database-configuration.adoc#database_creation[your databases are created] and xref:database-configuration.adoc]]#specific_database_configuration[customized to work with Bonita].
+. Make sure xref:database-configuration.adoc#database_creation[your databases are created] and xref:database-configuration.adoc#specific_database_configuration[customized to work with Bonita].
 . Edit file `<TOMCAT_HOME>/setup/database.properties` and modify the properties to suit your databases (Bonita internal database & Business Data database). Beware of xref:BonitaBPM_platform_setup.adoc#backslash_support[backslash characters].
 . If you use *Oracle* database, copy your xref:database-configuration.adoc#proprietary_jdbc_drivers[jdbc driver] in `<TOMCAT_HOME>/setup/lib/` folder.
 . Run `<TOMCAT_HOME>\setup\start-bonita.bat` (Windows system) or `<TOMCAT_HOME>/setup/start-bonita.sh` (Unix system) to run Bonita Tomcat bundle (see <<tomcat_start,Tomcat start script>>)
@@ -204,7 +204,7 @@ To update Bonita configuration after the first run, take a look at the xref:Boni
 ====
 
 
-* The file `database.properties` is the entry point to configure the xref:BonitaBPM_platform_setup.adoc#run_bundle_configure[Tomcat environment] and the xref:BonitaBPM_platform_setup.adoc]]#configure_tool[Bonita Platform configuration].
+* The file `database.properties` is the entry point to configure the xref:BonitaBPM_platform_setup.adoc#run_bundle_configure[Tomcat environment] and the xref:BonitaBPM_platform_setup.adoc#configure_tool[Bonita Platform configuration].
 * You can use command line arguments to specify database properties directly from the command line. Use `<TOMCAT_HOME>/setup/setup.sh --help` on Linux or `<TOMCAT_HOME>\setup\setup.bat --help` on Windows to have a list of available options.
 ====
 

--- a/modules/ROOT/pages/variables.adoc
+++ b/modules/ROOT/pages/variables.adoc
@@ -23,7 +23,7 @@ Expression, external API and URL parameter variables are evaluated every time so
 
 === External API
 
-External API variables are used to fetch data from outside the page. These are typically used for REST API calls using HTTP GET requests. The response is stored in the page data model. You can parameterize the URL construction with other data using `+{{variableName}}+` syntax. You can retrieve information using the xref:rest-api.adoc[Bonita REST APIs].
+External API variables are used to fetch data from outside the page. These are typically used for REST API calls using HTTP GET requests. The response is stored in the page data model. You can parameterize the URL construction with other data using `+{{variableName}}+` syntax. You can retrieve information using the xref:rest-api-overview.adoc[Bonita REST APIs].
 
 Here are some examples:
 

--- a/modules/ROOT/pages/wildfly-bundle.adoc
+++ b/modules/ROOT/pages/wildfly-bundle.adoc
@@ -135,7 +135,7 @@ If you just want to try Bonita Platform with the embedded H2 database (only for 
 For production, you are recommended to use one of the supported databases, with the following steps.
 ====
 
-. Make sure xref:database-configuration.adoc#database_creation[your databases are created] and xref:database-configuration.adoc]]#specific_database_configuration[customized to work with Bonita].
+. Make sure xref:database-configuration.adoc#database_creation[your databases are created] and xref:database-configuration.adoc#specific_database_configuration[customized to work with Bonita].
 . Edit file `<WILDFLY_HOME>/setup/database.properties` and modify the properties to suit your databases (Bonita internal database & Business Data database). Beware of xref:BonitaBPM_platform_setup.adoc#backslash_support[backslash characters].
 . If you use *Oracle* database, copy your xref:database-configuration.adoc#proprietary_jdbc_drivers[jdbc driver] in `<WILDFLY_HOME>/setup/lib` folder.
 . Run `<WILDFLY_HOME>\start-bonita.bat` (Windows system) or `<WILDFLY_HOME>/start-bonita.sh (Unix system)` to run Bonita WildFly bundle (see <<wildfly_start,WildFly start script>>)


### PR DESCRIPTION
Links to generated pages that don't exist anymore: the pages were previously
generated by the old markdown based solution, and don't exist anymore.
  - api-glossary.adoc
  - connectors-overview.adoc: remove non existing links to connectors list
  - data-handling-overview.adoc
  - first-steps-after-setup.adoc
  - set-up-kpis.adoc
  - software-extensibility.adoc

Fix links still using the markdown in the release-notes

Fix links to page that doesn't exist
  - comparison-of-7-x-and-6-x.adoc: no more subtask page as subtasks don't exist
  anymore in bonita
  - list-of-documents.adoc: link to getting started. WARN in newer doc version,
  a dedicated overview page exist and should then be referenced instead
  - manage-control-in-forms.adoc: remove the link as there is no more 'uid modal
  tutorial'
  - multi-language-pages.adoc.adoc
  change links to tutorial but the content of the target page is not in sync
  with the content of this page (not the same tutorial topic!)
  - variables.adoc: fix link to rest api overview

Fix links to wrong anchors (extra `]]` before the '#' in xref)
  - tomcat-bundle.adoc
  - wildfly-bundle.adoc

multi-language-pages.adoc.adoc: change links to tutorial but the content of the
target page is not in sync with the content of this page (not the same tutorial
topic!)

release-notes.adoc: fix link to bcd index of the latest version.
Use antora xref syntax to reference cross component page

covers https://github.com/bonitasoft/bonita-documentation-site/issues/96