### PR TITLE
doc(context): impact of multi-instance on context

### DIFF
--- a/modules/data/pages/contracts-and-contexts.adoc
+++ b/modules/data/pages/contracts-and-contexts.adoc
@@ -99,8 +99,12 @@ When generating a Form from a contract, a Text widget is created to display erro
 
 == Context
 
-To display contextual information of the task or the process instance in a form, you can leverage the business data and document references made publicly available through the context. The notion of context is available at two levels : process instance and human task. The context is a list of references to the business data and documents manipulated by the process instance during its execution.
-Currently, context is the same for a human task and its process instance. All the business data and documents defined are public.
+To display contextual information of the task or the process instance in a form, you can leverage the business data and document references made publicly available through the context. The notion of context is available at two levels : process instance and human task. The context is a list of references to the business data and documents manipulated by the process instance during its execution. All the business data and documents defined are public.  
+
+Most of the time, context is the same for a human task and its process instance. The human task context contains more information when the task is multi-instantiated based on a Multiple<Business Object>:   
+You will find a "multiInstanceIterator_ref" that points to the business object in the collection that has been used to create the multi-instance. 
+
+This is usefull when designing the form to know on which child instance of the multi-instantiation the form will be displayed (to display the right contextual information).
 
 Limitation : there is currently no way to customize which business data or document are public in Community edition. When using an Enterprise edition, you may want to use the xref:identity:bdm-access-control.adoc[BDM Access Control] to protect data access.
 


### PR DESCRIPTION
Explain that the UserTask context contains more information in case of a multi-instantiation. The extra data gives the reference of the object in the collection that has been used to create the multi-instance. 
Usually, as a UserTask is created for each element in the collection, we want to display that element in the Form. That is why we need to know the value of the iterator for the specific task instance we are currently displaying (the form is context aware).