### PR TITLE
ci: add write permissions for the check PR title workflow

### DIFF
--- a/.github/workflows/contribution-check.yml
+++ b/.github/workflows/contribution-check.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   pr-title:
     runs-on: ubuntu-20.04
+    permissions:
+      pull-requests: write # actions/stale adds labels and closes PR
     steps:
       - name: Lint pull request title
         uses: jef/conventional-commits-pr-action@v1


### PR DESCRIPTION
We are going to set default permissions to read. So use explicit write permissions when needed.

See also #2184
covers https://github.com/bonitasoft/bonita-documentation-site/issues/443
