### PR TITLE
feat(versions): add the last 2 missing versions

### DIFF
--- a/modules/ROOT/pages/product-versioning.adoc
+++ b/modules/ROOT/pages/product-versioning.adoc
@@ -36,7 +36,7 @@ Here is a Bonita Platform version / Technical Id / UI Designer version correspon
 | 7.12.10
 | 1.12.47
 
-| 2021-11-19
+| 2021-11-16
 | 2021.1-1116
 | 7.12.9
 | 1.12.47

--- a/modules/ROOT/pages/product-versioning.adoc
+++ b/modules/ROOT/pages/product-versioning.adoc
@@ -29,12 +29,12 @@ Here is a Bonita Platform version / Technical Id / UI Designer version correspon
 | 2022-03-07
 | 2021.1-0307
 | 7.12.11
-| 1.12.?
+| 1.12.47
 
 | 2022-02-02
 | 2021.1-0202
 | 7.12.10
-| 1.12.?
+| 1.12.47
 
 | 2021-11-19
 | 2021.1-1116

--- a/modules/ROOT/pages/product-versioning.adoc
+++ b/modules/ROOT/pages/product-versioning.adoc
@@ -26,6 +26,16 @@ Here is a Bonita Platform version / Technical Id / UI Designer version correspon
 |===
 | Release date | Bonita Platform version | Technical Id | UI Designer version
 
+| 2022-03-07
+| 2021.1-0307
+| 7.12.11
+| 1.12.?
+
+| 2022-02-02
+| 2021.1-0202
+| 7.12.10
+| 1.12.?
+
 | 2021-11-19
 | 2021.1-1116
 | 7.12.9


### PR DESCRIPTION
Add the missing versions according to what we already have in the `release-notes` page.

**Information**
Url to test the updated page: https://bonitasoft-bonita-doc-build_preview-pr-2031.surge.sh/bonita/2021.1/product-versioning#_technical_id

Current release notes page at the time of creating this PR

![image](https://user-images.githubusercontent.com/27200110/162403840-2a70498d-3aa0-43c2-b9e9-996ecc65fb03.png)
