### PR TITLE
chore(2021.1): fix bonita version attributes substitution

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -4,10 +4,11 @@ version: 2021.1
 asciidoc:
   attributes:
     bonitaVersion: 2021.1
-    bonitaDockerImageEnterpriseVersion: '7.12.2'
-    crowdinBonitaVersion: 7.12
     bonitaTechnicalVersion: '7.12.1' # latest public community version
     javadocVersion: 7.12
+    bonitaDockerImageEnterpriseVersion: '7.12.2'
+    crowdinBonitaVersion: 7.12
+    # page attributes
     page-editable: true
     page-out-of-support: false
 nav:

--- a/antora.yml
+++ b/antora.yml
@@ -5,8 +5,8 @@ asciidoc:
   attributes:
     varVersion: 2021.1
     bonitaDockerImageEnterpriseVersion: '7.12.2'
-    # latest public community version
-    bonitaTechnicalVersion: '7.12.1'
+    crowdinBonitaVersion: 7.12
+    bonitaTechnicalVersion: '7.12.1' # latest public community version
     javadocVersion: 7.12
     page-editable: true
     page-out-of-support: false

--- a/antora.yml
+++ b/antora.yml
@@ -4,6 +4,8 @@ version: 2021.1
 asciidoc:
   attributes:
     varVersion: 2021.1
+    bonitaDockerImageEnterpriseVersion: '7.12.2'
+    # latest public community version
     bonitaTechnicalVersion: '7.12.1'
     javadocVersion: 7.12
     page-editable: true

--- a/antora.yml
+++ b/antora.yml
@@ -3,7 +3,7 @@ title: Bonita
 version: 2021.1
 asciidoc:
   attributes:
-    varVersion: 2021.1
+    bonitaVersion: 2021.1
     bonitaDockerImageEnterpriseVersion: '7.12.2'
     crowdinBonitaVersion: 7.12
     bonitaTechnicalVersion: '7.12.1' # latest public community version

--- a/modules/ROOT/pages/bonita-docker-installation.adoc
+++ b/modules/ROOT/pages/bonita-docker-installation.adoc
@@ -15,18 +15,21 @@ docker run --name bonita -d -p 8080:8080 bonita
 
 To start the latest subscription release
 
-____
-Information on how to access Quay.io can be found https://customer.bonitasoft.com/download/request[here]
 
+// for the 'subs' parameter, see https://docs.asciidoctor.org/asciidoc/latest/subs/apply-subs-to-blocks/
+[source,shell script,subs="+macros"]
 ----
 docker login quay.io
-docker pull quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
+docker pull quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaDockerImageEnterpriseVersion}]
 docker logout quay.io
-docker run --name=bonita -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
+docker run --name=bonita -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaDockerImageEnterpriseVersion}]
 ----
 
-NOTE: You need to provide a valid licence, <<section-StepByStep,follow these steps>> in order to get and configure one.
-____
+[NOTE]
+====
+* Information on how to access Quay.io can be found https://customer.bonitasoft.com/download/request[here].
+* You need to provide a valid licence, <<section-StepByStep,follow these steps>> in order to get and configure one.
+====
 
 [#section-StepByStep]
 
@@ -36,8 +39,9 @@ ____
 
 First generate a request key into a container with a specific hostname (-h):
 
+[source,shell script,subs="+macros"]
 ----
-docker run --rm --name=bonita -h <hostname> -ti quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion} /bin/bash ./generateRequestKey.sh
+docker run --rm --name=bonita -h <hostname> -ti quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaDockerImageEnterpriseVersion}] /bin/bash ./generateRequestKey.sh
 ----
 
 Answer the questions related to the license you want. This will print out the request key and exit automatically from the running container.
@@ -54,21 +58,18 @@ Alternatively, you can create a named persistent volume in docker for keeping li
 
 Re-create a new Bonita container with the same hostname (-h) and this host directory mounted (-v) :
 
+[source,shell script,subs="+macros"]
 ----
-docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
+docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaDockerImageEnterpriseVersion}]
 ----
 
 [NOTE]
 ====
-
 This will only add the initial license to the Bonita Runtime. To renew a license on an existing installation see <<section-update-configuration,Update configuration and license section>>
 ====
 
-[cols=2*]
-|===
-| This will start a container running the Tomcat Bundle with Bonita Engine + Portal. As you did not specify any environment variables it's almost like if you had launched the Bundle on your host using startup.{sh
-| bat} (with security hardening on REST and HTTP APIs, cf Security part). It means that Bonita uses a H2 database here.
-|===
+
+This will start a container running the Tomcat Bundle with Bonita Engine + Portal. As you did not specify any environment variables it's almost like if you had launched the Bundle on your host using startup.+{sh|bat}+ (with security hardening on REST and HTTP APIs, cf Security part). It means that Bonita uses a H2 database here.
 
 You can access the portal on http://localhost:8080/bonita and login using the default credentials : install / install
 
@@ -86,8 +87,9 @@ docker run --name bonita -it -p 8080:8080 bonita bash
 
 *Subscription release*
 
+[source,shell script,subs="+macros"]
 ----
-docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ -it -p 8080:8080 quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion} bash
+docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ -it -p 8080:8080 quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaDockerImageEnterpriseVersion}] bash
 ----
 
 Then run `/opt/files/startup.sh` inside the container to start Tomcat. In order to stop Tomcat inside the container, press `Ctrl-C`. +
@@ -110,14 +112,16 @@ docker run --name mydbpostgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres
 
 See the official PostgreSQL documentation for more details.
 
+[source,shell script,subs="+macros"]
 ----
-docker run --name bonita_postgres -h <hostname> -v bonita-lic:/opt/bonita_lic/ --link mydbpostgres:postgres -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
+docker run --name bonita_postgres -h <hostname> -v bonita-lic:/opt/bonita_lic/ --link mydbpostgres:postgres -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaDockerImageEnterpriseVersion}]
 ----
 
 ==== Using docker-compose
 
-Create a file stack.yml with the following content (remember to replace the +++<hostname>+++with the one used in the licence generation command):+++</hostname>+++
+Create a file stack.yml with the following content (remember to replace the `<hostname>` with the one used in the licence generation command):
 
+[source,shell script,subs="+macros"]
 ----
 # Use tech_user/secret as user/password credentials
 version: '3'
@@ -132,7 +136,7 @@ services:
       - -c
       - max_prepared_transactions=100
   bonita:
-    image: quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
+    image: quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaDockerImageEnterpriseVersion}]
     hostname: <hostname>
     volumes:
       - ~/bonita-lic:/opt/bonita_lic/
@@ -192,14 +196,16 @@ BIZ_DB_USER=custombusinessuser
 BIZ_DB_PASS=custombusinesspass
 ----
 
+[source,shell script,subs="+macros"]
 ----
-docker run --name=bonita -h <hostname> --env-file=env.txt -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
+docker run --name=bonita -h <hostname> --env-file=env.txt -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaDockerImageEnterpriseVersion}]
 ----
 
 === Start Bonita with custom security credentials
 
+[source,shell script,subs="+macros"]
 ----
-docker run --name=bonita -v bonita-lic:/opt/bonita_lic/ -h <hostname> -e "TENANT_LOGIN=tech_user" -e "TENANT_PASSWORD=secret" -e "PLATFORM_LOGIN=pfadmin" -e "PLATFORM_PASSWORD=pfsecret" -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
+docker run --name=bonita -v bonita-lic:/opt/bonita_lic/ -h <hostname> -e "TENANT_LOGIN=tech_user" -e "TENANT_PASSWORD=secret" -e "PLATFORM_LOGIN=pfadmin" -e "PLATFORM_PASSWORD=pfsecret" -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaDockerImageEnterpriseVersion}]
 ----
 
 Now you can access the Bonita Portal on localhost:8080/bonita and login using: tech_user / secret
@@ -209,8 +215,9 @@ Now you can access the Bonita Portal on localhost:8080/bonita and login using: t
 This docker image ensures to activate by default both static and dynamic authorization checks on xref:rest-api-authorization.adoc[REST API]. To be coherent it also deactivates the HTTP API.
 But for specific needs you can override this behavior by setting HTTP_API to true and REST_API_DYN_AUTH_CHECKS to false :
 
+[source,shell script,subs="+macros"]
 ----
-docker run  -e HTTP_API=true -e REST_API_DYN_AUTH_CHECKS=false --name bonita -v bonita-lic:/opt/bonita_lic/ -h <hostname> -d -p 8080:8080  quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
+docker run  -e HTTP_API=true -e REST_API_DYN_AUTH_CHECKS=false --name bonita -v bonita-lic:/opt/bonita_lic/ -h <hostname> -d -p 8080:8080  quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaDockerImageEnterpriseVersion}]
 ----
 
 == Environment variables

--- a/modules/ROOT/pages/bonita-docker-installation.adoc
+++ b/modules/ROOT/pages/bonita-docker-installation.adoc
@@ -20,9 +20,9 @@ Information on how to access Quay.io can be found https://customer.bonitasoft.co
 
 ----
 docker login quay.io
-docker pull quay.io/bonitasoft/bonita-subscription:${varVersion}
+docker pull quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
 docker logout quay.io
-docker run --name=bonita -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}
+docker run --name=bonita -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
 ----
 
 NOTE: You need to provide a valid licence, <<section-StepByStep,follow these steps>> in order to get and configure one.
@@ -37,7 +37,7 @@ ____
 First generate a request key into a container with a specific hostname (-h):
 
 ----
-docker run --rm --name=bonita -h <hostname> -ti quay.io/bonitasoft/bonita-subscription:${varVersion} /bin/bash ./generateRequestKey.sh
+docker run --rm --name=bonita -h <hostname> -ti quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion} /bin/bash ./generateRequestKey.sh
 ----
 
 Answer the questions related to the license you want. This will print out the request key and exit automatically from the running container.
@@ -55,7 +55,7 @@ Alternatively, you can create a named persistent volume in docker for keeping li
 Re-create a new Bonita container with the same hostname (-h) and this host directory mounted (-v) :
 
 ----
-docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}
+docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
 ----
 
 [NOTE]
@@ -87,7 +87,7 @@ docker run --name bonita -it -p 8080:8080 bonita bash
 *Subscription release*
 
 ----
-docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ -it -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}.0 bash
+docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ -it -p 8080:8080 quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion} bash
 ----
 
 Then run `/opt/files/startup.sh` inside the container to start Tomcat. In order to stop Tomcat inside the container, press `Ctrl-C`. +
@@ -111,7 +111,7 @@ docker run --name mydbpostgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres
 See the official PostgreSQL documentation for more details.
 
 ----
-docker run --name bonita_postgres -h <hostname> -v bonita-lic:/opt/bonita_lic/ --link mydbpostgres:postgres -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}
+docker run --name bonita_postgres -h <hostname> -v bonita-lic:/opt/bonita_lic/ --link mydbpostgres:postgres -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
 ----
 
 ==== Using docker-compose
@@ -132,7 +132,7 @@ services:
       - -c
       - max_prepared_transactions=100
   bonita:
-    image: quay.io/bonitasoft/bonita-subscription:${varVersion}
+    image: quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
     hostname: <hostname>
     volumes:
       - ~/bonita-lic:/opt/bonita_lic/
@@ -193,13 +193,13 @@ BIZ_DB_PASS=custombusinesspass
 ----
 
 ----
-docker run --name=bonita -h <hostname> --env-file=env.txt -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}
+docker run --name=bonita -h <hostname> --env-file=env.txt -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
 ----
 
 === Start Bonita with custom security credentials
 
 ----
-docker run --name=bonita -v bonita-lic:/opt/bonita_lic/ -h <hostname> -e "TENANT_LOGIN=tech_user" -e "TENANT_PASSWORD=secret" -e "PLATFORM_LOGIN=pfadmin" -e "PLATFORM_PASSWORD=pfsecret" -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:${varVersion}
+docker run --name=bonita -v bonita-lic:/opt/bonita_lic/ -h <hostname> -e "TENANT_LOGIN=tech_user" -e "TENANT_PASSWORD=secret" -e "PLATFORM_LOGIN=pfadmin" -e "PLATFORM_PASSWORD=pfsecret" -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
 ----
 
 Now you can access the Bonita Portal on localhost:8080/bonita and login using: tech_user / secret
@@ -210,7 +210,7 @@ This docker image ensures to activate by default both static and dynamic authori
 But for specific needs you can override this behavior by setting HTTP_API to true and REST_API_DYN_AUTH_CHECKS to false :
 
 ----
-docker run  -e HTTP_API=true -e REST_API_DYN_AUTH_CHECKS=false --name bonita -v bonita-lic:/opt/bonita_lic/ -h <hostname> -d -p 8080:8080  quay.io/bonitasoft/bonita-subscription:${varVersion}
+docker run  -e HTTP_API=true -e REST_API_DYN_AUTH_CHECKS=false --name bonita -v bonita-lic:/opt/bonita_lic/ -h <hostname> -d -p 8080:8080  quay.io/bonitasoft/bonita-subscription:{bonitaDockerImageEnterpriseVersion}
 ----
 
 == Environment variables

--- a/modules/ROOT/pages/bonita-studio-download-installation.adoc
+++ b/modules/ROOT/pages/bonita-studio-download-installation.adoc
@@ -15,7 +15,7 @@ To download the latest version of Bonita Studio, open the https://www.bonitasoft
 
 // update package name
 
-When the download is finished, you should have one of the following files on your computer (x.y refers to the version of Bonita Studio, e.g. {varVersion}):
+When the download is finished, you should have one of the following files on your computer (x.y refers to the version of Bonita Studio, e.g. {bonitaVersion}):
 
 * Windows: `BonitaStudioCommunity-x.y-x86_64.exe`
 * macOS: `BonitaStudioCommunity-x.y-x86_64.dmg`

--- a/modules/ROOT/pages/bonita-studio-download-installation.adoc
+++ b/modules/ROOT/pages/bonita-studio-download-installation.adoc
@@ -15,11 +15,11 @@ To download the latest version of Bonita Studio, open the https://www.bonitasoft
 
 // update package name
 
-When the download is finished, you should have one of the following files on your computer (x.y.z refers to the version of Bonita Studio, e.g. $\{varVersion}.0):
+When the download is finished, you should have one of the following files on your computer (x.y refers to the version of Bonita Studio, e.g. {varVersion}):
 
-* Windows: `BonitaStudioCommunity-x.y.z-x86_64.exe`
-* macOS: `BonitaStudioCommunity-x.y.z-x86_64.dmg`
-* Linux: `BonitaStudioCommunity-x.y.z-x86_64.run`
+* Windows: `BonitaStudioCommunity-x.y-x86_64.exe`
+* macOS: `BonitaStudioCommunity-x.y-x86_64.dmg`
+* Linux: `BonitaStudioCommunity-x.y-x86_64.run`
 
 You are now ready to start the installation process.
 
@@ -46,9 +46,9 @@ image:images/getting-started-tutorial/installation/studio-installation-installer
 
 Bonita Studio is now installed. The default installation folders are:
 
-* Windows: `C:\BonitaStudioCommunity-x.y.z`
-* macOS: `/Applications/BonitaStudioCommunity-x.y.z`
-* Linux: `/home/<username>/BonitaStudioCommunity-x.y.z`
+* Windows: `C:\BonitaStudioCommunity-x.y`
+* macOS: `/Applications/BonitaStudioCommunity-x.y`
+* Linux: `/home/<username>/BonitaStudioCommunity-x.y`
 
 == First Bonita Studio execution
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,14 +1,14 @@
 = Bonita Documentation
 :description: Learn how to use the Bonita Platform and all of its components.
 
-Learn how to use the Bonita Platform and all of its components. 
+Learn how to use the Bonita Platform and all of its components.
 
 [.card-section]
 == Highlights
 
 [.card.card-index]
 --
-xref:release-notes.adoc[[.card-title]#Release note {varVersion}# [.card-body.card-content-overflow]#pass:q[A brief presentation of the new values, improvements, technical changes, deprecations, removals, and bug fixes of this release.]#]
+xref:release-notes.adoc[[.card-title]#Release note {bonitaVersion}# [.card-body.card-content-overflow]#pass:q[A brief presentation of the new values, improvements, technical changes, deprecations, removals, and bug fixes of this release.]#]
 --
 
 [.card.card-index]
@@ -41,7 +41,7 @@ xref:release-notes.adoc#fault-tolerance-mechanism[[.card-title]#Fault tolerance 
 xref:release-notes.adoc#SSO-create-users[[.card-title]#Create a new user automatically in Bonita# [.card-body.card-content-overflow]#pass:q[If the user is known by the SSO, let it become a Bonita user too.]#]
 --
 
-== Video: What's new in Bonita {varVersion}
+== Video: What's new in Bonita {bonitaVersion}
 
 {empty}
 

--- a/modules/ROOT/pages/languages.adoc
+++ b/modules/ROOT/pages/languages.adoc
@@ -80,9 +80,9 @@ Instructions below explain how to add a language to Bonita Portal. Steps below i
 . Go to http://translate.bonitasoft.org/[Bonita translation project].
 . Select the language you are interested in.
 . Make sure you click on the "Toggle Hidden Files" button image:images/crowdin_toggle_hidden_files.png[Toggle hidden files button] to see already fully translated files.
-. Browse the file tree to `{varVersion}.x/bonita-web/portal` folder.
+. Browse the file tree to `{crowdinBonitaVersion}/bonita-web/portal` folder.
 . For each file in the folder: open it and in the *_File_* menu click on *_Download_*. Each `.po/.pot` file has a language indicator and a locale indicator. For example, the files for the Brazilian Portuguese language end with `pt_BR.po`.
-. For Subscription editions, you also need to get the files from `{varVersion}.x/bonita-web-sp/portal` folder.
+. For Subscription editions, you also need to get the files from `{crowdinBonitaVersion}/bonita-web-sp/portal` folder.
 
 [discrete]
 ==== Install the files and configure java

--- a/modules/ROOT/pages/user-authentication-overview.adoc
+++ b/modules/ROOT/pages/user-authentication-overview.adoc
@@ -27,17 +27,17 @@ property in the Bonita web application deployment descriptor (a `web.xml`
 file located in `bonita.war/WEB-INF`).
 . Javascript in `index.html` will redirect the user to `/portal/homepage`
 (e.g. `+http://localhost:8080/bonita/portal/homepage+`).
-. https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/server/src/main/java/org/bonitasoft/console/common/server/login/filter/AuthenticationFilter.java[AuthenticationFilter]
+. https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/server/src/main/java/org/bonitasoft/console/common/server/login/filter/AuthenticationFilter.java[AuthenticationFilter]
 applied to the HTTP request send to `/portal/homepage`.
-The filter will check if the user is already authenticated. To do so, it will look in the HTTP session for an `apiSession` attribute (see https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/server/src/main/java/org/bonitasoft/console/common/server/login/filter/AlreadyLoggedInRule.java[AlreadyLoggedInRule]).
+The filter will check if the user is already authenticated. To do so, it will look in the HTTP session for an `apiSession` attribute (see https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/server/src/main/java/org/bonitasoft/console/common/server/login/filter/AlreadyLoggedInRule.java[AlreadyLoggedInRule]).
 If an `apiSession` attribute exists, this means a user is already authenticated.
 . If the attribute `apiSession` is not set, the user will be redirected to the login page.
 *Note:* Information about the original page the user tried to reach is included in a URL parameter named `redirectURL`.
-The login page URL is determined by the https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/common/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
+The login page URL is determined by the https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/common/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
 implementation. The implementation to use for the current tenant is configured in a file `authenticationManager-config.properties`
 (located in `setup/platform_conf/initial/tenant_template_portal` or `setup/platform_conf/current/tenants/[tenantid]/tenant_portal` and updatable using the xref:BonitaBPM_platform_setup.adoc[platform setup tool]).
-The default https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/common/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
-is https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/server/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java[StandardAuthenticationManagerImpl].
+The default https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/common/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
+is https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/server/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java[StandardAuthenticationManagerImpl].
 Its behavior is to redirect to the `login.jsp` page embedded in the webapp.
 Supporting different implementations enables authentication on an external application (useful for SSO deployement for example).
 . `login.jsp` page will ask the user for the username
@@ -47,41 +47,41 @@ username, password, tenant id (if provided in the URL, only applied to
 subscription editions), locale (optional, by priority order: provided
 in the URL, stored in HTTP cookie) and the `redirectURL`
 information.
-. URL `/loginservice` is handled by https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java[LoginServlet].
-. https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java[LoginServlet]
-calls `login` method of https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
-. https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
-searches for an https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/common/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
-implementation based on configuration file for current tenant (xref:BonitaBPM_platform_setup.adoc[`authenticationManager-config.properties`]). The default https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/common/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
-is https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/server/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java[StandardAuthenticationManagerImpl].
-. `authenticate` method is called on the https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/common/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager].
-`authenticate` method of https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/server/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java[StandardAuthenticationManagerImpl]
+. URL `/loginservice` is handled by https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java[LoginServlet].
+. https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java[LoginServlet]
+calls `login` method of https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
+. https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
+searches for an https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/common/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
+implementation based on configuration file for current tenant (xref:BonitaBPM_platform_setup.adoc[`authenticationManager-config.properties`]). The default https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/common/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
+is https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/server/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java[StandardAuthenticationManagerImpl].
+. `authenticate` method is called on the https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/common/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager].
+`authenticate` method of https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/server/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java[StandardAuthenticationManagerImpl]
 implementation of this method does nothing (the subsequent engine login is enough to authenticate the user)
 . The authentication is considered successful if no Exception is thrown by the `authenticate` method.
-. https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
+. https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
 will then call engine API https://javadoc.bonitasoft.com/api/{javadocVersion}/org/bonitasoft/engine/api/LoginAPI.html#login(java.lang.String,%20java.lang.String)[LoginAPI.login()]
-. At this point, operations are processed on Bonita Engine side. Engine (see https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/LoginAPIImpl.java[LoginAPIImpl]
-class) verifies that the username and password are not empty. A verification is also done to validate that the tenant is enabled (use provided tenant id or default one if not provided). Then https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/LoginAPIImpl.java[LoginAPIImpl]
-will call https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/bpm/bonita-core/bonita-login/bonita-login-api/src/main/java/org/bonitasoft/engine/core/login/LoginService.java[LoginService]
-(one implementation available: https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/bpm/bonita-core/bonita-login/bonita-login-api-impl/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginService]).
-. SecuredLoginService calls https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/services/bonita-authentication/bonita-authentication-api/src/main/java/org/bonitasoft/engine/authentication/GenericAuthenticationService.java[GenericAuthenticationService].
-The default implementation is: https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/services/bonita-authentication/bonita-authentication-api-impl/src/main/java/org/bonitasoft/engine/authentication/impl/AuthenticationServiceImpl.java[AuthenticationServiceImpl].
-. The https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/services/bonita-authentication/bonita-authentication-api-impl/src/main/java/org/bonitasoft/engine/authentication/impl/AuthenticationServiceImpl.java[AuthenticationServiceImpl]
+. At this point, operations are processed on Bonita Engine side. Engine (see https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/LoginAPIImpl.java[LoginAPIImpl]
+class) verifies that the username and password are not empty. A verification is also done to validate that the tenant is enabled (use provided tenant id or default one if not provided). Then https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/LoginAPIImpl.java[LoginAPIImpl]
+will call https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-login/bonita-login-api/src/main/java/org/bonitasoft/engine/core/login/LoginService.java[LoginService]
+(one implementation available: https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-login/bonita-login-api-impl/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginService]).
+. SecuredLoginService calls https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-authentication/bonita-authentication-api/src/main/java/org/bonitasoft/engine/authentication/GenericAuthenticationService.java[GenericAuthenticationService].
+The default implementation is: https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-authentication/bonita-authentication-api-impl/src/main/java/org/bonitasoft/engine/authentication/impl/AuthenticationServiceImpl.java[AuthenticationServiceImpl].
+. The https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-authentication/bonita-authentication-api-impl/src/main/java/org/bonitasoft/engine/authentication/impl/AuthenticationServiceImpl.java[AuthenticationServiceImpl]
 verifies that your username and password are valid.
-. After call of the https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/services/bonita-authentication/bonita-authentication-api/src/main/java/org/bonitasoft/engine/authentication/GenericAuthenticationService.java[GenericAuthenticationService],
-https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/bpm/bonita-core/bonita-login/bonita-login-api-impl/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginServiceImpl]
-performs an extra check to verify that the provided username exists in the Bonita database (https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/bpm/bonita-core/bonita-login/bonita-login-api-impl/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginServiceImpl]
-does not trust https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/services/bonita-authentication/bonita-authentication-api-impl/src/main/java/org/bonitasoft/engine/authentication/impl/AuthenticationServiceImpl.java[AuthenticationServiceImpl]).
+. After call of the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-authentication/bonita-authentication-api/src/main/java/org/bonitasoft/engine/authentication/GenericAuthenticationService.java[GenericAuthenticationService],
+https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-login/bonita-login-api-impl/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginServiceImpl]
+performs an extra check to verify that the provided username exists in the Bonita database (https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-login/bonita-login-api-impl/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginServiceImpl]
+does not trust https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-authentication/bonita-authentication-api-impl/src/main/java/org/bonitasoft/engine/authentication/impl/AuthenticationServiceImpl.java[AuthenticationServiceImpl]).
 *Note:* A specific behavior applies for the tenant technical user.
-. https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/bpm/bonita-core/bonita-login/bonita-login-api-impl/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginServiceImpl]
-returns an object that represents the session. This is a server side only object (https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/services/bonita-session/bonita-session-api/src/main/java/org/bonitasoft/engine/session/model/SSession.java[SSession])
-. Call get back to https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/LoginAPIImpl.java[LoginAPIImpl]
-that converts https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/services/bonita-session/bonita-session-api/src/main/java/org/bonitasoft/engine/session/model/SSession.java[SSession]
-to https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/bpm/bonita-api/bonita-common-api/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession].
-. https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/bpm/bonita-api/bonita-common-api/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession]
-is provided back up to the https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
+. https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-login/bonita-login-api-impl/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginServiceImpl]
+returns an object that represents the session. This is a server side only object (https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-session/bonita-session-api/src/main/java/org/bonitasoft/engine/session/model/SSession.java[SSession])
+. Call get back to https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/LoginAPIImpl.java[LoginAPIImpl]
+that converts https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-session/bonita-session-api/src/main/java/org/bonitasoft/engine/session/model/SSession.java[SSession]
+to https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-api/bonita-common-api/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession].
+. https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-api/bonita-common-api/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession]
+is provided back up to the https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
 that will add session information as HTTP session attribute.
-. Call get back to https://github.com/bonitasoft/bonita-web/blob/{varVersion}.0/server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java[LoginServlet]
+. Call get back to https://github.com/bonitasoft/bonita-web/blob/{bonitaTechnicalVersion}/server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java[LoginServlet]
 that will redirect the user to the requested page.
 
 NOTE: If you xref:single-sign-on-with-cas.adoc[configure your Bonita platform to use CAS], the logical flow of authentication is the same as above.
@@ -104,7 +104,7 @@ and corresponds to one user.
 
 *The Bonita Engine session*
 
-See https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/bpm/bonita-api/bonita-common-api/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession]
+See https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-api/bonita-common-api/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession]
 class. This session is created by Bonita Engine on the Bonita Portal request, when the user submits a login page.
 
 *Session expiration*
@@ -114,7 +114,7 @@ an exception will be raised. Bonita Portal will catch this exception,
 invalidate the HTTP session and redirect the user to the login page.
 
 NOTE: The Bonita Engine default session duration is one hour (default value
-defined in https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/services/bonita-session/bonita-session-impl/src/main/java/org/bonitasoft/engine/session/impl/SessionServiceImpl.java[SessionServiceImpl]).
+defined in https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-session/bonita-session-impl/src/main/java/org/bonitasoft/engine/session/impl/SessionServiceImpl.java[SessionServiceImpl]).
 You can configure a different session duration by editing the `bonita.tenant.session.duration` property in `bonita-tenant-community-custom.properties`. Specify the duration in milliseconds.
 
 If the HTTP session has expired, Bonita Portal will redirect the user to the
@@ -132,7 +132,7 @@ Engine session and HTTP session will be invalidated.
 
 == How does the Bonita Portal know if a user is authenticated?
 
-The Bonita Portal checks if a valid Bonita Engine session (https://github.com/bonitasoft/bonita-engine/blob/{varVersion}.0/bpm/bonita-api/bonita-common-api/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession]
+The Bonita Portal checks if a valid Bonita Engine session (https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-api/bonita-common-api/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession]
 object) is found in the
 `apiSession`
 attribute inside the HttpRequest. If the engine session is still valid, the user will have access to the required resource.


### PR DESCRIPTION
Fix attributes that were not substituted in code examples (mainly for the Enterprise Docker image).
Introduce dedicated attributes to manage the various versions we have on both components
and tools: this makes things more explicit and provide more flexibility.

