### PR TITLE
Remove unwanted char in SAML doc

### DIFF
--- a/modules/ROOT/pages/single-sign-on-with-saml.adoc
+++ b/modules/ROOT/pages/single-sign-on-with-saml.adoc
@@ -48,7 +48,6 @@ This service validates and process the SAML response :
 
 [WARNING]
 ====
- +
 Bonita "username" should match the NameId or one attribute of the subject returned by the IdP in the response.
  If some users need to be able to log in without having an account on the IDP, you can authorize it by activating an option in the file `authenticationManager-config.properties` (see 2. below). Users will then be able to log in using the portal login page (/login.jsp) provided they have a bonita account and their password is different from their username.
 ====


### PR DESCRIPTION
-> the single '+' at the beginning of the admonition makes the content of the admonition a source code block (dunno why) -> doesn't render well.
