### PR TITLE
chore: fix preview build errors

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -60,5 +60,5 @@ jobs:
           failOnError: true
           teardown: 'true'
           build: |
-            ./build-preview.bash --use-multi-repositories --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }},${{ BONITA_BRANCH_FOR_CLOUD }}" --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}" --component-with-branches bcd:"${{ env.BCD_BRANCH }}" --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }} --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
+            ./build-preview.bash --use-multi-repositories --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }},${{ env.BONITA_BRANCH_FOR_CLOUD }}" --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}" --component-with-branches bcd:"${{ env.BCD_BRANCH }}" --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }} --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
             ls -lh build/site

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -36,6 +36,8 @@ jobs:
       CLOUD_BRANCH: 'master'
       # Needed to build the 'cloud' doc
       BCD_BRANCH: '3.6'
+      BONITA_BRANCH_FOR_CLOUD: '2022.1'
+      TOOLKIT_BRANCH: '1.0'
     steps:
       - name: Get documentation site source code
         if: github.event.action != 'closed'
@@ -58,5 +60,5 @@ jobs:
           failOnError: true
           teardown: 'true'
           build: |
-            ./build-preview.bash --use-multi-repositories --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }}" --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}" --component-with-branches bcd:"${{ env.BCD_BRANCH }}" --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
+            ./build-preview.bash --use-multi-repositories --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }},${{ BONITA_BRANCH_FOR_CLOUD }}" --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}" --component-with-branches bcd:"${{ env.BCD_BRANCH }}" --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }} --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
             ls -lh build/site

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -34,6 +34,8 @@ jobs:
       DOC_SITE_BRANCH: master
       PR_NUMBER: ${{ github.event.pull_request.number }}
       CLOUD_BRANCH: 'master'
+      # Needed to build the 'cloud' doc
+      BCD_BRANCH: '3.6'
     steps:
       - name: Get documentation site source code
         if: github.event.action != 'closed'
@@ -56,5 +58,5 @@ jobs:
           failOnError: true
           teardown: 'true'
           build: |
-            ./build-preview.bash --use-multi-repositories --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }}" --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}" --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
+            ./build-preview.bash --use-multi-repositories --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }}" --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}" --component-with-branches bcd:"${{ env.BCD_BRANCH }}" --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
             ls -lh build/site

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,7 +1,7 @@
 = Bonita Documentation
 :description: Learn how to get the most out of the Bonita Platform and all of its components.
 
-Learn how to get the most out of the Bonita Platform and all of its components.
+Yeah! Learn how to get the most out of the Bonita Platform and all of its components.
 
 [.card-section]
 == Your automation project with Bonita

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,7 +1,7 @@
 = Bonita Documentation
 :description: Learn how to get the most out of the Bonita Platform and all of its components.
 
-Yeah! Learn how to get the most out of the Bonita Platform and all of its components.
+Learn how to get the most out of the Bonita Platform and all of its components.
 
 [.card-section]
 == Your automation project with Bonita


### PR DESCRIPTION
Bonita 2021.2 documentation has xref to bonita-cloud, so it includes bonita-cloud page when building the preiview.
2 days ago, bonita-cloud introduced xref to bcd. See https://github.com/bonitasoft/bonita-cloud-doc/pull/25/
By transitivity, we now need to include bcd when building bonita preview.