### PR TITLE
feat(logger): add info on how to activate old sysout log

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -43,7 +43,7 @@ https://logging.apache.org/log4j/2.x/log4j-jul/index.html[here]
 
 If you want to continue using the previous log format, the previous pattern is present in the `log4j2-appenders.xml` file but commented out.
 
-The Tomcat bundle does not log anymore in the console but only in `bonita.log` file. The previous behavior can be activated by activating the `Console` appender in `log4j2-appenders.xml`
+The Tomcat bundle does not log anymore in the console but only in `bonita.log` file. The previous behavior can be activated by setting the system property `-Dbonita.runtime.logger.sysout=Console` in tomcat's `setEnv.sh`
 ====
 
 === Docker image


### PR DESCRIPTION
In 2022.1, we will not log by default in system out. To revert back to
the old behavior there is a system property that can be set as explained
here.

Relates to
[RUNTIME-795](https://bonitasoft.atlassian.net/browse/RUNTIME-795)
