### PR TITLE
Update(purge-tool): warning documents not deleted

### DIFF
--- a/modules/ROOT/pages/handling-documents.adoc
+++ b/modules/ROOT/pages/handling-documents.adoc
@@ -153,6 +153,8 @@ def attachNewDocumentVersionToCase(ProcessAPI processAPI, long processInstanceId
 }
 ----
 
+[#delete_document_archived_case]
+
 == Delete documents of archived cases based on archive date
 
 The use case is to delete the documents of archived cases older than a certain date.

--- a/modules/ROOT/pages/purge-tool.adoc
+++ b/modules/ROOT/pages/purge-tool.adoc
@@ -6,6 +6,14 @@ Bonita Purge Tool provides the capability to purge finished (archived) process i
 By default, all archives are preserved forever in Bonita runtime, but if your functional context allows you to remove old unused process instances
 (for example, if you only need to keep a history of last 6 months), use this tool to clean up your Bonita database.
 
+
+[WARNING]
+====
+The purge tool doesn't delete documents from the platform. 
+
+If you need to reduce the size of the Document table in the engine database, please refer to the documentation: xref:handling-documents.adoc#delete_document_archived_case[Delete documents of archived cases based on archive date]
+====
+
 [NOTE]
 ====
 

--- a/modules/ROOT/pages/purge-tool.adoc
+++ b/modules/ROOT/pages/purge-tool.adoc
@@ -9,9 +9,7 @@ By default, all archives are preserved forever in Bonita runtime, but if your fu
 
 [WARNING]
 ====
-The purge tool doesn't delete documents from the platform. 
-
-If you need to reduce the size of the Document table in the engine database, please refer to the documentation: xref:handling-documents.adoc#delete_document_archived_case[Delete documents of archived cases based on archive date]
+The purge tool doesn't delete documents (stored in the DOCUMENT table) from the platform. It will only remove the mapping between the archived cases and the document itself. If you need to reduce the size of the Document table in the engine database, please refer to the documentation: xref:handling-documents.adoc#delete_document_archived_case[Delete documents of archived cases based on archive date]
 ====
 
 [NOTE]


### PR DESCRIPTION
* Adding a clear message that the Documents aren't deleted from the database
* If the user needs to reduce the size of the document table, they need to use the Java APIs