### PR TITLE
Update multi-tenancy-and-tenant-configuration.adoc

### DIFF
--- a/modules/ROOT/pages/multi-tenancy-and-tenant-configuration.adoc
+++ b/modules/ROOT/pages/multi-tenancy-and-tenant-configuration.adoc
@@ -10,7 +10,8 @@ but it will not be offered to new customers, nor offered as a modification for e
 
 [IMPORTANT]
 ====
-As mentioned in the release note, Bonita Enterprise customers need a contractual agreement to create additional tenants. For any new tenant creation, any general or contractual question related to Multi-tenancy, please contact your customer success representative.
+As mentioned in the release note, Bonita Enterprise customers need a contractual agreement to create additional tenants. +
+For any new tenant creation, any general or contractual question related to Multi-tenancy, please contact your customer success representative.
 ====
 
 For customers already in a multi-tenant architecture:

--- a/modules/ROOT/pages/multi-tenancy-and-tenant-configuration.adoc
+++ b/modules/ROOT/pages/multi-tenancy-and-tenant-configuration.adoc
@@ -3,7 +3,8 @@
 
 [WARNING]
 ====
-This feature was deprecated in Bonita 2021.1. This means that Multi-tenant architecture will continue to work in Bonita for existing Bonita subscription customers,
+This feature is deprecated. +
+This means that Multi-tenant architecture will continue to work in Bonita for existing Bonita subscription customers,
 but it will not be offered to new customers, nor offered as a modification for existing Bonita subscription customers who are not already using multi-tenancy.
 ====
 

--- a/modules/ROOT/pages/multi-tenancy-and-tenant-configuration.adoc
+++ b/modules/ROOT/pages/multi-tenancy-and-tenant-configuration.adoc
@@ -1,16 +1,26 @@
 = Multi-tenant configuration for a Bonita platform
-:description: (Deprecated). One single platform to admininstrate with multiple logical engines. Described what a Tenant is and how to setup Bonita with Multi-tenancy.
+:description: (Deprecated). One single platform to administrate with multiple logical engines. Described what a Tenant is and how to setup Bonita with Multi-tenancy.
 
 [WARNING]
 ====
-
-Starting with Bonita 2021.1, this feature is *deprecated*, and as such, not offered to new customers nor as a Subscription modification for existing customers. +
-We strongly recommend to use multiple instances of Bonita Runtime for every separate entity, or to subscribe to Bonita Cloud with as many Runtimes as there are required entities. By entities, we mean either different end-customers, or different internal departments/subsidiaries. +
-Such a multi-platforms approach allows:
-
-* a specific configuration, independant software versions, infrastructure resources (CPU, memory, disk) and platform lifecycle for each platform (increased flexibility, customization capacities)
-* the physical segregation of resources and data (increased security)
-* the possibility to split public/private Cloud instances
-
-*Support is still provided for customers who already use a multi-tenant architecture for their Bonita on-premises installation*.
+This feature was deprecated in Bonita 2021.1. This means that Multi-tenant architecture will continue to work in Bonita for existing Bonita subscription customers,
+but it will not be offered to new customers, nor offered as a modification for existing Bonita subscription customers who are not already using multi-tenancy.
 ====
+
+[IMPORTANT]
+====
+As mentioned in the release note, Bonita Enterprise customers need a contractual agreement to create additional tenants. For any new tenant creation, any general or contractual question related to Multi-tenancy, please contact your customer success representative.
+====
+
+For customers already in a multi-tenant architecture:
+
+* *Support is provided*, and it will be provided as long as the feature is not removed from Bonita.
+
+For customers considering a multi-tenant architecture:
+
+ * Multi Tenancy being deprecated, current Bonitasoft's official recommendation is to use multiple instances of Bonita Runtime for every separate entity, or to subscribe to *Bonita Cloud* with as many Runtimes as there are required entities. By entities, we mean either different end-customers, or different internal departments/subsidiaries. Such a multi-runtime approach allows:
+
+** a specific configuration, independent software versions, infrastructure resources (CPU, memory, disk) and platform lifecycle for each platform (increased flexibility, customization capacities)
+** the physical segregation of resources and data (increased security)
+** the possibility to split public/private Cloud instances
+


### PR DESCRIPTION
Multi-tenancy is deprecated at Bonita starting from version 2021.1, hence it should be reflected in the documentation with : 
- a warning message informing that the feature is deprecated but still supported
- an error message informing that the feature is not for free even for customers
- by removing the tenant creation procedure

For version 7.10 and 7.11 we have to display the warning and error but keep the procedure - > dedicated PR for it #1846 
