### PR TITLE
fix(alias): add alias for migration-tool page in update-tools-changelog

### DIFF
--- a/modules/version-update/pages/update-tools-changelog.adoc
+++ b/modules/version-update/pages/update-tools-changelog.adoc
@@ -1,5 +1,5 @@
 = Bonita Migration and Bonita Update tool changelog
-
+:page-aliases: ROOT:migration-tool.adoc
 :description: This is the changelog for Bonita Migration Tool and Bonita Update Tool. 
 
 This is the changelog for Bonita Migration Tool and Bonita Update Tool. 


### PR DESCRIPTION
Sister PR to https://github.com/bonitasoft/bonita-doc/pull/2193
Since 7.11 is out of support, we don't propagate upward from it, hence the separate commit.

Relates to [RUNTIME-1461](https://bonitasoft.atlassian.net/browse/RUNTIME-1461)