### PR TITLE
fix(custom-deployment): remove extra warning block

### DIFF
--- a/modules/runtime/pages/custom-deployment.adoc
+++ b/modules/runtime/pages/custom-deployment.adoc
@@ -55,9 +55,6 @@ Some configuration files from the bundle will overwrite some default tomcat conf
 with care in a tomcat where other applications are already installed.
 ====
 
-[WARNING]
-====
-
 === Data sources configuration
 
 . Open the file `TOMCAT_DIRECTORY/conf/Catalina/localhost/bonita.xml`


### PR DESCRIPTION
The last merge introduced a malformed warning block (unterminated admonition
block). It broke the rendering of the end of the page.


### Screenshots

before | after
------- | -------
![before_fix](https://user-images.githubusercontent.com/27200110/141970702-465bf129-24cd-43c3-a1a3-39635c787405.png) | ![after_fix](https://user-images.githubusercontent.com/27200110/141970736-de40ac04-d442-4ef9-8e90-2eb663525779.png)
 
