### PR TITLE
feat(rest_api_authentication): added a Rest API POST example

### DIFF
--- a/modules/ROOT/pages/rest-api-authentication.adoc
+++ b/modules/ROOT/pages/rest-api-authentication.adoc
@@ -76,6 +76,13 @@ Let's list processes from the API by providing authentication information.
 $ curl -b saved_cookies.txt -X GET --url 'http://localhost:8080/bonita/API/bpm/process?c=100&p=0'
 ----
 
+Let's create a new 'Create supplier' process instance (from Studio example "Procurement") by providing the X-Bonita-API-Token header, the required body and the 'Create supplier' id (modify 5975558489041216684 by the Process ID of your environment, given in output from the previous curl command above).
+
+[source,bash]
+----
+ $ curl -b saved_cookies.txt -X POST -H "Content-Type: application/json" --header 'X-Bonita-API-Token: 2f86dcab-9b54-45e6-8eb1-f82c2a2f8e25' --data '{"supplierInput":{"name":"My supplier","description":"This is the best supplier"}}' --url "http://localhost:8080/bonita/API/bpm/process/5975558489041216684/instantiation"
+----
+
 == Logout from Bonita
 
 When processing is complete, you must log out.


### PR DESCRIPTION
It appears a 'POST' example is required, since the usage of the X-Bonita-API-Token can be confusing (need to be twice in the header: in the Cookie key and also in a dedicated X-Bonita-API-Token key.
Moreover, it can be also useful to show the body content.
The example is from the (delivered) Procurement example.