### PR TITLE
chore: remove cloud branch reference

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -36,7 +36,6 @@ jobs:
       CLOUD_BRANCH: 'master'
       # Needed to build the 'cloud' doc
       BCD_BRANCH: '3.6'
-      BONITA_BRANCH_FOR_CLOUD: '2022.1'
       TOOLKIT_BRANCH: '1.0'
     steps:
       - name: Get documentation site source code
@@ -60,5 +59,5 @@ jobs:
           failOnError: true
           teardown: 'true'
           build: |
-            ./build-preview.bash --use-multi-repositories --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }},${{ env.BONITA_BRANCH_FOR_CLOUD }}" --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}" --component-with-branches bcd:"${{ env.BCD_BRANCH }}" --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }} --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
+            ./build-preview.bash --use-multi-repositories --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }} --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}" --component-with-branches bcd:"${{ env.BCD_BRANCH }}" --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }} --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
             ls -lh build/site


### PR DESCRIPTION
* remove cloud branch reference to avoid duplicate version on 2022.1 branches on pr-preview build