### PR TITLE
feat(OIDC): Google integration

### DIFF
--- a/modules/ROOT/pages/single-sign-on-with-oidc.adoc
+++ b/modules/ROOT/pages/single-sign-on-with-oidc.adoc
@@ -16,7 +16,8 @@ OpenID Connect configuration is at tenant level. Each tenant can use a different
 [NOTE]
 ====
 
-Bonita uses http://www.keycloak.org/[Keycloak] OIDC Service client adapter. It has been extended to support other OIDC providers than Keycloak.
+Bonita uses http://www.keycloak.org/[Keycloak] OIDC Service client adapter. It has been extended to support other OIDC providers than Keycloak.  
+Authentication in Bonita with OIDC has been tested with both Keycloak server and Google's OpenID Connect endpoint.
 ====
 
 == OpenID Connect overview for Bonita
@@ -369,7 +370,8 @@ Once you obtained the Access token, you can make your REST API request in a norm
 [discrete]
 ==== Authorization Code Grant
 
-Those scenarios work the same way as when you login on Bonita portal/apps except it is the client application that needs to use Bonita REST API which needs to trigger the authentication process by calling the OIDC provider authorisation endpoint with Bonita OIDC client as `client_id`. The rest of the scenario is similar to what is described in the xref:#oidc-overview[OIDC Authorization Code Flow schema]. +
+Those scenarios work the same way as when you login on Bonita portal/apps except, in this case, it is the client application that uses Bonita REST API which needs to trigger the authentication process by calling the OIDC provider authorisation endpoint with Bonita OIDC client as `client_id`. The rest of the scenario is similar to what is described in the xref:#oidc-overview[OIDC Authorization Code Flow schema]. +
+For example, if Bonita is configured to use Google's OpenID Connect endpoint for authentication, then an application that wants to use Bonita REST API will need to delegate authentication to Google to obtain an authorization code for Bonita REST API. +
 With Authorization Code Flow, once you obtain the authorization code, you can request again the OIDC provider to get the tokens with as `grant_type` value `authorization_code`:
 
 ----


### PR DESCRIPTION
* explain that our implementation has been validated with Keycloak and Google’s providers
* in the REST API section of the OIDC page mention that is is possible to delegate auth to an OIDC provider to provide access to bonita REST API  (example google)

Relates to [RUNTIME-452](https://bonitasoft.atlassian.net/browse/RUNTIME-452)