### PR TITLE
fix(OIDC): fix group path

### DIFF
--- a/modules/identity/pages/single-sign-on-with-oidc.adoc
+++ b/modules/identity/pages/single-sign-on-with-oidc.adoc
@@ -115,7 +115,7 @@ Make sure to xref:ROOT:multi-tenancy-and-tenant-configuration.adoc[set the right
 
          # Create users on the fly, when they are missing from bonita but authenticated by the SSO. The user will belong to the group and role specified below.
          #authentication.passphraseOrPasswordAuthenticationService.createMissingUser.enable=true
-         #authentication.passphraseOrPasswordAuthenticationService.createMissingUser.defaultMembershipGroupPath=/ACME/HR
+         #authentication.passphraseOrPasswordAuthenticationService.createMissingUser.defaultMembershipGroupPath=/acmr/hr
          #authentication.passphraseOrPasswordAuthenticationService.createMissingUser.defaultMembershipRoleName=member
 
          # CAS authentication delegate : enables the user, providing login/password,


### PR DESCRIPTION
example with automatic user création doesn't work with default ACME organization
path is lower case
