### PR TITLE
feat(OIDC): tomcat config with reverse proxy

### DIFF
--- a/modules/identity/pages/single-sign-on-with-oidc.adoc
+++ b/modules/identity/pages/single-sign-on-with-oidc.adoc
@@ -208,8 +208,8 @@ Note that if you try to access `http://<bundle host>:<port>/bonita/login.jsp`, t
 ====
 
 If your Bonita platform is behind a reverse proxy or a load balancer, You need to make sure : +
-- the reverse proxy / load balancer is configured to include to the requests the correct headers for the host and the protocol (for example if the proxy / load balancer is in charge of the SSL/HTTPS layer) +
-- the application server is configured to use these headers (it is usually the case by default fot yhe `Host` header) +
+- the reverse proxy / load balancer is configured to include to the requests the correct headers for the host and  for the protocol (typically if the proxy / load balancer is in charge of the SSL/HTTPS layer) +
+- the application server is configured to use these headers (it is usually the case by default for the `Host` header) +
 This is required so that `HttpServletRequest.getRequestURL` returns the URL used by the user and not the internal URL used by the reverse proxy. So if redirect_uri` query param is not right in the OIDC provider 302 redirect response, it is likely that this configuration is missing. +
 For example, if you are running Apache >=2.0.31 as reverse proxy, this configuration is controlled by the property http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#proxypreservehost[ProxyPreserveHost] that will override the `Host:` header. +
 This can also be achieved by configuring the load balancer / reverse proxy so that it sets the `X-Forwarded-` HTTP headers. For example :
@@ -217,7 +217,7 @@ This can also be achieved by configuring the load balancer / reverse proxy so th
     X-Forwarded-Proto: https
     X-Forwarded-Host: your.bonita.external.url.host
 ----
-In order for Tomcat server to use those headers, you can use Tomcat's RemoteIpValve. In order to do that, edit `<BUNDLE_HOME>/server/conf/server.xml` to add:
+In order for Tomcat server to use those headers, you can use Tomcat's RemoteIpValve. Edit `<BUNDLE_HOME>/server/conf/server.xml` to add:
 [source,xml]
 ----
    <Valve className="org.apache.catalina.valves.RemoteIpValve"

--- a/modules/identity/pages/single-sign-on-with-oidc.adoc
+++ b/modules/identity/pages/single-sign-on-with-oidc.adoc
@@ -207,16 +207,36 @@ Note that if you try to access `http://<bundle host>:<port>/bonita/login.jsp`, t
 [WARNING]
 ====
 
-If your Bonita platform is behind a reverse proxy or a load balancer, You need to make sure the reverse proxy / load balancer is configured
-to include the correct headers for the host (and the protocol if needed) to the requests and the application server is configured to use these headers (it is usually the case by default). +
-This is required so that `HttpServletRequest.getRequestURL` returns the URL used by the user and not the internal URL used by the reverse proxy. +
+If your Bonita platform is behind a reverse proxy or a load balancer, You need to make sure :
+* the reverse proxy / load balancer is configured to include the correct headers for the host and the protocol (for example if the proxy / load balancer is in charge of the SSL/HTTPS layer) to the requests 
+* the application server is configured to use these headers (it is usually the case by default fot yhe `Host` header). +
+This is required so that `HttpServletRequest.getRequestURL` returns the URL used by the user and not the internal URL used by the reverse proxy. So if redirect_uri` query param is not right in the OIDC provider 302 redirect response, it is likely that this configuration is missing.+
 For example, if you are running Apache >=2.0.31 as reverse proxy, this configuration is controlled by the property http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#proxypreservehost[ProxyPreserveHost] that will override the `Host:` header. +
 This can also be achieved by configuring the load balancer / reverse proxy so that it sets the `X-Forwarded-` HTTP headers. For example :
 ----
     X-Forwarded-Proto: https
     X-Forwarded-Host: your.bonita.external.url.host
 ----
-If you need more fine tuning or if you cannot update the reverse proxy configuration, you can consult the official documentation for https://tomcat.apache.org/connectors-doc/common_howto/proxy.html[Tomcat]
+In order for Tomcat server to use those headers, you can use Tomcat's RemoteIpValve. To do that, edit 
+.<BUNDLE_HOME>/server/conf/server.xml
+[source,xml]
+----
+   <Valve className="org.apache.catalina.valves.RemoteIpValve"
+           internalProxies="replace_by_regex_of_iternal_proxies_IPs"
+           remoteIpHeader="x-forwarded-for"
+           remoteIpProxiesHeader="x-forward-by"
+           protocolHeader="x-forwarded-proto"
+           hostHeader="x-forwarded-host"/>
+----
+In addition, you can add some log to diagnose received headers:
+.<BUNDLE_HOME>/server/conf/server.xml
+[source,xml]
+----
+      <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="Proto %{X-Forwarded-Proto}i Host %{X-Forwarded-Host}i For %{X-Forwarded-For}i By %{X-Forwarded-By}i %h %l %u %t &quot;%r&quot; %s %b"/>
+----
+More information can be found in Tomcat offical documentation https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Remote_IP_Valve [Remote_IP_Valve] and https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Access_Log_Valve[Access_Log_Valve]
 ====
 
 == Configure the Identity Provider

--- a/modules/identity/pages/single-sign-on-with-oidc.adoc
+++ b/modules/identity/pages/single-sign-on-with-oidc.adoc
@@ -234,7 +234,7 @@ In addition, you can add some log to diagnose received headers in `<BUNDLE_HOME>
                prefix="localhost_access_log" suffix=".txt"
                pattern="Proto %{X-Forwarded-Proto}i Host %{X-Forwarded-Host}i For %{X-Forwarded-For}i By %{X-Forwarded-By}i %h %l %u %t &quot;%r&quot; %s %b"/>
 ----
-More information can be found in Tomcat offical documentation https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Remote_IP_Valve [Remote_IP_Valve] and https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Access_Log_Valve[Access_Log_Valve]
+More information can be found in Tomcat offical documentation https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Remote_IP_Valve[Remote_IP_Valve] and https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Access_Log_Valve[Access_Log_Valve]
 ====
 
 == Configure the Identity Provider

--- a/modules/identity/pages/single-sign-on-with-oidc.adoc
+++ b/modules/identity/pages/single-sign-on-with-oidc.adoc
@@ -208,17 +208,16 @@ Note that if you try to access `http://<bundle host>:<port>/bonita/login.jsp`, t
 ====
 
 If your Bonita platform is behind a reverse proxy or a load balancer, You need to make sure :
-* the reverse proxy / load balancer is configured to include the correct headers for the host and the protocol (for example if the proxy / load balancer is in charge of the SSL/HTTPS layer) to the requests 
-* the application server is configured to use these headers (it is usually the case by default fot yhe `Host` header). +
-This is required so that `HttpServletRequest.getRequestURL` returns the URL used by the user and not the internal URL used by the reverse proxy. So if redirect_uri` query param is not right in the OIDC provider 302 redirect response, it is likely that this configuration is missing.+
+ * the reverse proxy / load balancer is configured to include to the requests the correct headers for the host and the protocol (for example if the proxy / load balancer is in charge of the SSL/HTTPS layer)
+ * the application server is configured to use these headers (it is usually the case by default fot yhe `Host` header)
+This is required so that `HttpServletRequest.getRequestURL` returns the URL used by the user and not the internal URL used by the reverse proxy. So if redirect_uri` query param is not right in the OIDC provider 302 redirect response, it is likely that this configuration is missing. +
 For example, if you are running Apache >=2.0.31 as reverse proxy, this configuration is controlled by the property http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#proxypreservehost[ProxyPreserveHost] that will override the `Host:` header. +
 This can also be achieved by configuring the load balancer / reverse proxy so that it sets the `X-Forwarded-` HTTP headers. For example :
 ----
     X-Forwarded-Proto: https
     X-Forwarded-Host: your.bonita.external.url.host
 ----
-In order for Tomcat server to use those headers, you can use Tomcat's RemoteIpValve. To do that, edit 
-.<BUNDLE_HOME>/server/conf/server.xml
+In order for Tomcat server to use those headers, you can use Tomcat's RemoteIpValve. To do that, edit `<BUNDLE_HOME>/server/conf/server.xml` to add:
 [source,xml]
 ----
    <Valve className="org.apache.catalina.valves.RemoteIpValve"
@@ -228,8 +227,7 @@ In order for Tomcat server to use those headers, you can use Tomcat's RemoteIpVa
            protocolHeader="x-forwarded-proto"
            hostHeader="x-forwarded-host"/>
 ----
-In addition, you can add some log to diagnose received headers:
-.<BUNDLE_HOME>/server/conf/server.xml
+In addition, you can add some log to diagnose received headers in `<BUNDLE_HOME>/server/conf/server.xml`:
 [source,xml]
 ----
       <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"

--- a/modules/identity/pages/single-sign-on-with-oidc.adoc
+++ b/modules/identity/pages/single-sign-on-with-oidc.adoc
@@ -207,9 +207,9 @@ Note that if you try to access `http://<bundle host>:<port>/bonita/login.jsp`, t
 [WARNING]
 ====
 
-If your Bonita platform is behind a reverse proxy or a load balancer, You need to make sure :
- * the reverse proxy / load balancer is configured to include to the requests the correct headers for the host and the protocol (for example if the proxy / load balancer is in charge of the SSL/HTTPS layer)
- * the application server is configured to use these headers (it is usually the case by default fot yhe `Host` header)
+If your Bonita platform is behind a reverse proxy or a load balancer, You need to make sure : +
+- the reverse proxy / load balancer is configured to include to the requests the correct headers for the host and the protocol (for example if the proxy / load balancer is in charge of the SSL/HTTPS layer) +
+- the application server is configured to use these headers (it is usually the case by default fot yhe `Host` header) +
 This is required so that `HttpServletRequest.getRequestURL` returns the URL used by the user and not the internal URL used by the reverse proxy. So if redirect_uri` query param is not right in the OIDC provider 302 redirect response, it is likely that this configuration is missing. +
 For example, if you are running Apache >=2.0.31 as reverse proxy, this configuration is controlled by the property http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#proxypreservehost[ProxyPreserveHost] that will override the `Host:` header. +
 This can also be achieved by configuring the load balancer / reverse proxy so that it sets the `X-Forwarded-` HTTP headers. For example :
@@ -217,7 +217,7 @@ This can also be achieved by configuring the load balancer / reverse proxy so th
     X-Forwarded-Proto: https
     X-Forwarded-Host: your.bonita.external.url.host
 ----
-In order for Tomcat server to use those headers, you can use Tomcat's RemoteIpValve. To do that, edit `<BUNDLE_HOME>/server/conf/server.xml` to add:
+In order for Tomcat server to use those headers, you can use Tomcat's RemoteIpValve. In order to do that, edit `<BUNDLE_HOME>/server/conf/server.xml` to add:
 [source,xml]
 ----
    <Valve className="org.apache.catalina.valves.RemoteIpValve"

--- a/modules/identity/pages/single-sign-on-with-oidc.adoc
+++ b/modules/identity/pages/single-sign-on-with-oidc.adoc
@@ -210,7 +210,7 @@ Note that if you try to access `http://<bundle host>:<port>/bonita/login.jsp`, t
 If your Bonita platform is behind a reverse proxy or a load balancer, You need to make sure : +
 - the reverse proxy / load balancer is configured to include to the requests the correct headers for the host and  for the protocol (typically if the proxy / load balancer is in charge of the SSL/HTTPS layer) +
 - the application server is configured to use these headers (it is usually the case by default for the `Host` header) +
-This is required so that `HttpServletRequest.getRequestURL` returns the URL used by the user and not the internal URL used by the reverse proxy. So if redirect_uri` query param is not right in the OIDC provider 302 redirect response, it is likely that this configuration is missing. +
+This is required so that `HttpServletRequest.getRequestURL` returns the URL used by the user and not the internal URL used by the reverse proxy. So, if the query parameter `redirect_uri` is not right in the OIDC provider 302 redirect response, it is likely that this configuration is missing. +
 For example, if you are running Apache >=2.0.31 as reverse proxy, this configuration is controlled by the property http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#proxypreservehost[ProxyPreserveHost] that will override the `Host:` header. +
 This can also be achieved by configuring the load balancer / reverse proxy so that it sets the `X-Forwarded-` HTTP headers. For example :
 ----


### PR DESCRIPTION
* When reverse proxy is responsible of the HTTPS part and Tomcat remains in HTTP, a specific config should be added to tomcat to use the correct protocol Header forwarded by the proxy

Co-authored-by: laurentleseigneur <laurent.leseigneur@bonitasoft.com>

This PR is as adaptation of #2018
