### PR TITLE
refactor: remove the AsciiDoc link syntax when it is not needed

### DIFF
--- a/modules/ROOT/pages/configure-email-connector.adoc
+++ b/modules/ROOT/pages/configure-email-connector.adoc
@@ -13,7 +13,7 @@ A connector is a piece of code that is executed when starting or finishing a pro
 
 In order to avoid settings that are specific to real email provider, we will use a tool for a fake email server "FakeSMTP":
 
-. Download FakeSMTP from this link: https://nilhcem.github.io/FakeSMTP/downloads/fakeSMTP-latest.zip
+. Download FakeSMTP from this https://nilhcem.github.io/FakeSMTP/downloads/fakeSMTP-latest.zip
 . Unzip the file
 . Run FakeSMTP by double-clicking on the JAR file, or by running this shell command: `java -jar fakeSMTP-2.0.jar`
 . When the user interface is displayed, set the *listening port* to _2525_

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -98,5 +98,5 @@ https://www.bonitasoft.com/library/ultimate-guide-bpmn[[.card-title]#The Ultimat
 
 [.card.card-index]
 --
-https://documentation.bonitasoft.com/javadoc/api/{varVersion}/index.html[[.card-title]#Javadoc# [.card-body.card-content-overflow]#pass:q[The API documentation extracted from our source code]#]
+https://javadoc.bonitasoft.com/api/{varVersion}/index.html[[.card-title]#Javadoc# [.card-body.card-content-overflow]#pass:q[The API documentation extracted from our source code]#]
 --

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -83,20 +83,20 @@ xref:create-your-first-project-with-the-engine-apis-and-maven.adoc[[.card-title]
 
 [.card.card-index]
 --
-link:https://www.bonitasoft.com/downloads[[.card-title]#Download Bonita software# [.card-body.card-content-overflow]#pass:q[A link to our Community web site, the place to get Bonita]#]
+https://www.bonitasoft.com/downloads[[.card-title]#Download Bonita software# [.card-body.card-content-overflow]#pass:q[A link to our Community web site, the place to get Bonita]#]
 --
 
 [.card.card-index]
 --
-link:https://www.bpmn.org[[.card-title]#BPMN standard# [.card-body.card-content-overflow]#pass:q[A link to THE BPMN reference]#]
+https://www.bpmn.org[[.card-title]#BPMN standard# [.card-body.card-content-overflow]#pass:q[A link to THE BPMN reference]#]
 --
 
 [.card.card-index]
 --
-link:https://www.bonitasoft.com/library/ultimate-guide-bpmn[[.card-title]#The Ultimate Guide to BPMN2# [.card-body.card-content-overflow]#pass:q[Download Bonitasoft's whitepaper on BPMN2]#]
+https://www.bonitasoft.com/library/ultimate-guide-bpmn[[.card-title]#The Ultimate Guide to BPMN2# [.card-body.card-content-overflow]#pass:q[Download Bonitasoft's whitepaper on BPMN2]#]
 --
 
 [.card.card-index]
 --
-link:https://documentation.bonitasoft.com/javadoc/api/{varVersion}/index.html[[.card-title]#Javadoc# [.card-body.card-content-overflow]#pass:q[The API documentation extracted from our source code]#]
+https://documentation.bonitasoft.com/javadoc/api/{varVersion}/index.html[[.card-title]#Javadoc# [.card-body.card-content-overflow]#pass:q[The API documentation extracted from our source code]#]
 --


### PR DESCRIPTION
For links used for attachments, see #2059 