### PR TITLE
doc: Bonita 7.10 is out of support

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -5,6 +5,6 @@ asciidoc:
   attributes:
     varVersion: "7.10"
     page-editable: true
-    page-out-of-support: false
+    page-out-of-support: true
 nav:
   - modules/ROOT/taxonomy.adoc


### PR DESCRIPTION
* Since 5 december, Bonita 7.10 is out-of-support

