### PR TITLE
fix: reword Customer Portal --> Customer Service Center

### DIFF
--- a/modules/ROOT/pages/purge-tool.adoc
+++ b/modules/ROOT/pages/purge-tool.adoc
@@ -10,7 +10,7 @@ By default, all archives are preserved forever in Bonita runtime, but if your fu
 ====
 
 For Enterprise, Performance, Efficiency, and Teamwork editions only. +
-This tool is not available publicly. Use https://customer.bonitasoft.com/download/request[Bonita Customer Portal] to download it.
+This tool is not available publicly. Use https://customer.bonitasoft.com/download/request[Bonita Customer Service Center] to download it.
 ====
 
 == Pre-requisites


### PR DESCRIPTION
Since January 2021, the Customer Portal should be referred to as the "Customer Service Center"