### PR TITLE
ci(build): fix duplicate 2022.1 branches

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -19,7 +19,6 @@ jobs:
       CLOUD_BRANCH: 'master'
       # Needed to build the 'cloud' doc
       BCD_BRANCH: '3.6'
-      BONITA_BRANCH_FOR_CLOUD: '2022.1'
       TOOLKIT_BRANCH: '1.0'
       BONITA_BRANCH_FOR_TOOLKIT: '2022.2'
     steps:
@@ -31,7 +30,7 @@ jobs:
           build-preview-command: >-
             ./build-preview.bash --use-multi-repositories
             --start-page "${{ env.COMPONENT_VERSION }}"@"${{ env.COMPONENT_NAME }}"::index.adoc
-            --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_BRANCH_NAME }},${{ env.BONITA_BRANCH_FOR_CLOUD }},${{ env.BONITA_BRANCH_FOR_TOOLKIT }}"
+            --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_BRANCH_NAME }},${{ env.BONITA_BRANCH_FOR_TOOLKIT }}"
             --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
             --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"


### PR DESCRIPTION
The 2022.1 branch was added to the built site. It targets the same version as the branch of the Pull Request. So Antora detected duplicated navigation files for this version and the build failed because of that.

### Warning
After this PR is merged, we should carefully merge 2022.1 into 2022.2. In 2022.2, we have to add the build of the 2022.1 branch to ensure xref validation for BCD pages.