### PR TITLE
chore: fix PR preview workfow for 2021.2

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -15,6 +15,7 @@ jobs:
       pull-requests: write # surge-preview write PR comments
     env:
       COMPONENT_NAME: bonita
+      COMPONENT_VERSION: 2021.2 # TODO should be computed (from the base branch of this PR)
       # Required to pass xref validation
       CLOUD_BRANCH: 'master'
       # Needed to build the 'cloud' doc
@@ -35,6 +36,7 @@ jobs:
           # '-' No newline at end (strip)
           build-preview-command: >-
             ./build-preview.bash --use-multi-repositories
+            --start-page "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_VERSION }}:index.adoc
             --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }},${{ env.BONITA_BRANCH_FOR_CLOUD }},${{ env.BONITA_BRANCH_FOR_TOOLKIT }}"
             --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write # surge-preview write PR comments
     env:
       COMPONENT_NAME: bonita
-      COMPONENT_VERSION: 2021.2 # TODO should be computed (from the base branch of this PR)
+      COMPONENT_VERSION: ${{ github.base_ref }} # The base_ref or target branch of the pull request in a workflow run.
       # Required to pass xref validation
       CLOUD_BRANCH: 'master'
       # Needed to build the 'cloud' doc
@@ -36,7 +36,7 @@ jobs:
           # '-' No newline at end (strip)
           build-preview-command: >-
             ./build-preview.bash --use-multi-repositories
-            --start-page "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_VERSION }}:index.adoc
+            --start-page "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_VERSION }}":index.adoc
             --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }},${{ env.BONITA_BRANCH_FOR_CLOUD }},${{ env.BONITA_BRANCH_FOR_TOOLKIT }}"
             --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -23,6 +23,7 @@ jobs:
       BCD_BRANCH: '3.6'
       BONITA_BRANCH_FOR_CLOUD: '2022.1'
       TOOLKIT_BRANCH: '1.0'
+      BONITA_BRANCH_FOR_TOOLKIT: '2022.2'
     steps:
       - name: Compute environment variables
         run: |
@@ -36,7 +37,7 @@ jobs:
           # '-' No newline at end (strip)
           build-preview-command: >-
             ./build-preview.bash --use-multi-repositories
-            --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }},${{ env.BONITA_BRANCH_FOR_CLOUD }}"
+            --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }},${{ env.BONITA_BRANCH_FOR_CLOUD }},${{ env.BONITA_BRANCH_FOR_TOOLKIT }}"
             --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
             --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -1,5 +1,7 @@
 name: Build PR preview
 
+# Change to trigger workflow run
+
 on:
   pull_request:
     # To manage 'surge-preview' action teardown, add default event types + closed event type

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -1,7 +1,5 @@
 name: Build PR preview
 
-# Change to trigger workflow run
-
 on:
   pull_request:
     # To manage 'surge-preview' action teardown, add default event types + closed event type

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -36,7 +36,7 @@ jobs:
           # '-' No newline at end (strip)
           build-preview-command: >-
             ./build-preview.bash --use-multi-repositories
-            --start-page "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_VERSION }}":index.adoc
+            --start-page "${{ env.COMPONENT_VERSION }}"@"${{ env.COMPONENT_NAME }}"::index.adoc
             --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }},${{ env.BONITA_BRANCH_FOR_CLOUD }},${{ env.BONITA_BRANCH_FOR_TOOLKIT }}"
             --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"


### PR DESCRIPTION
- include bonita@2022.2: test-toolkit requires it for xref validation
- configure site start page: target current component version, so the surge url provided in PR comment opens on the version updated by the PR
