### PR TITLE
doc(2022.1-alpha): allow to display next released version in live documentation

### DIFF
--- a/.github/workflows/push-content.yml
+++ b/.github/workflows/push-content.yml
@@ -4,8 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      # TODO reactivate when integrating this version to the documentation
-      - '2022.1_diable'
+      - '2022.1'
     paths:
       - 'modules/**'
       - 'antora.yml'

--- a/antora.yml
+++ b/antora.yml
@@ -14,8 +14,7 @@ asciidoc:
     crowdinBonitaVersion: 7.14
     # page attributes
     page-editable: true
-    page-out-of-support: false
-    next-release: true
-    hide-search-bar: true
+    page-next-release: true
+    page-hide-search-bar: true
 nav:
   - modules/ROOT/taxonomy.adoc

--- a/antora.yml
+++ b/antora.yml
@@ -16,6 +16,6 @@ asciidoc:
     page-editable: true
     page-out-of-support: false
     next-release: true
-    searchable: false
+    hide-search-bar: true
 nav:
   - modules/ROOT/taxonomy.adoc

--- a/antora.yml
+++ b/antora.yml
@@ -1,8 +1,11 @@
 name: bonita
 title: Bonita
-version: 2022.1
-# TODO when integrating this version to the documentation, update push-content.yml
-prerelease: Beta
+# TODO: When we are in beta release, put version: 2022.1
+version: 1
+# TODO: remove this line when we are in beta phase
+display_version: 2022.1-alpha
+# TODO when integrating this version to the documentation, update push-content.yml and replace alpha by beta
+prerelease: alpha
 asciidoc:
   attributes:
     bonitaVersion: 2022.1
@@ -12,5 +15,7 @@ asciidoc:
     # page attributes
     page-editable: true
     page-out-of-support: false
+    next-release: true
+    searchable: false
 nav:
   - modules/ROOT/taxonomy.adoc


### PR DESCRIPTION
* this alpha version will not crawl by algolia
* Adding two attributes to allow version searchable or dev-release