### PR TITLE
feat(2021.2): activate pagination links in all pages

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,6 +8,7 @@ asciidoc:
     javadocVersion: 7.13
     crowdinBonitaVersion: 7.13
     # page attributes
+    page-pagination: true # display links to previous/next pages at the bottom of the page
     page-editable: true
     page-out-of-support: false
 nav:


### PR DESCRIPTION
I propose to add the links to all pages starting from 2021.2 as in this version, the taxonomy has been reordered and the content refreshed for a more guided tour.

It is possible to apply the changes to 

- a previous version
- to a subset of pages (but this requires more configuration)
- to the whole documentation site

Please let me know by posting a comment.

closes https://github.com/bonitasoft/bonita-documentation-site/issues/273


### Initial proposal

Bottom of https://bonitasoft-bonita-doc-build_preview-pr-1877.surge.sh/bonita/2021.2/release-notes

**_light theme_**
![image](https://user-images.githubusercontent.com/27200110/148072106-a830abc4-e63a-4b63-8914-1a916aadca8b.png)

**_dark theme_**
![image](https://user-images.githubusercontent.com/27200110/148163469-c40d2443-a534-42f0-9dda-36a56b944afc.png)

