### PR TITLE
fix(create a connector): wrong trailing char for first command and ex…

### DIFF
--- a/modules/process/pages/connector-archetype.adoc
+++ b/modules/process/pages/connector-archetype.adoc
@@ -59,6 +59,8 @@ A folder named _[your artifact id]_ is created, with your Bonita connector proje
 ====
 You can avoid the interactive mode by specifying all properties of your project directly in the command line, but by doing that you'll bypass the validation performed on the properties content.
 
+Example
+
 [source,bash]
 ----
 mvn -B archetype:generate \

--- a/modules/process/pages/connector-archetype.adoc
+++ b/modules/process/pages/connector-archetype.adoc
@@ -19,8 +19,8 @@ To create your connector project, prompt a terminal and enter the following comm
 
 [source,bash]
 ----
-mvn archetype:generate /
-  -DarchetypeGroupId=org.bonitasoft.archetypes /
+mvn archetype:generate \
+  -DarchetypeGroupId=org.bonitasoft.archetypes \
   -DarchetypeArtifactId=bonita-connector-archetype
 ----
 
@@ -58,6 +58,21 @@ A folder named _[your artifact id]_ is created, with your Bonita connector proje
 [TIP]
 ====
 You can avoid the interactive mode by specifying all properties of your project directly in the command line, but by doing that you'll bypass the validation performed on the properties content.
+
+[source,bash]
+----
+mvn -B archetype:generate \
+  -DarchetypeGroupId=org.bonitasoft.archetypes \
+  -DarchetypeArtifactId=bonita-connector-archetype \
+  -DgroupId=com.acme.bonita.connectors \
+  -DartifactId=ACME-bonita-connectors \
+  -Dversion=1.0-SNAPSHOT \
+  -Dpackage=com.acme.bonita.connectors \
+  -DbonitaVersion=7.13.0 \
+  -DclassName=SAPMultiFunction \
+  -Dlanguage=java \
+  -Dwrapper=true
+----
 ====
 
 == Connector development


### PR DESCRIPTION
- wrong / trailing char replaced with \
- all properties specified on the command line example
