### PR TITLE
fix(docker-compose): escape  $ to have a great display

### DIFF
--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -201,7 +201,7 @@ services:
         set -e
         echo 'Waiting for PostgreSQL to be available'
         maxTries=10
-        while [ "$$maxTries" -gt 0 ] && [ $$(echo 'QUIT' | nc -w 1 "$$DB_HOST" 5432; echo "$$?") -gt 0 ]; do
+        while [ "\$$maxTries" -gt 0 ] && [ $$(echo 'QUIT' | nc -w 1 "\$$DB_HOST" 5432; echo "$$?") -gt 0 ]; do
             sleep 1
             let maxTries--
         done


### PR DESCRIPTION
escape  $ to fix docker-compose to  have a great display in the doc site