### PR TITLE
chore: Use real latest bonita version in antora.yml

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -7,7 +7,7 @@ prerelease: beta
 asciidoc:
   attributes:
     bonitaVersion: 2022.2
-    bonitaTechnicalVersion: '7.15.0' # latest public community version
+    bonitaTechnicalVersion: '7.15.0.beta-02' # latest public community version
     javadocVersion: 7.15
     crowdinBonitaVersion: 7.15
     # page attributes


### PR DESCRIPTION
* avoid getting 404 error page when we link files in our Github repository

example in actual production documentation: 
https://documentation.bonitasoft.com/bonita/2022.2/identity/user-authentication-overview#_bonita_runtime_authentication_scenario