### PR TITLE
doc(docker-image): versions available on quay

### DIFF
--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -8,14 +8,14 @@ This guide assumes you have a working docker environment.
 
 == Quick start
 
-To start the latest Community release:
+To start the latest Community release - only main versions:
 
 [source,bash]
 ----
 docker run --name bonita -d -p 8080:8080 bonita
 ----
 
-To start the latest Subscription release:
+To start the latest Subscription release - only main and maintenance versions:
 
 [NOTE]
 ====

--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -8,14 +8,14 @@ This guide assumes you have a working docker environment.
 
 == Quick start
 
-To start the latest Community release - only main versions:
+To start the latest Community release - main versions only :
 
 [source,bash]
 ----
 docker run --name bonita -d -p 8080:8080 bonita
 ----
 
-To start the latest Subscription release - only main and maintenance versions:
+To start the latest Subscription release - main and maintenance versions only:
 
 [NOTE]
 ====


### PR DESCRIPTION
Precise the versions that are available on quay.io so that customers will not search for a beta version. 
