### PR TITLE
fix: remove comments in admin tools java example

### DIFF
--- a/modules/ROOT/pages/create-administration-tools.adoc
+++ b/modules/ROOT/pages/create-administration-tools.adoc
@@ -280,14 +280,6 @@ import org.bonitasoft.engine.search.SearchOptionsBuilder;
 import org.bonitasoft.engine.search.SearchResult;
 import org.bonitasoft.engine.session.APISession;
 
-/**
- *
- */
-
-/**
- * @author John Doe
- *
- */
 public class ListFailedTasksCmd implements Callable<Void> {
     private static final String ROW_SEPARATOR = "\n";
 	private static final String COL_SEPARATOR = "\t";


### PR DESCRIPTION
Remove useless JavaDoc comments (empty and author)
