### PR TITLE
fix(cas): rephrase jaasAuthenticationService addition

### DIFF
--- a/modules/ROOT/pages/single-sign-on-with-cas.adoc
+++ b/modules/ROOT/pages/single-sign-on-with-cas.adoc
@@ -89,8 +89,10 @@ If the platform has already been initialized, every update to the configuration 
 * `setup push`
 ====
 +
- .. Remove the comment flags from these lines:
-`authentication.service.ref.name=jaasAuthenticationService`
+ .. You must perform following changes:
+
+* Comment out the `authentication.service.ref.name=authenticationService` line
+* Add this new line: `authentication.service.ref.name=jaasAuthenticationService`
  .. *Optionally*, to enable xref:guest-user.adoc[guest user access], uncomment this lines:
 +
 ----

--- a/modules/ROOT/pages/single-sign-on-with-cas.adoc
+++ b/modules/ROOT/pages/single-sign-on-with-cas.adoc
@@ -89,7 +89,7 @@ If the platform has already been initialized, every update to the configuration 
 * `setup push`
 ====
 +
- .. You must perform following changes:
+ .. You must perform the following changes:
 
 * Comment out the `authentication.service.ref.name=authenticationService` line
 * Add this new line: `authentication.service.ref.name=jaasAuthenticationService`


### PR DESCRIPTION
* Configuration file template has changed, but not the documentation. 
* Instead of uncommenting a line, now the user must replace manually the string themselves.
