### PR TITLE
fix(sync): make ldap sync update users with different case (#278)

### DIFF
--- a/modules/identity/pages/ldap-synchronizer.adoc
+++ b/modules/identity/pages/ldap-synchronizer.adoc
@@ -412,6 +412,7 @@ This file defines the synchronization settings.
 Supported values: ignore, warn or fatal +
 Default value: warn
 * bonita_username_case: optional parameter that specifies whether the LDAP user names should be converted to a given case upon being imported in Bonita. +
+Note that even when using mixed case, you can not have two usernames differing only by the case. Existing usernames are updated with the correct case.+
 Supported values: mixed, uppercase or lowercase +
 Default value: lowercase
 * ldap_watched_directories: defines the LDAP directories to watch. +

--- a/modules/identity/pages/ldap-synchronizer.adoc
+++ b/modules/identity/pages/ldap-synchronizer.adoc
@@ -411,8 +411,8 @@ This file defines the synchronization settings.
 * error_level_upon_failing_to_get_related_user: optional parameter that specifies whether an error should be blocking upon getting related users (manager) +
 Supported values: ignore, warn or fatal +
 Default value: warn
-* bonita_username_case: optional parameter that specifies whether the LDAP user names should be converted to a given case upon being imported in Bonita. +
-Note that even when using mixed case, you can not have two usernames differing only by the case. Existing usernames are updated with the correct case.+
+* bonita_username_case: optional parameter, that specifies whether the LDAP usernames should be converted to a given case upon being imported in Bonita. +
+Note that two usernames differing only by the case will be handled as being the same username. Existing username will be updated with the new one. +
 Supported values: mixed, uppercase or lowercase +
 Default value: lowercase
 * ldap_watched_directories: defines the LDAP directories to watch. +


### PR DESCRIPTION
Consider that two entries wich differ only by the case are meant to be the same entry.

Documentation for fix [RUNTIME-278](https://bonitasoft.atlassian.net/browse/RUNTIME-278)