### PR TITLE
chore(2023.1): display search bar on site

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,8 +1,7 @@
 name: bonita
 title: Bonita
-# TODO: When releasing beta version, put version: 2022.2
 version: 2023.1
-# TODO: When releasing beta version, replace alpha by beta
+# TODO: When releasing beta version, replace alpha by beta. Remove when releasing GA
 prerelease: -alpha
 asciidoc:
   attributes:
@@ -14,8 +13,8 @@ asciidoc:
     page-pagination: true # display links to previous/next pages at the bottom of the page
     page-editable: true
     page-out-of-support: false
-    page-next-release: true # TODO: When releasing beta version, set this field to false
-    page-hide-search-bar: true # TODO: When releasing beta version, set this field to false
+    page-next-release: true # TODO: When releasing GA version, set this field to false
+    page-hide-search-bar: false
 nav:
   - modules/ROOT/release-note-nav.adoc
   - modules/bonita-overview/bonita-overview-nav.adoc


### PR DESCRIPTION
The 2023.1 is available in the Algolia index.
Also fix some wrong comments in `antora.yml` about when the properties will be updated.


Algolia index on 2022-08-16. I have also test search with the test client available in the Search Preview of the Algolia Crawler
![image](https://user-images.githubusercontent.com/27200110/184853126-de76d18b-fb43-4b6e-990d-024ae848ab3c.png)


