### PR TITLE
chore: simplify preview build

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -17,15 +17,13 @@ jobs:
       COMPONENT_NAME: bonita
       # Except if you want to test in progress work that your content depends on, keep it set to master
       # Also update the path to the action from the bonita-documentation-site repository
-      # TODO use master when available
-      DOC_SITE_BRANCH: chore/remove_duplications_in_surge_preview_workflow
+      DOC_SITE_BRANCH: master
     steps:
       - name: Compute environment variables
         run: |
           echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
       - name: Build and publish PR preview
-        # TODO use master when available
-        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@chore/remove_duplications_in_surge_preview_workflow
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@master
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -9,51 +9,26 @@ on:
       - 'antora.yml'
       - '.github/workflows/build-pr-preview.yml'
 jobs:
-  # inspired from https://github.community/t/how-can-i-test-if-secrets-are-available-in-an-action/17911/9
-  check_secrets:
-    runs-on: ubuntu-20.04
-    outputs:
-      is_SURGE_TOKEN_set: ${{ steps.secret_availability.outputs.is_SURGE_TOKEN_set }}
-    steps:
-      - name: Compute secrets availability
-        id: secret_availability
-        env:
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN_DOC }}
-        run: |
-          echo "is_SURGE_TOKEN_set: ${{ env.SURGE_TOKEN != '' }}"
-          echo "::set-output name=is_SURGE_TOKEN_set::${{ env.SURGE_TOKEN != '' }}"
-
   build_preview:
-    needs: [check_secrets]
-    # Only build preview for member of the repository
-    if: needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
     runs-on: ubuntu-20.04
     env:
       COMPONENT_NAME: bonita
       # Except if you want to test in progress work that your content depends on, keep it set to master
-      DOC_SITE_BRANCH: master
-      PR_NUMBER: ${{ github.event.pull_request.number }}
+      # Also update the path to the action from the bonita-documentation-site repository
+      # TODO use master when available
+      DOC_SITE_BRANCH: chore/remove_duplications_in_surge_preview_workflow
     steps:
-      - name: Get documentation site source code
-        if: github.event.action != 'closed'
-        run: |
-          # Remove existing .git directory
-          rm -rf *
-          git clone --depth 1 --single-branch --branch ${DOC_SITE_BRANCH} https://github.com/bonitasoft/bonitasoft.github.io.git .
       - name: Compute environment variables
         run: |
           echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
-          # the surge-preview action generates https://{{repository.owner}}-{{repository.name}}-{{job.name}}-pr-{{pr.number}}.surge.sh
-          repo_owner_and_name=$(echo "${{github.repository}}" | sed 's/\//-/g')
-          echo PREVIEW_URL=https://$repo_owner_and_name-"${{github.job}}"-pr-$PR_NUMBER.surge.sh >> $GITHUB_ENV
-      - name: Publish preview
-        uses: afc163/surge-preview@v1
+      - name: Build and publish PR preview
+        # TODO use master when available
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@chore/remove_duplications_in_surge_preview_workflow
         with:
-          surge_token: ${{ secrets.SURGE_TOKEN_DOC }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: build/site
-          failOnError: true
-          teardown: 'true'
-          build: |
-            ./build-preview.bash --branch "${{ env.BRANCH_NAME }}" --component "${{ env.COMPONENT_NAME }}" --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
-            ls -lh build/site
+          surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          doc-site-branch: ${{ env.DOC_SITE_BRANCH }}
+          # '>' Replace newlines with spaces (folded)
+          # '-' No newline at end (strip)
+          build-preview-command: |
+            ./build-preview.bash --branch "${{ env.BRANCH_NAME }}" --component "${{ env.COMPONENT_NAME }}"

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -15,9 +15,6 @@ jobs:
       pull-requests: write # surge-preview write PR comments    
     env:
       COMPONENT_NAME: bonita
-      # Except if you want to test in progress work that your content depends on, keep it set to master
-      # Also update the path to the action from the bonita-documentation-site repository
-      DOC_SITE_BRANCH: master
     steps:
       - name: Compute environment variables
         run: |
@@ -27,6 +24,6 @@ jobs:
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          doc-site-branch: ${{ env.DOC_SITE_BRANCH }}
+          doc-site-branch: master
           build-preview-command: |-
             ./build-preview.bash --branch "${{ env.BRANCH_NAME }}" --component "${{ env.COMPONENT_NAME }}"

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build_preview:
     runs-on: ubuntu-20.04
+    permissions:
+      pull-requests: write # surge-preview write PR comments    
     env:
       COMPONENT_NAME: bonita
       # Except if you want to test in progress work that your content depends on, keep it set to master

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -28,7 +28,5 @@ jobs:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           doc-site-branch: ${{ env.DOC_SITE_BRANCH }}
-          # '>' Replace newlines with spaces (folded)
-          # '-' No newline at end (strip)
-          build-preview-command: |
+          build-preview-command: |-
             ./build-preview.bash --branch "${{ env.BRANCH_NAME }}" --component "${{ env.COMPONENT_NAME }}"


### PR DESCRIPTION
Use action provided by the bonita-documentation-site repository.

Requires https://github.com/bonitasoft/bonita-documentation-site/pull/378
Covers https://github.com/bonitasoft/bonita-documentation-site/issues/270

Remaining Tasks
- [x] fix warning `Unexpected input(s) 'github-token', valid inputs are ['gh-token', 'surge-token', 'build-preview-command', 'doc-site-branch']`. Should be fixed by https://github.com/bonitasoft/bonita-documentation-site/pull/378/commits/719dd9fd511a454f70e29f65c1df7ea41ee69cc1
- [x] use master version
- [x] set GH_TOKEN permissions