### PR TITLE
feat(archives): keep a single paragraph for 7.6 and 7.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # Bonita documentation archives
 
-This repository contains the documentation site content for Bonita Archives.
-It uses AsciiDoctor and Antora to create documentation content.
+This repository contains the sources of archives of the https://documentation.bonitasoft.com/bonita/0/archives[Bonita documentation site]. It uses https://docs.asciidoctor.org/asciidoc/latest/[AsciiDoc] format for
+the documentation content.
 
 
-## View rendered content on GitHub
+== Content writing guidelines
 
-WIP
+See https://github.com/bonitasoft/bonita-documentation-site/blob/master/docs/content/CONTRIBUTING.adoc[Bonita documentation content writing guidelines] for
+recommendations about writing Asciidoc pages the Bonita-way.
 
-## Contribute
 
-WIP
+== Providing feedbacks about Bonita product
+
+For any questions or feedbacks about the *product itself*, please use the following resources:
+
+* http://community.bonitasoft.com/[Community website]
+* https://bonita.atlassian.net/projects/BBPMC/[Community Bug tracker (Jira)]

--- a/modules/ROOT/pages/archives.adoc
+++ b/modules/ROOT/pages/archives.adoc
@@ -3,20 +3,13 @@
 
 This page gives access to the download of Bonita documentation archives, in case you need something very specific to those versions. The format is either html (for not so old versions) or pdf (for very old versions).
 
-== Bonita 7.7
+== Bonita 7.6 and Bonita 7.7
 
 The format here is html. +
 Download the .zip archive, extract it, and then open the index.html file to launch the site. +
 You can navigate those sites with the table of content on the left.
 
 * https://github.com/bonitasoft/bonita-doc/releases/download/7.7-20221005_082727/documentation-bonita-7.7.zip[Bonita 7.7]
-
-== Bonita 7.6
-
-The format here is html. +
-Download the .zip archive, extract it, and then open the index.html file to launch the site. +
-You can navigate those sites with the table of content on the left.
-
 * https://github.com/bonitasoft/bonita-doc/releases/download/7.6-20220330_125930/documentation-bonita-7.6.zip[Bonita 7.6]
 
 == Bonita BPM 7.3 to Bonita BPM 7.5


### PR DESCRIPTION
We had a paragraph for Bonita BPM from 7.3 to 7.5, to group version prior the Bonita rename that occurred in v7.6.
In 7.7, this is still the same product name and archive structure, so 7.6 and 7.7 must be stored in the same paragraph.