### PR TITLE
chore: add github workflow to check PR title and body

### DIFF
--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -8,9 +8,6 @@ jobs:
   check-for-cc:
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
       - name: check-for-cc
         id: check-for-cc
         uses: agenthunt/conventional-commit-checker-action@v1.0.0

--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -1,0 +1,18 @@
+name: Commit Message format check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-for-cc:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: check-for-cc
+        id: check-for-cc
+        uses: agenthunt/conventional-commit-checker-action@v1.0.0
+        with:
+          pr-body-regex: '(.*\n*)+(.*)'


### PR DESCRIPTION
We document what the title and body should be but this is not also followed.
This workflow adds a failed status to the PR to remind everybody to follow the
guidelines.

**Note**: the worfklow definition is copied from https://github.com/bonitasoft/bonita-documentation-site/blob/35e5eaa92578676a80ae7e946d9681b946f56b38/.github/workflows/commit-message-check-format.yml and is known to work.
See also https://github.com/bonitasoft/bonita-documentation-site/pull/289