### PR TITLE
fix(formatting): fix docker-compose source sample

### DIFF
--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -150,7 +150,7 @@ docker run --name bonita_postgres -h <hostname> -v bonita-lic:/opt/bonita_lic/ -
 
 Create a file `docker-compose.yml` with the following content
 
-[source,yaml]
+[source,yaml,subs="+macros"]
 ----
 # Use tech_user/secret as user/password credentials
 version: '3'
@@ -188,9 +188,9 @@ services:
       - |
         set -e
         echo 'Waiting for Postgres to be available'
-        export PGPASSWORD=$${POSTGRES_ENV_POSTGRES_PASSWORD}
+        export PGPASSWORD=\$${POSTGRES_ENV_POSTGRES_PASSWORD}
         maxTries=10
-        while [[ "$$maxTries" -gt 0 ]] && ! psql -h $${DB_HOST} -U 'postgres' -c '\l'; do
+        while [[ "$$maxTries" -gt 0 ]] && ! psql -h \$${DB_HOST} -U 'postgres' -c '\l'; do
             let maxTries--
             sleep 1
         done
@@ -203,6 +203,7 @@ services:
 
 * Replace `<hostname>` with the one used in the licence generation command
 * Replace `~/bonita-lic` with the folder containing the license (on Windows use `/` and avoid `~`)
+* leave double `$$` untouched
 
 Run `docker-compose up`, wait for it to initialize completely, and visit `+http://localhost:8080+`, or `+http://host-ip:8080+` (as appropriate).
 


### PR DESCRIPTION
`pass:a[{bonitaVersion}]` did not display well without `subs="+macros"`