### PR TITLE
fix(2021.1): remove hard coded links to the production documentation site

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -19,14 +19,21 @@ jobs:
       CLOUD_BRANCH: 'master'
       # Needed to build the 'cloud' doc
       BCD_BRANCH: '3.6'
-      BONITA_BRANCH_FOR_CLOUD: '2021.1'
+      BONITA_BRANCH_FOR_CLOUD: '2022.1'
+      TOOLKIT_BRANCH: '1.0'
+      BONITA_BRANCH_FOR_TOOLKIT: '2022.2'
     steps:
-      - name: Build preview
+      - name: Build PR preview
         uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@master
         with:
-          build-preview-command: |-
-            ./build-preview.bash 
-            --component "${{ env.COMPONENT_NAME }}" 
-            --branch "${{ env.COMPONENT_BRANCH_NAME }}"
+          surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # '>' Replace newlines with spaces (folded)
+          # '-' No newline at end (strip)
+          build-preview-command: >-
+            ./build-preview.bash --use-multi-repositories
             --start-page "${{ env.COMPONENT_VERSION }}"@"${{ env.COMPONENT_NAME }}"::index.adoc
+            --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_BRANCH_NAME }},${{ env.BONITA_BRANCH_FOR_CLOUD }},${{ env.BONITA_BRANCH_FOR_TOOLKIT }}"
             --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
+            --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
+            --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -14,9 +14,19 @@ jobs:
     env:
       COMPONENT_NAME: bonita
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}
+      COMPONENT_VERSION: ${{ github.base_ref }} # The base_ref or target branch of the pull request in a workflow run.
+      # Required to pass xref validation
+      CLOUD_BRANCH: 'master'
+      # Needed to build the 'cloud' doc
+      BCD_BRANCH: '3.6'
+      BONITA_BRANCH_FOR_CLOUD: '2021.1'
     steps:
       - name: Build preview
         uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@master
         with:
           build-preview-command: |-
-            ./build-preview.bash --component "${{ env.COMPONENT_NAME }}" --branch "${{ env.COMPONENT_BRANCH_NAME }}"
+            ./build-preview.bash 
+            --component "${{ env.COMPONENT_NAME }}" 
+            --branch "${{ env.COMPONENT_BRANCH_NAME }}"
+            --start-page "${{ env.COMPONENT_VERSION }}"@"${{ env.COMPONENT_NAME }}"::index.adoc
+            --component-with-branches bcd:"${{ env.BCD_BRANCH }}"

--- a/antora.yml
+++ b/antora.yml
@@ -7,6 +7,8 @@ asciidoc:
     bonitaTechnicalVersion: '7.12.1' # latest public community version
     javadocVersion: 7.12
     crowdinBonitaVersion: 7.12
+    # ref versions of other components
+    bcdDocVersion: '3.6'
     # page attributes
     page-editable: true
     page-out-of-support: false

--- a/modules/ROOT/pages/admin-application-overview.adoc
+++ b/modules/ROOT/pages/admin-application-overview.adoc
@@ -37,7 +37,7 @@ After Studio validation, the application is imported or cloned; you can view its
 
 == Access in pre-Production and in Production
 
-To deploy the applications into a bundle or the Cloud, you can use {bcdDocVersion}@bcd::livingapp_manage_configuration.adoc[Bonita Continuous Delivery] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
+To deploy the applications into a bundle or the Cloud, you can use {bcdDocVersion}@bcd::bcd_cli.adoc[Bonita Continuous Delivery] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
 Alternatively, you can deploy an application by importing all its components in the following order:
 
 * Organization then profiles

--- a/modules/ROOT/pages/admin-application-overview.adoc
+++ b/modules/ROOT/pages/admin-application-overview.adoc
@@ -37,7 +37,7 @@ After Studio validation, the application is imported or cloned; you can view its
 
 == Access in pre-Production and in Production
 
-To deploy the applications into a bundle or the Cloud, you can use https://documentation.bonitasoft.com/bcd//_manage_living_application[Bonita Continuous Delivery] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
+To deploy the applications into a bundle or the Cloud, you can use {bcdDocVersion}@bcd::livingapp_manage_configuration.adoc[Bonita Continuous Delivery] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
 Alternatively, you can deploy an application by importing all its components in the following order:
 
 * Organization then profiles

--- a/modules/ROOT/pages/automating-builds.adoc
+++ b/modules/ROOT/pages/automating-builds.adoc
@@ -7,21 +7,17 @@ This allows to automate builds through scripts or any automation tooling.
 
 [WARNING]
 ====
-
-This way of building artifacts is deprecated. Use https://documentation.bonitasoft.com/bcd/latest/livingapp_build[Bonita Continuous Delivery add-on] instead.
+This way of building artifacts is deprecated. Use {bcdDocVersion}@bcd::livingapp_build.adoc[Bonita Continuous Delivery add-on] instead.
 ====
 
 [NOTE]
 ====
-
 For Enterprise, Performance, Efficiency, and Teamwork editions only.
 ====
 
 [WARNING]
 ====
-
-
-* The solution described here relies on the `Workspace API`/`BonitaStudioBuilder`, which has been deprecated since Bonita 7.7.0. Instead, we strongly encourage you to use the LA builder included in the tooling suite of https://documentation.bonitasoft.com/bcd/latest/[_Bonita Continuous Delivery_ add-on] add-on. One added-value is that LA builder does not need a studio to be installed.
+The solution described here relies on the `Workspace API`/`BonitaStudioBuilder`, which has been deprecated since Bonita 7.7.0. Instead, we strongly encourage you to use the LA builder included in the tooling suite of {bcdDocVersion}@bcd::index.adoc[_Bonita Continuous Delivery_ add-on] add-on. One added-value is that LA builder does not need a studio to be installed.
 ====
 
 == Overview

--- a/modules/ROOT/pages/bonita-studio-download-installation.adoc
+++ b/modules/ROOT/pages/bonita-studio-download-installation.adoc
@@ -5,15 +5,12 @@ The first step of to getting started  is to set up your development environment.
 
 [NOTE]
 ====
-
 If you have any problems while working through this tutorial, you can https://community.bonitasoft.com/questions-and-answers[ask for help on the Bonita community] and/or open an issue on the Bonita https://bonita.atlassian.net/projects/BBPMC/issues[Community issue tracker].
 ====
 
 == Download Bonita Studio
 
 To download the latest version of Bonita Studio, open the https://www.bonitasoft.com/downloads[download page] and click on the *Download* button. This will start the download of the Bonita Studio installer for your operating system.
-
-// update package name
 
 When the download is finished, you should have one of the following files on your computer (x.y refers to the version of Bonita Studio, e.g. {bonitaVersion}):
 
@@ -39,10 +36,6 @@ The installer will guide you through a very basic installation configuration:
 . A "thank you for downloading" page will be displayed in your web browser. You can close it
 
 image:images/getting-started-tutorial/installation/studio-installation-installer-08-last-screen.png[Bonita Studio installer last screen]
-// {.img-responsive .img-thumbnail}
-
-// update package name
-
 
 Bonita Studio is now installed. The default installation folders are:
 
@@ -57,38 +50,32 @@ Now Bonita Studio should be running on your computer. If not, you can manually s
 You should get the Bonita Studio welcome page:
 
 image:images/getting-started-tutorial/installation/studio-first-start-02-studio-on-welcome-page.png[Bonita Studio with welcome page displayed]
-// {.img-responsive .img-thumbnail}
 
 [NOTE]
 ====
-
 When Bonita Studio starts, various tasks are executed in the background, such as the embedded Bonita test server startup (including Bonita Engine initialization), Bonita test organization deployment, and more.
-This might take a while and some features may not be immediately available. A pop-up window will appear to indicate you can update the Bonita server configuration in https://documentation.bonitasoft.com/bonita//bonita-bpm-studio-preferences[preferences] image:images/getting-started-tutorial/installation/studio-first-start-03-starting-bonita-server-popup.png[Bonita Studio Server starting pop-up]
+This might take a while and some features may not be immediately available. A pop-up window will appear to indicate you can update the Bonita server configuration in xref:bonita-bpm-studio-preferences.adoc[preferences] image:images/getting-started-tutorial/installation/studio-first-start-03-starting-bonita-server-popup.png[Bonita Studio Server starting pop-up]
 ====
 
 When the Bonita Engine is started, you will see a confirmation pop-up on your Bonita Studio welcome page.
 
 image:images/getting-started-tutorial/installation/studio-first-start-04-engine-started-popup.png[Bonita Studio server started pop-up]
-// {.img-responsive .img-thumbnail}
 
 == Installation validation
 
 To make sure that everything is properly installed, click on the *Portal* button image:images/getting-started-tutorial/installation/portal-icon.png[Bonita Portal icon] in the toolbar. This should open the Bonita Portal home page in your web browser:
 
 image:images/getting-started-tutorial/installation/web-browser-display-portal.png[Bonita Portal display in a web browser]
-// {.img-responsive .img-thumbnail}
 
 Also click on the *UI Designer* button image:images/getting-started-tutorial/installation/ui-designer-icon.png[UI Designer icon] in the toolbar. This will display a pop-up window that you can ignore:
 
 image:images/getting-started-tutorial/installation/ui-designer-launch-pop-up.png[UI Designer first launch pop-up window]
-// {.img-responsive .img-thumbnail}
 
 And the UI Designer should open in your web browser:
 
 image:images/getting-started-tutorial/installation/ui-designer-first-start.png[UI Designer, on first launch, displayed in a web browser]
-// {.img-responsive .img-thumbnail}
 
 == Ready to move on
 
-You have sucessfully installed Bonita Studio, and the tools and test environment are up and running.
+You have successfully installed Bonita Studio, and the tools and test environment are up and running.
 You are ready to move to the next chapter to xref:draw-bpmn-diagram.adoc[start creating your first process].

--- a/modules/ROOT/pages/comparison-of-7-x-and-6-x.adoc
+++ b/modules/ROOT/pages/comparison-of-7-x-and-6-x.adoc
@@ -47,8 +47,8 @@ See the xref:bonita-bpm-installation-overview.adoc[Installation overview].
 | Now available in all editions. See xref:parameters.adoc[Parameters] and xref:environments.adoc[Environments]
 
 | Workspace API
-| The Workspace API is provided to generate `.bar` files from the command line, ready for production. .bar files are for deployment only and cannot be read by the studio. .bos files are for Studio interchange only and cannot be deployed to production. Each file format is optimal in term of content and is optimized for the target use case
-| The Workspace API retains its 6.x capabilities. Moreover, it can export forms that are mapped to process instantiations or tasks, and pages that are mapped to a case overview. It cannot export application pages that are not elements of a process. For this reason the Workspace API has been deprecated in 7.7.0, and is replaced by the _LA builder_ included in the tooling suite of https://documentation.bonitasoft.com/bcd/latest/[_Bonita Continuous Delivery_ add-on]. See xref:automating-builds.adoc[Automating builds]
+| The Workspace API is provided to generate `.bar` files from the command line, ready for production. .bar files are for deployment only and cannot be read by the studio. .bos files are for Studio interchange only and cannot be deployed to production. Each file format is optimal in terms of content and is optimized for the target use case
+| The Workspace API retains its 6.x capabilities. Moreover, it can export forms that are mapped to process instantiations or tasks, and pages that are mapped to a case overview. It cannot export application pages that are not elements of a process. For this reason the Workspace API has been deprecated in 7.7.0, and is replaced by the _LA builder_ included in the tooling suite of {bcdDocVersion}@bcd::index.adoc [_Bonita Continuous Delivery_ add-on]. See xref:automating-builds.adoc[Automating builds]
 |===
 
 == Feature improvements in Bonita Studio
@@ -62,7 +62,7 @@ See the xref:bonita-bpm-installation-overview.adoc[Installation overview].
 
 | Process migration
 | N/A
-| A process created in Bonita 6.x could run in 7.x (up to 7.7.x) without any modification. Starting with Bonita 7.8, you must use contracts created from outside of the studio, or migrate the forms. See xref:contracts-and-contexts.adoc[Contracts] and xref:migrate-a-form-from-6-x.adoc[Migrate a form from 6.x]
+| A process created in Bonita 6.x could run in 7.x (up to 7.7.x) without any modification. Starting with Bonita 7.8, you must use contracts created from outside the Studio, or migrate the forms. See xref:contracts-and-contexts.adoc[Contracts] and xref:migrate-a-form-from-6-x.adoc[Migrate a form from 6.x]
 
 | Application theme and layout
 | Not in 6.x
@@ -74,7 +74,7 @@ See the xref:bonita-bpm-installation-overview.adoc[Installation overview].
 
 | Improved UI
 | Not in 6.x
-| Improvements to the Details panel so that tab structure reflects typical worksflow
+| Improvements to the Details panel so that tab structure reflects typical workflow
 
 | Variable definition
 | Easy variable definition for process data, using the expression editor to set the initial or default values
@@ -116,7 +116,7 @@ See the xref:bonita-bpm-installation-overview.adoc[Installation overview].
 
 | User interface
 | For users, a simple interface for starting cases and performing tasks. For administrators, an interface for managing processes and applications, and the organization, with views for monitoring process and case status
-| No change for users. For adminsitrators, the case process and case monitoring views have been improved, new live update features have been added, and the application editor has been improved. See xref:bonita-bpm-portal-interface-overview.adoc[Bonita Portal interface overview]
+| No change for users. For administrators, the case process and case monitoring views have been improved, new live update features have been added, and the application editor has been improved. See xref:bonita-bpm-portal-interface-overview.adoc[Bonita Portal interface overview]
 
 | Task management
 | Users can choose how to manage tasks. They can perform one task after another in list order, or select my tasks for themselves then perform them in the order they choose.
@@ -127,14 +127,15 @@ See the xref:bonita-bpm-installation-overview.adoc[Installation overview].
 | No change. See xref:mobile-portal.adoc[Mobile overview]
 
 | Subtasks
-| A subtask is a part of an existing task. The assignee can create a subtask (to request a missing information for example) and must assign it to a specific person, by name. The assignee can be the creator
-| Supported up to 7.2.4. No more substasks can be created starting from 7.3.0, but open process instances execute them correctly
+| A subtask is a part of an existing task. The assignee can create a subtask (to request missing information for example) and must assign it to a specific person, by name. The assignee can be the creator
+| Supported up to 7.2.4. No more subtasks can be created starting from 7.3.0, but open process instances execute them correctly
 
 | Replay tasks and connectors in error
 | It is now possible for the administrator to replay a task or a connector that is in error. This enables a resolution of failed tasks and better service to end users. and connectors in error
 | No change. See xref:process-configuration-overview.adoc[Process configuration overview] and xref:mobile-portal.adoc[Mobile overview]
 
 | Anonymous user
+// TODO find the xref for "anonymous user"
 | You can now complete a task as an http://documentation.bonitasoft.com/anonymous-user[anonymous user], that is, without being registered in the organization. For example, on an e-commerce site, a new user can browse stock and save items to a basket, then register with the site if they want to save their basket for later or to buy something
 | Not supported
 |===

--- a/modules/ROOT/pages/comparison-of-7-x-and-6-x.adoc
+++ b/modules/ROOT/pages/comparison-of-7-x-and-6-x.adoc
@@ -102,7 +102,7 @@ See the xref:bonita-bpm-installation-overview.adoc[Installation overview].
 
 | Anonymous user
 | You can define a process that has an unknown initiator.
-| Not supported
+| Not supported but you can configure a xref:guest-user.adoc[Guest user] in Bonita Portal to achieve a similar behavior.
 |===
 
 == Feature improvements in Bonita Portal
@@ -135,9 +135,8 @@ See the xref:bonita-bpm-installation-overview.adoc[Installation overview].
 | No change. See xref:process-configuration-overview.adoc[Process configuration overview] and xref:mobile-portal.adoc[Mobile overview]
 
 | Anonymous user
-// TODO find the xref for "anonymous user"
-| You can now complete a task as an http://documentation.bonitasoft.com/anonymous-user[anonymous user], that is, without being registered in the organization. For example, on an e-commerce site, a new user can browse stock and save items to a basket, then register with the site if they want to save their basket for later or to buy something
-| Not supported
+| You can start a process orcomplete task as an anonymous user, that is, without being registered in the organization. For example, on an e-commerce site, a new user can browse stock and save items to a basket, then register with the site if they want to save their basket for later or to buy something
+| You can configure a xref:guest-user.adoc[Guest user] and use it to make some applications and process instantiation form accessible without having to log in.
 |===
 
 == Feature improvements in Bonita Engine

--- a/modules/ROOT/pages/comparison-of-7-x-and-6-x.adoc
+++ b/modules/ROOT/pages/comparison-of-7-x-and-6-x.adoc
@@ -74,7 +74,7 @@ See the xref:bonita-bpm-installation-overview.adoc[Installation overview].
 
 | Improved UI
 | Not in 6.x
-| Improvements to the Details panel so that tab structure reflects typical workflow
+| Improvements to the Details panel so that tab structure reflects typical workflows
 
 | Variable definition
 | Easy variable definition for process data, using the expression editor to set the initial or default values

--- a/modules/ROOT/pages/create-application.adoc
+++ b/modules/ROOT/pages/create-application.adoc
@@ -1,6 +1,6 @@
 = Create an application
 :description: :experimental:
-
+// activate the 'menu' AsciiDoc macro
 :experimental:
 
 The last step of this Getting Started tutorial is to create an application.
@@ -18,7 +18,6 @@ To create the application, add a new application descriptor:
 The `applicationDescriptorFile.xml` is initialized and the editor will help you create the application directly from Bonita Studio.
 
 image:images/getting-started-tutorial/create-application/applicationEditor.png[Application Descriptor Editor]
-// {.img-responsive .img-thumbnail}
 
 To create an application, you have to define:
 
@@ -34,11 +33,9 @@ To create an application, you have to define:
 . Enter _dashboard_ in the column *Token*
 +
 image:images/getting-started-tutorial/create-application/create-application.gif[Application deployment]
-// {.img-responsive .img-thumbnail}
 
 [NOTE]
 ====
-
 The look & feel can be fully customized by modifying the xref:layouts.adoc[layout] and adding a custom xref:customize-living-application-theme.adoc[theme].
 ====
 
@@ -51,13 +48,11 @@ The application is ready to be used. Now you need to deploy it in Bonita Portal:
 . In the *Deploy status* pop up window, click on *Close*
 +
 image:images/getting-started-tutorial/create-application/application-deployment.gif[Application deployment]
-// {.img-responsive .img-thumbnail}
 
 Congratulations! You have successfully created your first process and your first application with Bonita.
 
 [NOTE]
 ====
-
 Verify that the application has been created in Bonita Portal.
 
 . Click on the Portal icon image:images/getting-started-tutorial/create-application/portal-icon.png[Portal icon] in the Bonita Studio coolbar.
@@ -65,7 +60,7 @@ Verify that the application has been created in Bonita Portal.
 . Select *Administrator*
 . Click on the *Applications* tab
 
-You will see the application _Claims_ that you have just deployed listed in the *Applications list*. If you click on the URL, _My Dashboard_ page will be displayed in your brower.
+You will see the application _Claims_ that you have just deployed listed in the *Applications list*. If you click on the URL, _My Dashboard_ page will be displayed in your browser.
 ====
 
-To learn more about Bonita components and concepts, we recommend the https://www.youtube.com/playlist?list=PLvvoQatxaHOMHRiP7hFayNXTJNdxIEiYp[Bonita Camp tutorial]. Of course https://documentation.bonitasoft.com[official documentation] is also a great place to learn more about Bonita. If you prefer to learn from examples, you can find several on the https://community.bonitasoft.com/project?title=&field_type_tid=3869[community website]. And finally, remember that you can always get help and https://community.bonitasoft.com/questions-and-answers/[ask questions of the Bonita Community].
+To learn more about Bonita components and concepts, we recommend the https://www.youtube.com/playlist?list=PLvvoQatxaHOMHRiP7hFayNXTJNdxIEiYp[Bonita Camp tutorial]. Of course xref:index.adoc[official documentation] is also a great place to learn more about Bonita. If you prefer to learn from examples, you can find several on the https://community.bonitasoft.com/project?title=&field_type_tid=3869[community website]. And finally, remember that you can always get help and https://community.bonitasoft.com/questions-and-answers/[ask questions of the Bonita Community].

--- a/modules/ROOT/pages/creating-an-actor-filter.adoc
+++ b/modules/ROOT/pages/creating-an-actor-filter.adoc
@@ -2,7 +2,7 @@
 :description: An actor filter is implemented in Bonita in two parts, the definition and the implementation. This enables you to change the
 
 An actor filter is implemented in Bonita in two parts, the definition and the implementation. This enables you to change the
-implementation without changing the definition. Several implementations can be created for a single definition. See xref:actor-filtering.adoc[here]for a list of actor filters provided with the product.
+implementation without changing the definition. Several implementations can be created for a single definition. See xref:actor-filtering.adoc[here] for a list of actor filters provided with the product.
 
 An actor filter is a type of connector and is created in the same way, using the same schema files as for a connector. You can define a new actor filter definition or implementation in Bonita Studio, using the wizards started from the *Development* menu, *Actor filters* sub menu. You can also create a new actor filter definition or implementation externally, and import it into Bonita Studio.
 
@@ -20,7 +20,10 @@ The following sections explain the elements of the definition. You can also use 
 
 === Actor filter configuration wizard definition
 
-The XML file that defines the actor filter configuration wizard contains definitions for header information identifying the actor filter (including the icon), for inputs and outputs, and for the wizard pages. The definition follows the schema defined in http://documentation.bonitasoft.com/ns/connector/definition/6.0/connector-definition-descriptor.xsd. The table below lists the items in the definition:
+The XML file that defines the actor filter configuration wizard contains definitions for header information identifying the actor filter (including the icon), for inputs and outputs, and for the wizard pages.
+The definition follows the schema defined in https://github.com/bonitasoft/bonita-actorfilter-archetype/blob/1.1.4/src/main/resources/archetype-resources/schemas/connector-definition-descriptor.xsd[connector-definition-descriptor.xsd].
+
+The table below lists the items in the definition:
 
 |===
 |  | Occurrence | Description
@@ -84,7 +87,7 @@ The following example is the XML definition for the _initiator manager_ actor fi
 </definition:ConnectorDefinition>
 ----
 
-In this example, there is one input, a Boolean that determines whether or not the task is automatically assigned to the user identified by the filter. There is one page in the configuration wizard, which contains one widget.
+In this example, there is one input, a Boolean that determines whether the task is automatically assigned to the user identified by the filter. There is one page in the configuration wizard, which contains one widget.
 
 === Language properties file
 
@@ -122,10 +125,9 @@ The resource file defines:
 * the id and version of the implementation
 * the set of dependencies required by the implementation.
 
-The resource file follows the schema defined in http://documentation.bonitasoft.com/ns/connector/definition/6.0/connector-implementation-descriptor.xsd .
+The resource file follows the schema defined in https://github.com/bonitasoft/bonita-actorfilter-archetype/blob/1.1.4/src/main/resources/archetype-resources/schemas/connector-definition-descriptor.xsd[connector-definition-descriptor.xsd].
 
-The following example is the resource file of an implementation of the
-initiator manager actor filter:
+The following example is the resource file of an implementation of the initiator manager actor filter:
 
 [source,xml]
 ----
@@ -150,7 +152,7 @@ initiator manager actor filter:
 
 The Java class must implement the org.bonitasoft.engine.filter.AbstractUserFilterclass and use the Engine ExecutionContext. The following methods must be implemented:
 
-* validateInputParameters to check that the configuration of the actor filter is well defined
+* validateInputParameters to check that the configuration of the actor filter is well-defined
 * filter to get a list of identifiers of all the users that correspond to a specified actor name
 * shouldAutoAssignTaskIfSingleResult to assign the step to the user if filter returns one user
 

--- a/modules/ROOT/pages/how-a-bdm-is-deployed.adoc
+++ b/modules/ROOT/pages/how-a-bdm-is-deployed.adoc
@@ -7,6 +7,7 @@ Lean how the engine handles the BDM deployment and redeployment.
 
 To deploy a BDM, we need to pass a *ZIP file* containing the model definition as an XML file, like the one below:
 
+// about the xmlns value involving documentation.bonitasoft.com: this is really what is used in Bonita, see https://github.com/bonitasoft/bonita-engine/commit/33cad1138baaf46f7510d395024f18f3a4788045
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/modules/ROOT/pages/languages.adoc
+++ b/modules/ROOT/pages/languages.adoc
@@ -104,7 +104,7 @@ Instructions below explain how to add a language to Bonita Portal. Steps below i
 [WARNING]
 ====
 
-The `mobile_xxxx.po/.pot` files used for the language of the https://documentation.bonitasoft.com/bonita/7.4/mobile-portal[Bonita Mobile Portal] may contain some keys missing translation. For the Mobile Portal to be displayed correctly in the new language, these keys must not be empty.
+The `mobile_xxxx.po/.pot` files used for the language of the xref:mobile-portal.adoc[Bonita Mobile Portal] may contain some keys missing translation. For the Mobile Portal to be displayed correctly in the new language, these keys must not be empty.
 
 On the other hand, some of the keys in the `mobile_xxxx.po/.pot` files are duplicates from the ones in other non-mobile `.po/.pot` files. These keys must all have the same value (whether translated or chosen to be left in English) across all the `.po/.pot` files.
 

--- a/modules/ROOT/pages/ldap.adoc
+++ b/modules/ROOT/pages/ldap.adoc
@@ -3,7 +3,7 @@
 
 The LDAP connector allows a process to retrieve data from an LDAP server by running a query.
 
-If you are looking for LDAP Authentication please go to: https://documentation.bonitasoft.com/bonita/{javadocVersion}/active-directory-or-ldap-authentication[Active Directory or LDAP authentication].
+If you are looking for LDAP Authentication please go to: xref:active-directory-or-ldap-authentication.adoc[Active Directory or LDAP authentication].
 
 Configuring an LDAP connector with the wizard:
 
@@ -119,14 +119,14 @@ Then click *_Next_*.
             ... 12 more
 ----
 
-*Root cause*: Your LDAP Active Directory is using the pagination. Generally on LDAP Server using the pagination, the page size is set to 1000.  
+*Root cause*: Your LDAP Active Directory is using the pagination. Generally on LDAP Server using the pagination, the page size is set to 1000.
 
-By default, the pagination is not managed by the LDAP Connector since is not supported by all LDAP servers. So if your LDAP Active Directory is using the pagination, it will not be handle by the connector and will make it fail after 1000 users.  
+By default, the pagination is not managed by the LDAP Connector since is not supported by all LDAP servers. So if your LDAP Active Directory is using the pagination, it will not be handle by the connector and will make it fail after 1000 users.
 
-*Solutions*:  
+*Solutions*:
 
 1. Increase the page size on your Active Directory by increasing the value of MaxPageSize : https://support.microsoft.com/en-us/kb/315071
 
 2. Develop a Custom LDAP Connector managing the pagination of your Active Directory. +
 Do to so, you can read the xref:connector-archetype.adoc[documentation page on the connector archetype.]
-  
+

--- a/modules/ROOT/pages/set-up-continuous-integration.adoc
+++ b/modules/ROOT/pages/set-up-continuous-integration.adoc
@@ -12,7 +12,7 @@ For Enterprise, Performance, Efficiency, and Teamwork editions only.
 [WARNING]
 ====
 * The solution described here relies on the BonitaStudioBuilder, which has been deprecated since Bonita 7.7.0. Instead, we strongly encourage you to use the LA builder included in the tooling suite of Bonita Continuous Delivery add-on. One added-value is that LA builder does not need a studio to be installed.
-* https://documentation.bonitasoft.com/bcd/latest/[Bonita Continuous Delivery add-on] comes with an out-of-the-box solution based on Jenkins CI.
+* {bcdDocVersion}@bcd::index.adoc[Bonita Continuous Delivery add-on] comes with an out-of-the-box solution based on Jenkins CI.
 ====
 
 With Continuous Integration (CI) your processes are continuously built and tested while you are designing them. Collaborating on process design can be enhanced with CI by ensuring the integrity of your processes along the development phase.

--- a/modules/ROOT/pages/software-extensibility.adoc
+++ b/modules/ROOT/pages/software-extensibility.adoc
@@ -141,7 +141,7 @@ If a form uses some Javascript code based on an element in the HTML Document Obj
 You can customize this mapping by defining your own bean and override property. See xref:custom-authorization-rule-mapping.adoc[Authorization Rule Mapping]
 * *BonitaStudioBuilder*
 Bonita Entreprise editions include a script, BonitaStudioBuilder (also known as the Workspace API), for building a bar file from a process in a project. This intended to be used for automating process builds in a continuous integration and testing environment. You can use the BonitaStudioBuilder to build a bar file for processes stored in a project.
-WorkspaceAPI is deprecated since Bonita 7.7.0. Instead, we strongly encourage you to use the _LA builder_ included in the tooling suite of {bcdDocVersion}@bcd::index.adoc[_Bonita Continuous Delivery_ add-on]. One added-value is that LA builder does not need a Studio to be installed.
+WorkspaceAPI is deprecated since Bonita 7.7.0. Instead, we strongly encourage you to use the _LA builder_ included in the tooling suite of {bcdDocVersion}@bcd::bcd_cli.adoc[_Bonita Continuous Delivery_ add-on]. One added-value is that LA builder does not need a Studio to be installed.
 
 Only the elements listed on this page are intended to be used as extension points. For other elements, there is no guarantee of stability, and a high probability of changes across versions.
 For example, the following should not be considered to be extension points:

--- a/modules/ROOT/pages/software-extensibility.adoc
+++ b/modules/ROOT/pages/software-extensibility.adoc
@@ -141,7 +141,7 @@ If a form uses some Javascript code based on an element in the HTML Document Obj
 You can customize this mapping by defining your own bean and override property. See xref:custom-authorization-rule-mapping.adoc[Authorization Rule Mapping]
 * *BonitaStudioBuilder*
 Bonita Entreprise editions include a script, BonitaStudioBuilder (also known as the Workspace API), for building a bar file from a process in a project. This intended to be used for automating process builds in a continuous integration and testing environment. You can use the BonitaStudioBuilder to build a bar file for processes stored in a project.
-WorkspaceAPI is deprecated since Bonita 7.7.0. Instead, we strongly encourage you to use the _LA builder_ included in the tooling suite of https://documentation.bonitasoft.com/bcd/2.0/[_Bonita Continuous Delivery_ add-on]. One added-value is that LA builder does not need a Studio to be installed.
+WorkspaceAPI is deprecated since Bonita 7.7.0. Instead, we strongly encourage you to use the _LA builder_ included in the tooling suite of {bcdDocVersion}@bcd::index.adoc[_Bonita Continuous Delivery_ add-on]. One added-value is that LA builder does not need a Studio to be installed.
 
 Only the elements listed on this page are intended to be used as extension points. For other elements, there is no guarantee of stability, and a high probability of changes across versions.
 For example, the following should not be considered to be extension points:

--- a/modules/ROOT/pages/user-application-overview.adoc
+++ b/modules/ROOT/pages/user-application-overview.adoc
@@ -31,7 +31,7 @@ After Studio validation, the application is imported or cloned; you can view its
 
 == Access in pre-Production and in Production
 
-To deploy the applications into a bundle or the Cloud, you can use {bcdDocVersion}@bcd::livingapp_manage_configuration.adoc[Bonita Continuous Delivery] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
+To deploy the applications into a bundle or the Cloud, you can use {bcdDocVersion}@bcd::livingapp_manage_configuration.adoc[Bonita Continuous Delivery] using the {bcdDocVersion}@bcd::bcd_cli.adoc[CLI] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
 Alternatively, you can deploy an application by importing all its components in the following order:
 
 * Organization then profiles

--- a/modules/ROOT/pages/user-application-overview.adoc
+++ b/modules/ROOT/pages/user-application-overview.adoc
@@ -31,7 +31,7 @@ After Studio validation, the application is imported or cloned; you can view its
 
 == Access in pre-Production and in Production
 
-To deploy the applications into a bundle or the Cloud, you can use {bcdDocVersion}@bcd::livingapp_manage_configuration.adoc[Bonita Continuous Delivery] using the {bcdDocVersion}@bcd::bcd_cli.adoc[CLI] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
+To deploy the applications into a bundle or the Cloud, you can use {bcdDocVersion}@bcd::livingapp_manage_configuration.adoc[Bonita Continuous Delivery]'s {bcdDocVersion}@bcd::bcd_cli.adoc[CLI] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
 Alternatively, you can deploy an application by importing all its components in the following order:
 
 * Organization then profiles

--- a/modules/ROOT/pages/user-application-overview.adoc
+++ b/modules/ROOT/pages/user-application-overview.adoc
@@ -31,7 +31,7 @@ After Studio validation, the application is imported or cloned; you can view its
 
 == Access in pre-Production and in Production
 
-To deploy the applications into a bundle or the Cloud, you can use https://documentation.bonitasoft.com/bcd//_manage_living_application[Bonita Continuous Delivery] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
+To deploy the applications into a bundle or the Cloud, you can use {bcdDocVersion}@bcd::livingapp_manage_configuration.adoc[Bonita Continuous Delivery] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
 Alternatively, you can deploy an application by importing all its components in the following order:
 
 * Organization then profiles


### PR DESCRIPTION
- remove hard coded links to documentation.bonitasoft.com and use xref instead
- adding bcd branch when building the preview to make xref validation pass
