### PR TITLE
feat(runtime): add info about connector failure retry change

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -65,7 +65,7 @@ If they want to reuse the configuration in a custom manner or upgrade to Enterpr
 === Other changes
 
 === Connector Retry
-When the engine fails to evaluate output operations of a connector, the connector is no more automatically retried. It could be an issue to re-execute a connector because, connectors might have side effects. It is the choice of the administrator of the platform to re-execute the connector or not. See xref:runtime:connectors-execution.adoc[documentation about connector execution] for details about connector failure and replay.
+When the engine fails to evaluate output operations of a connector, the connector is no more automatically retried. It could be an issue to re-execute a connector because connectors might have side effects. It is the choice of the administrator of the platform to re-execute the connector or not. See xref:runtime:connectors-execution.adoc[documentation about connector execution] for details about connector failure and replay.
 
 == Technical updates
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -62,6 +62,11 @@ For Community users who update to 2022.1, dynamic authorization checking does no
 However, the configuration stays unchanged, even if it is not used anymore. +
 If they want to reuse the configuration in a custom manner or upgrade to Enterprise edition, the configuration will be back there and fully functional.
 
+=== Other changes
+
+=== Connector Retry
+When the engine fails to evaluate output operations of a connector, the connector is no more automatically retried. It is put as failed to avoid automatic re-execution.
+
 == Technical updates
 
 ===  Log4j2 Logger

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -65,7 +65,7 @@ If they want to reuse the configuration in a custom manner or upgrade to Enterpr
 === Other changes
 
 === Connector Retry
-When the engine fails to evaluate output operations of a connector, the connector is no more automatically retried. It is put as failed to avoid automatic re-execution.
+When the engine fails to evaluate output operations of a connector, the connector is no more automatically retried. It could be an issue to re-execute a connector because, connectors might have side effects. It is the choice of the administrator of the platform to re-execute the connector or not. See xref:runtime:connectors-execution.adoc[documentation about connector execution] for details about connector failure and replay.
 
 == Technical updates
 


### PR DESCRIPTION
We do no try to retry connector evaluation outputs that can lead to wild connector re-execution.

I've put it in a section "other changed", because it's a small thing. I don't know if its a good idea 🤷
