### PR TITLE
fix(deleteDocumentContent): fix example

### DIFF
--- a/modules/ROOT/pages/handling-documents.adoc
+++ b/modules/ROOT/pages/handling-documents.adoc
@@ -181,7 +181,7 @@ def deleteArchivedDocumentsOlderThan(ProcessAPI processAPI, long archivedDate) {
 	def searchResult = searchArchivedDocumentsOlderThanArchivedDate(processAPI, archivedDate, startIndex, maxResults)
 	while(searchResult.count > 0){
 		searchResult.result.each { archivedDocument ->
-			processAPI.deleteContentOfArchivedDocument(archivedDocument.contentStorageId.toLong());
+			processAPI.deleteContentOfArchivedDocument(archivedDocument.getId());
 		}
 		startIndex += maxResults
 		searchResult = searchArchivedDocumentsOlderThanArchivedDate(processAPI, archivedDate, startIndex, maxResults)


### PR DESCRIPTION
The processAPI.deleteContentOfArchivedDocument() method expects 
--> the id of the archived document: archiveDocument.getId() = id of element in ARCH_DOCUMENT_MAPPING table
--> and NOT the id of the document content: archiveDocument.contentStorageId = id of the document content in DOCUMENT table

Versions: 7.11, 2021.1, 2021.2
