### PR TITLE
refactor(7.10): use the new Antora 3 syntax to reference 'attachments' 

### DIFF
--- a/modules/ROOT/pages/insert-data-in-a-docx-odt-template.adoc
+++ b/modules/ROOT/pages/insert-data-in-a-docx-odt-template.adoc
@@ -57,8 +57,7 @@ This example uses key values taken from a business variable.
 
 === Business Data Model
 
-// IMPORTANT: links to attachments change in Antora 3.0. See https://docs.antora.org/antora/3.0/whats-new/#attachment-resource-ids and https://docs.antora.org/antora/3.0/page/attachments/
-Here is a link:{attachmentsdir}/study-leave-template.docx[template example] for Leave Request submission and approval. +
+Here is a xref:attachment$study-leave-template.docx[template example] for Leave Request submission and approval. +
 This .docx file uses keys, most of which will be replaced by values from business variables created from the following *Business Data Model*:
 
 image::images/images-6_0/MyUser_Model_lazy.png[]

--- a/modules/ROOT/pages/multi-language-pages.adoc
+++ b/modules/ROOT/pages/multi-language-pages.adoc
@@ -123,8 +123,7 @@ Use an online Json checker to make sure there are no format errors in the file. 
 }
 ----
 
-// IMPORTANT: links to attachments change in Antora 3.0. See https://docs.antora.org/antora/3.0/whats-new/#attachment-resource-ids and https://docs.antora.org/antora/3.0/page/attachments/
-You can link:{attachmentsdir}/localization.json[download a copy of this `localization.json` file] for testing.
+You can  xref:attachment$localization.json[download a copy of this `localization.json` file] for testing.
 
 In the UI Designer, import this file as an asset of the travel tool page. This will replace any existing `localization.json` file. Save the page.
 


### PR DESCRIPTION
It involves xref, so reference validation is done by Antora and it reduces errors.
The old syntax is deprecated, so we are also preparing the future.

### Notes
Covers https://github.com/bonitasoft/bonita-documentation-site/issues/360
For 7.11+, see #2059