### PR TITLE
feat(docker): Update docker install

### DIFF
--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -169,8 +169,10 @@ services:
       - -c
       - max_prepared_transactions=100
   bonita:
-    image: bonita:7.14.0
-    hostname: custom-hostname.example.com
+    image: quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaVersion}]
+    hostname: <hostname>
+    volumes:
+      - ~/bonita-lic:/opt/bonita_lic/
     ports:
       - 8080:8080
     environment:
@@ -187,6 +189,8 @@ services:
       - TENANT_PASSWORD=secret
       - PLATFORM_LOGIN=pfadmin
       - PLATFORM_PASSWORD=pfsecret
+      - MONITORING_USERNAME=monitorAdmin
+      - MONITORING_PASSWORD=monitor_Secr3t-P455w0rD
     restart: on-failure:2
     depends_on:
       - db

--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -145,74 +145,10 @@ You can run the image with the following command:
 
 [source,bash]
 ----
-docker run --name mydbpostgres -h <hostname> -v <your-bonita-license-folder>:/opt/bonita_lic/ -d bonitasoft/bonita-postgres:12.6
+docker run --name mydbpostgres -d bonitasoft/bonita-postgres:12.6
 ----
 
 This image is built from the following https://github.com/Bonitasoft-Community/bonita-database-docker/tree/main/postgres/12[GitHub repository], which can be further adapted/customized to suit your needs.
-
-
-==== Using docker-compose
-
-Create a file `docker-compose.yml` with the following content
-
-[source,yaml,subs="+macros"]
-----
-# Use tech_user/secret as user/password credentials
-version: '3'
-
-services:
-  db:
-    image: postgres:12.6
-    environment:
-      POSTGRES_PASSWORD: example
-    restart: always
-    command:
-      - -c
-      - max_prepared_transactions=100
-  bonita:
-    image: quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaVersion}]
-    hostname: <hostname>
-    volumes:
-      - ~/bonita-lic:/opt/bonita_lic/
-    ports:
-      - 8080:8080
-    environment:
-      - POSTGRES_ENV_POSTGRES_PASSWORD=example
-      - DB_VENDOR=postgres
-      - DB_HOST=db
-      - TENANT_LOGIN=tech_user
-      - TENANT_PASSWORD=secret
-      - PLATFORM_LOGIN=pfadmin
-      - PLATFORM_PASSWORD=pfsecret
-      - MONITORING_USERNAME=monitorAdmin
-      - MONITORING_PASSWORD=monitor_Secr3t-P455w0rD
-    restart: on-failure:2
-    depends_on:
-      - db
-    entrypoint:
-      - bash
-      - -c
-      - |
-        set -e
-        echo 'Waiting for Postgres to be available'
-        export PGPASSWORD=\$${POSTGRES_ENV_POSTGRES_PASSWORD}
-        maxTries=10
-        while [[ "$$maxTries" -gt 0 ]] && ! psql -h \$${DB_HOST} -U 'postgres' -c '\l'; do
-            let maxTries--
-            sleep 1
-        done
-        if [[ "$$maxTries" -le 0 ]]; then
-            echo >&2 'error: unable to contact Postgres after 10 tries'
-            exit 1
-        fi
-        exec /opt/files/startup.sh
-----
-
-* Replace `<hostname>` with the one used in the licence generation command
-* Replace `~/bonita-lic` with the folder containing the license (on Windows use `/` and avoid `~`)
-* leave double `$$` untouched
-
-Run `docker-compose up`, wait for it to initialize completely, and visit `+http://localhost:8080+`, or `+http://host-ip:8080+` (as appropriate).
 
 ==== PostgreSQL as an installed service
 
@@ -241,7 +177,7 @@ docker run --name=bonita -h <hostname> --env-file=env.txt -d -p 8080:8080 quay.i
 
 [source,shell script,subs="+macros"]
 ----
-docker run --name=bonita -v bonita-lic:/opt/bonita_lic/ -h <hostname> -e "TENANT_LOGIN=tech_user" -e "TENANT_PASSWORD=secret" -e "PLATFORM_LOGIN=pfadmin" -e "PLATFORM_PASSWORD=pfsecret" -e "MONITORING_USERNAME=monitorAdmin" -e "MONITORING_PASSWORD=monitor_Secr3t-P455w0rD" -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaVersion}]
+docker run --name=bonita -v ~/bonita-lic:/opt/bonita_lic/ -h <hostname> -e "TENANT_LOGIN=tech_user" -e "TENANT_PASSWORD=secret" -e "PLATFORM_LOGIN=pfadmin" -e "PLATFORM_PASSWORD=pfsecret" -e "MONITORING_USERNAME=monitorAdmin" -e "MONITORING_PASSWORD=monitor_Secr3t-P455w0rD" -d -p 8080:8080 quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaVersion}]
 ----
 
 Now you can access the Bonita Runtime on localhost:8080/bonita and login using: tech_user / secret
@@ -253,7 +189,7 @@ But for specific needs you can override this behavior by setting HTTP_API to tru
 
 [source,shell script,subs="+macros"]
 ----
-docker run -e HTTP_API=true -e HTTP_API_PASSWORD=S0me-h11p-s3cr3t -e BONITA_RUNTIME_AUTHORIZATION_DYNAMICCHECK_ENABLED=false --name bonita -v bonita-lic:/opt/bonita_lic/ -h <hostname> -d -p 8080:8080  quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaVersion}]
+docker run -e HTTP_API=true -e HTTP_API_PASSWORD=S0me-h11p-s3cr3t -e BONITA_RUNTIME_AUTHORIZATION_DYNAMICCHECK_ENABLED=false --name bonita -v ~/bonita-lic:/opt/bonita_lic/ -h <hostname> -d -p 8080:8080  quay.io/bonitasoft/bonita-subscription:pass:a[{bonitaVersion}]
 ----
 
 == Environment variables

--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -150,6 +150,70 @@ docker run --name mydbpostgres -d bonitasoft/bonita-postgres:12.6
 
 This image is built from the following https://github.com/Bonitasoft-Community/bonita-database-docker/tree/main/postgres/12[GitHub repository], which can be further adapted/customized to suit your needs.
 
+==== Using docker-compose
+
+Create a file `docker-compose.yml` with the following content
+
+[source,yaml,subs="+macros"]
+----
+# Use tech_user/secret as user/password credentials
+version: '3'
+
+services:
+  db:
+    image: bonitasoft/bonita-postgres:12.6
+    environment:
+      POSTGRES_PASSWORD: example
+    restart: always
+    command:
+      - -c
+      - max_prepared_transactions=100
+  bonita:
+    image: bonita:7.14.0
+    hostname: custom-hostname.example.com
+    ports:
+      - 8080:8080
+    environment:
+      - DB_VENDOR=postgres
+      - DB_HOST=db
+      - DB_PORT=5432
+      - DB_NAME=bonita
+      - DB_USER=bonita
+      - DB_PASS=bpm
+      - BIZ_DB_NAME=business_data
+      - BIZ_DB_USER=business_data
+      - BIZ_DB_PASS=bpm
+      - TENANT_LOGIN=tech_user
+      - TENANT_PASSWORD=secret
+      - PLATFORM_LOGIN=pfadmin
+      - PLATFORM_PASSWORD=pfsecret
+    restart: on-failure:2
+    depends_on:
+      - db
+    entrypoint:
+      - bash
+      - -c
+      - |
+        set -e
+        echo 'Waiting for PostgreSQL to be available'
+        maxTries=10
+        while [ "$$maxTries" -gt 0 ] && [ $$(echo 'QUIT' | nc -w 1 "$$DB_HOST" 5432; echo "$$?") -gt 0 ]; do
+            sleep 1
+            let maxTries--
+        done
+        if [ "$$maxTries" -le 0 ]; then
+            echo >&2 'error: unable to contact Postgres after 10 tries'
+            exit 1
+        fi
+        exec /opt/files/startup.sh /opt/bonita/server/bin/catalina.sh run
+----
+
+* Replace `<hostname>` with the one used in the licence generation command
+* Replace `~/bonita-lic` with the folder containing the license (on Windows use `/` and avoid `~`)
+* leave double `$$` untouched
+
+Run `docker-compose up`, wait for it to initialize completely, and visit `+http://localhost:8080+`, or `+http://host-ip:8080+` (as appropriate).
+
 ==== PostgreSQL as an installed service
 
 If you don't want to run your database in a docker container, the following file `env.txt` needs to be configured and provided to the docker run command:


### PR DESCRIPTION
* correct postgres startup command
* homogenize the license folder to ~/bonita-lic
* remove the docker-compose: it does not work in 2022.1 anymore, there is no easy way to make it work - so we remove it, for lack of a better solution.

Closes [RUNTIME-889](https://bonitasoft.atlassian.net/browse/RUNTIME-889)