### PR TITLE
doc(REST): troubleshooting section for the content-range header

### DIFF
--- a/modules/ROOT/pages/rest-api-overview.adoc
+++ b/modules/ROOT/pages/rest-api-overview.adoc
@@ -353,3 +353,13 @@ If the HTTP response's status is `401 Unauthorized`:
 * if one of the PUT, DELETE or POST method is used, make sure that the `X-Bonita-API-Token` header is included
 * if the X-Bonita-API-Token header is included, make sure that the value is the same as the one of the cookie generated during the last login
 * Maybe a logout was issued or the session has expired; try to log in again, and re run the request with the new cookies and the new value for the `X-Bonita-API-Token` header.
+
+===== HTTP/1.1 416 Content Range Not Satisfiable
+
+If the HTTP response's status is `416 Range Not Satisfiable`:
+
+This error can happen on xref:#resource_search[search requests] with pagination when a firewall is blocking the response.
+Bonita REST API is using the `content-range` response headers to return pagiunation information and some firewalls may block this usage.
+
+* If you have a firewall with an option "Allow HTTP partial response" in its configuration, make sure it is enabled at least for you Bonita runtime server address.
+* Make sure your firewall or your reverse proxy doesn't have any other option that could block this response header

--- a/modules/ROOT/pages/rest-api-overview.adoc
+++ b/modules/ROOT/pages/rest-api-overview.adoc
@@ -342,9 +342,9 @@ $  curl -b saved_cookies.txt -X POST --url 'http://localhost:8080/bonita/API/bpm
 $ curl -b saved_cookies.txt -X GET --url 'http://localhost:8080/bonita/logoutservice?redirect=false'
 ----
 
-==== Troubleshooting
+== Troubleshooting
 
-===== HTTP/1.1 401 Unauthorized
+=== HTTP/1.1 401 Unauthorized
 
 If the HTTP response's status is `401 Unauthorized`:
 
@@ -354,7 +354,7 @@ If the HTTP response's status is `401 Unauthorized`:
 * if the X-Bonita-API-Token header is included, make sure that the value is the same as the one of the cookie generated during the last login
 * Maybe a logout was issued or the session has expired; try to log in again, and re run the request with the new cookies and the new value for the `X-Bonita-API-Token` header.
 
-===== HTTP/1.1 416 Content Range Not Satisfiable
+=== HTTP/1.1 416 Content Range Not Satisfiable
 
 If the HTTP response's status is `416 Range Not Satisfiable`:
 

--- a/modules/ROOT/pages/rest-api-overview.adoc
+++ b/modules/ROOT/pages/rest-api-overview.adoc
@@ -359,7 +359,7 @@ If the HTTP response's status is `401 Unauthorized`:
 If the HTTP response's status is `416 Range Not Satisfiable`:
 
 This error can happen on xref:#resource_search[search requests] with pagination when a firewall is blocking the response.
-Bonita REST API is using the `content-range` response headers to return pagiunation information and some firewalls may block this usage.
+Bonita REST API is using the `content-range` response headers to return pagination information and some firewalls may prevent this usage.
 
 * If you have a firewall with an option "Allow HTTP partial response" in its configuration, make sure it is enabled at least for you Bonita runtime server address.
 * Make sure your firewall or your reverse proxy doesn't have any other option that could block this response header


### PR DESCRIPTION
* add troubleshooting section for the 416 error when the content-range header is blocked by some firewalls

Covers [RUNTIME-821](https://bonitasoft.atlassian.net/browse/RUNTIME-821)