### PR TITLE
chore: skip preview for PR created from fork repositories

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -5,7 +5,7 @@ on:
     # To manage 'surge-preview' action teardown, add default event types + closed event type
     types: [opened, synchronize, reopened, closed]
     paths:
-      - 'modules/ROOT/**'
+      - 'modules/**'
       - 'antora.yml'
       - '.github/workflows/build-pr-preview.yml'
 jobs:

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -9,9 +9,24 @@ on:
       - 'antora.yml'
       - '.github/workflows/build-pr-preview.yml'
 jobs:
+  # inspired from https://github.community/t/how-can-i-test-if-secrets-are-available-in-an-action/17911/9
+  check_secrets:
+    runs-on: ubuntu-20.04
+    outputs:
+      is_SURGE_TOKEN_set: ${{ steps.secret_availability.outputs.is_SURGE_TOKEN_set }}
+    steps:
+      - name: Compute secrets availability
+        id: secret_availability
+        env:
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+        run: |
+          echo "is_SURGE_TOKEN_set: ${{ env.SURGE_TOKEN != '' }}"
+          echo "::set-output name=is_SURGE_TOKEN_set::${{ env.SURGE_TOKEN != '' }}"
+
   build_preview:
-    # Don't build preview for non member of the repository
-    if: ${{ secrets.SURGE_TOKEN_DOC != '' }}
+    needs: [check_secrets]
+    # Only build preview for member of the repository
+    if: needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
     runs-on: ubuntu-20.04
     env:
       COMPONENT_NAME: bonita

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_preview:
     # Don't build preview for non member of the repository
-    if: ${{ env.SURGE_TOKEN_DOC != '' }}
+    if: ${{ secrets.SURGE_TOKEN_DOC != '' }}
     runs-on: ubuntu-20.04
     env:
       COMPONENT_NAME: bonita

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -10,6 +10,8 @@ on:
       - '.github/workflows/build-pr-preview.yml'
 jobs:
   build_preview:
+    # Don't build preview for non member of the repository
+    if: ${{ env.SURGE_TOKEN_DOC != '' }}
     runs-on: ubuntu-20.04
     env:
       COMPONENT_NAME: bonita

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Compute secrets availability
         id: secret_availability
         env:
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN_DOC }}
         run: |
           echo "is_SURGE_TOKEN_set: ${{ env.SURGE_TOKEN != '' }}"
           echo "::set-output name=is_SURGE_TOKEN_set::${{ env.SURGE_TOKEN != '' }}"


### PR DESCRIPTION
This prevents deployment errors: there is no more deployment but the PR creator won't think that something is broken in the documentation.

covers https://github.com/bonitasoft/bonita-documentation-site/issues/239

### Tests done

2328a71 simulates unavailable secret
4b9dd55 shows that the preview is built when the secret is available