### PR TITLE
fix(2021.2): activate the menu macro in pages where it is not activated

### DIFF
--- a/modules/best-practices/pages/project-documentation-generation.adoc
+++ b/modules/best-practices/pages/project-documentation-generation.adoc
@@ -1,5 +1,6 @@
 = Generate project documentation
 :page-aliases: ROOT:project-documentation-generation.adoc
+:experimental: // activate the 'menu' macro
 :description: How to generate the project documentation in Bonita Studio.
 
 How to generate the project documentation in Bonita Studio.
@@ -29,7 +30,7 @@ However, we provide examples to make your life easier and a framework so that bu
 
 == Generating the documentation
 
-Right-click on your project and select the `Documentation > Generate` menu:
+Right-click on your project and select the `menu:Documentation[Generate]` menu:
 
 image::images/doc-generation/generate_doc_menu.png[Generate documentation]
 

--- a/modules/getting-started/pages/configure-email-connector.adoc
+++ b/modules/getting-started/pages/configure-email-connector.adoc
@@ -1,6 +1,7 @@
 = Configure an email connector
-:description: getting started tutorial - configure email connector
 :page-aliases: ROOT:configure-email-connector.adoc
+:experimental: // activate the 'menu' macro
+:description: getting started tutorial - configure email connector
 
 Bonita provides connectors for a process to interact with external systems, such as publishing a document on a CMS, calling a REST API, or sending an email. In this example we will configure an email connector, to send a notification to the manager that the task _Deal with unsatisfied customer_ requires their attention.
 

--- a/modules/getting-started/pages/create-application.adoc
+++ b/modules/getting-started/pages/create-application.adoc
@@ -1,6 +1,7 @@
 = Create an application
-:description: getting started tutorial - create an application
 :page-aliases: ROOT:create-application.adoc
+:experimental: // activate the 'menu' macro
+:description: getting started tutorial - create an application
 
 The last step of this Getting Started tutorial is to create an application.
 

--- a/modules/getting-started/pages/create-web-user-interfaces.adoc
+++ b/modules/getting-started/pages/create-web-user-interfaces.adoc
@@ -1,6 +1,7 @@
 = Create web user interfaces (forms)
-:description: getting started tutorial - create web user interfaces
 :page-aliases: ROOT:create-web-user-interfaces.adoc
+:experimental: // activate the 'menu' macro
+:description: getting started tutorial - create web user interfaces
 
 Generally, a user usually drives process execution using web interfaces. Bonita provides xref:ROOT:ui-designer-overview.adoc[the UI Designer] to easily create such interfaces.
 

--- a/modules/getting-started/pages/declare-business-variables.adoc
+++ b/modules/getting-started/pages/declare-business-variables.adoc
@@ -1,6 +1,7 @@
 = Declare business variables
-:description: getting started tutorial - declare business variables
 :page-aliases: ROOT:declare-business-variables.adoc
+:experimental: // activate the 'menu' macro
+:description: getting started tutorial - declare business variables
 
 For your process to perform operations on business data such as the classic create, read, update and delete operations, you'll need to include business variables in your process definition.
 

--- a/modules/getting-started/pages/declare-contracts.adoc
+++ b/modules/getting-started/pages/declare-contracts.adoc
@@ -1,6 +1,7 @@
 = Declare contracts
-:description: getting started tutorial - declare contracts
 :page-aliases: ROOT:declare-contracts.adoc
+:experimental: // activate the 'menu' macro
+:description: getting started tutorial - declare contracts
 
 So far our process defines a sequences of events and tasks, and declares a business variable that it will instantiate and update when executed.
 

--- a/modules/getting-started/pages/define-business-data-model.adoc
+++ b/modules/getting-started/pages/define-business-data-model.adoc
@@ -1,6 +1,7 @@
 = Define business data model (BDM)
-:description: getting started tutorial - define business data model
 :page-aliases: ROOT:define-business-data-model.adoc
+:experimental: // activate the 'menu' macro
+:description: getting started tutorial - define business data model
 
 The Bonita platform provides a means to define, manipulate and store your business data. This data management service will create Java objects to allow data manipulation, database tables for storage, and all operations required to get the data from your process into the database and vice versa.
 

--- a/modules/getting-started/pages/define-who-can-do-what.adoc
+++ b/modules/getting-started/pages/define-who-can-do-what.adoc
@@ -1,6 +1,7 @@
 = Define who can do what
-:description: getting started tutorial - define who can do what
 :page-aliases: ROOT:define-who-can-do-what.adoc
+:experimental: // activate the 'menu' macro
+:description: getting started tutorial - define who can do what
 
 Up to this point, when you execute the process you are acting as a single user (username: _walter.bates_, password: _bpm_) who can perform all user tasks. In a scenario closer to a real life use case, there are different types of users: customers (who can submit claims), employees (who answer claims) and the manager of the user who provides the answer (who interacts with unsatisfied customers).
 

--- a/modules/getting-started/pages/draw-bpmn-diagram.adoc
+++ b/modules/getting-started/pages/draw-bpmn-diagram.adoc
@@ -1,6 +1,7 @@
 = Start building an application: draw a BPMN process diagram
-:description: getting started tutorial - draw a BPMN process diagram
 :page-aliases: ROOT:draw-bpmn-diagram.adoc
+:experimental: // activate the 'menu' macro
+:description: getting started tutorial - draw a BPMN process diagram
 
 Now that you have your development environment (i.e. Bonita Studio) up and running, you are ready to start building your first Bonita Living Application.
 

--- a/modules/identity/pages/profile-creation.adoc
+++ b/modules/identity/pages/profile-creation.adoc
@@ -7,7 +7,7 @@
 
 == Definition
 
-=== Fonctional
+=== Functional
 
 Profiles work as permissions to give access to xref:ROOT:applications.adoc[Living Applications]
 


### PR DESCRIPTION
The experimental AsciiDoc attribute had been removed accidentally.
Probably because it wasn't clear for people who don't know AsciiDoc a lot that
it activates the menu macro.

### Context
See https://docs.antora.org/antora/2.3/asciidoc/ui-macros/#set-the-experimental-attribute
Erroneous removals: #1643 and #1644
cc @NathalieC 


### Rendering changes

For instance, in `bonita/2021.2/getting-started/configure-email-connector`

before | after
-------- | -------
![image](https://user-images.githubusercontent.com/27200110/142180249-9007841f-878a-4ae2-9fa9-c4d5c90ee522.png) | ![image](https://user-images.githubusercontent.com/27200110/142180427-252f3c71-0037-49be-abe5-00f08e4a203d.png)
 
