### PR TITLE
docs(web): Fix errors in the Getting Started (2021.1)

### DIFF
--- a/modules/ROOT/pages/define-business-data-model.adoc
+++ b/modules/ROOT/pages/define-business-data-model.adoc
@@ -32,7 +32,7 @@ image:images/getting-started-tutorial/define-business-data-model/define-business
 image:images/getting-started-tutorial/define-business-data-model/create-business-object-with-attributes.gif[Create business object with attributes]
 // {.img-responsive .img-thumbnail}
 
-. Click on *Finish* button
+. Click on *Deploy* button
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/define-business-data-model.adoc
+++ b/modules/ROOT/pages/define-business-data-model.adoc
@@ -21,9 +21,9 @@ In Bonita Studio, create a BDM:
 image:images/getting-started-tutorial/define-business-data-model/define-business-data-model-menu.png[Define business data model menu]
 // {.img-responsive .img-thumbnail}
 
-. Click on *Add* button
+. Click on *Add Object* button
 . Type the object name _Claim_ (objects name must always start with an uppercase letter)
-. In the *Attributes* tab, click on *Add* button
+. In the *Attributes* table, click on *Add* button
 . Add 3 attributes (attributes name must always start with a lowercase letter):
 . _description_ of type _STRING_ and _mandatory_ (check the checkbox in the *mandatory* column)
 . _answer_ of type _STRING_, _optional_
@@ -57,7 +57,7 @@ When you click on the "Finish" button three different operations are performed:
 
 ====
 
-Now you have a fully functional business data management model. You are ready to move to the next chapter and xref:declare-business-variables.adoc[start populating the database with data collected by the process].
+Now you have a fully functional business data model. You are ready to move to the next chapter and xref:declare-business-variables.adoc[start populating the database with data collected by the process].
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/define-who-can-do-what.adoc
+++ b/modules/ROOT/pages/define-who-can-do-what.adoc
@@ -135,6 +135,6 @@ import org.bonitasoft.engine.search.SearchResult
 image:images/getting-started-tutorial/define-who-can-do-what/configure-user-manager-actor-filter.gif[Configure user manager actor filter for manager lane]
 // {.img-responsive .img-thumbnail}
 
-Run the process again, and this time only _mauro.zetticci_ should have access to _Read the answer and rate it_ and only _michael.morrison_ should have access to _Deal with unsatisfied customer_ (as the manager of both users who can complete the task _Review and answer claim_).
+Run the process again, and this time only _mauro.zetticci_ should have access to _Review and answer claim_ and only _michael.morrison_ should have access to _Deal with unsatisfied customer_ (as the manager of both users who can complete the task _Review and answer claim_).
 
 Now we have a fully customized process that processes data and dispatches tasks to appropriate users. The xref:configure-email-connector.adoc[next step] will be to make this process interact with the outside world.


### PR DESCRIPTION
Fix errors in the Getting Started tutorial. 

Here's a report of what I changed in the PR :
- ~In https://documentation.bonitasoft.com/bonita/2021.1/draw-bpmn-diagram ->  Dead link: https://www.bonitasoft.com/library/ultimate-guide-bpmn , I change it with the one working.~  already available in the 2021.1 branch

- In https://documentation.bonitasoft.com/bonita/2021.1/define-business-data-model ->  Step 9 : Finish button don’t exist in the UI. I do believe it’s supposed to say “Deploy” because first time I didnt deploy the BDM and I couldn’t use the application with the business data. It can be confusing. 

- In https://documentation.bonitasoft.com/bonita/2021.1/define-who-can-do-what , end of article, the sentence “Run the process again, and this time only mauro.zetticci should have access to Read the answer and rate it” is wrong. This is not the task Read the answer and rate it but Review and answer claim who should be mark on the doc.