### PR TITLE
Fix (theme-development.adoc): Update bootswatch and explain where to place the include-path

### DIFF
--- a/modules/ROOT/pages/theme-development.adoc
+++ b/modules/ROOT/pages/theme-development.adoc
@@ -46,7 +46,7 @@ A second way to create a custom theme is starting from a new custom theme in Stu
 +
 [source,json]
 ----
-  --include-path ./node_modules/bootstrap-sass/assets/stylesheets/ --include-path ./node_modules/bootswatch/`name-of-default-theme`/ src/scss/main.scss
+ ... --include-path ./node_modules/bootstrap-sass/assets/stylesheets/ --include-path ./node_modules/bootswatch/`name-of-default-theme`/ src/scss/main.scss ...
 ----
 
 * In the file `src/scss/main.scss`, import the variables of the theme before importing bootstrap by adding:

--- a/modules/ROOT/pages/theme-development.adoc
+++ b/modules/ROOT/pages/theme-development.adoc
@@ -33,20 +33,20 @@ Export the examples to see how to structure a theme.
 
 Some of the default themes are based on the https://bootswatch.com/[bootswatch examples], so you can easily choose another existing theme and package it to define a new theme.
 
-A second way to create a custom theme is starting from a new custom theme in Studio and using a Bootswatch default Sass theme. In order to do this using the version 3.3.7 of Bootswatch:
+A second way to create a custom theme is starting from a new custom theme in Studio and using a Bootswatch default Sass theme. In order to do this using the version 3.4.1 of Bootswatch:
 
 * In the custom theme file `package.json`, add `bootswatch` in the `devDependencies` section
 +
 [source,json]
 ----
-  "bootswatch": "3.3.7"
+  "bootswatch": "3.4.1"
 ----
 
-* In this same file `package.json`, include the bootswatch path towards the default theme in the scripts/build section
+* In this same file `package.json`, include the bootswatch path towards the default theme in the scripts/build section and just before `src/scss/main.scss`
 +
 [source,json]
 ----
-  --include-path ./node_modules/bootswatch/`name-of-default-theme`/
+  --include-path ./node_modules/bootstrap-sass/assets/stylesheets/ --include-path ./node_modules/bootswatch/`name-of-default-theme`/ src/scss/main.scss
 ----
 
 * In the file `src/scss/main.scss`, import the variables of the theme before importing bootstrap by adding:


### PR DESCRIPTION

As example

`{
  "name": "darklyTheme",
  "version": "0.0.1",
  "description": "Flatly in night mode https://bootswatch.com/darkly",
  "license": "GPL-2.0-or-later",
  "scripts": {
    "build": "node-sass --precision 8 --output-style compressed --omit-source-map-url true --include-path ./node_modules/bootstrap-sass/assets/stylesheets/ --include-path ./node_modules/bootswatch/darkly/ src/scss/main.scss target/theme.noprefix.css && postcss target/theme.noprefix.css --no-map --use autoprefixer -b \"last 2 versions\" -o dist/theme.css"
  },
  "devDependencies": {
    "autoprefixer": "10.0.1",
    "bootstrap-sass": "3.4.1",
    "node-sass": "4.14.1",
    "postcss-cli": "8.0.0",
    "postcss": "8.1.1",
    "bootswatch": "3.4.1"
  }
}`
