### PR TITLE
fix: use correct syntax for links to the BCD docs

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -10,7 +10,7 @@ jobs:
   build_preview:
     runs-on: ubuntu-20.04
     permissions:
-      pull-requests: write # surge-preview write PR comments    
+      pull-requests: write # surge-preview write PR comments
     env:
       COMPONENT_NAME: bonita
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}
@@ -26,8 +26,6 @@ jobs:
       - name: Build PR preview
         uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@master
         with:
-          surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build_preview:
     runs-on: ubuntu-20.04
+    permissions: read-all
     env:
       COMPONENT_NAME: bonita
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   build_preview:
     runs-on: ubuntu-20.04
-    permissions: read-all
     env:
       COMPONENT_NAME: bonita
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   build_preview:
     runs-on: ubuntu-20.04
-    permissions:
-      pull-requests: write # surge-preview write PR comments
     env:
       COMPONENT_NAME: bonita
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}

--- a/modules/ROOT/pages/admin-application-overview.adoc
+++ b/modules/ROOT/pages/admin-application-overview.adoc
@@ -37,7 +37,7 @@ After Studio validation, the application is imported or cloned; you can view its
 
 == Access in pre-Production and in Production
 
-To deploy the applications into a bundle or the Cloud, you can use {bcdDocVersion}@bcd::bcd_cli.adoc[Bonita Continuous Delivery] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
+To deploy the applications into a bundle or the Cloud, you can use xref:{bcdDocVersion}@bcd::bcd_cli.adoc[Bonita Continuous Delivery] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
 Alternatively, you can deploy an application by importing all its components in the following order:
 
 * Organization then profiles

--- a/modules/ROOT/pages/automating-builds.adoc
+++ b/modules/ROOT/pages/automating-builds.adoc
@@ -7,7 +7,7 @@ This allows to automate builds through scripts or any automation tooling.
 
 [WARNING]
 ====
-This way of building artifacts is deprecated. Use {bcdDocVersion}@bcd::livingapp_build.adoc[Bonita Continuous Delivery add-on] instead.
+This way of building artifacts is deprecated. Use xref:{bcdDocVersion}@bcd::livingapp_build.adoc[Bonita Continuous Delivery add-on] instead.
 ====
 
 [NOTE]
@@ -17,7 +17,7 @@ For Enterprise, Performance, Efficiency, and Teamwork editions only.
 
 [WARNING]
 ====
-The solution described here relies on the `Workspace API`/`BonitaStudioBuilder`, which has been deprecated since Bonita 7.7.0. Instead, we strongly encourage you to use the LA builder included in the tooling suite of {bcdDocVersion}@bcd::index.adoc[_Bonita Continuous Delivery_ add-on] add-on. One added-value is that LA builder does not need a studio to be installed.
+The solution described here relies on the `Workspace API`/`BonitaStudioBuilder`, which has been deprecated since Bonita 7.7.0. Instead, we strongly encourage you to use the LA builder included in the tooling suite of xref:{bcdDocVersion}@bcd::index.adoc[_Bonita Continuous Delivery_ add-on] add-on. One added-value is that LA builder does not need a studio to be installed.
 ====
 
 == Overview

--- a/modules/ROOT/pages/comparison-of-7-x-and-6-x.adoc
+++ b/modules/ROOT/pages/comparison-of-7-x-and-6-x.adoc
@@ -48,7 +48,7 @@ See the xref:bonita-bpm-installation-overview.adoc[Installation overview].
 
 | Workspace API
 | The Workspace API is provided to generate `.bar` files from the command line, ready for production. .bar files are for deployment only and cannot be read by the studio. .bos files are for Studio interchange only and cannot be deployed to production. Each file format is optimal in terms of content and is optimized for the target use case
-| The Workspace API retains its 6.x capabilities. Moreover, it can export forms that are mapped to process instantiations or tasks, and pages that are mapped to a case overview. It cannot export application pages that are not elements of a process. For this reason the Workspace API has been deprecated in 7.7.0, and is replaced by the _LA builder_ included in the tooling suite of {bcdDocVersion}@bcd::index.adoc [_Bonita Continuous Delivery_ add-on]. See xref:automating-builds.adoc[Automating builds]
+| The Workspace API retains its 6.x capabilities. Moreover, it can export forms that are mapped to process instantiations or tasks, and pages that are mapped to a case overview. It cannot export application pages that are not elements of a process. For this reason the Workspace API has been deprecated in 7.7.0, and is replaced by the _LA builder_ included in the tooling suite of xref:{bcdDocVersion}@bcd::index.adoc [_Bonita Continuous Delivery_ add-on]. See xref:automating-builds.adoc[Automating builds]
 |===
 
 == Feature improvements in Bonita Studio

--- a/modules/ROOT/pages/comparison-of-7-x-and-6-x.adoc
+++ b/modules/ROOT/pages/comparison-of-7-x-and-6-x.adoc
@@ -48,7 +48,7 @@ See the xref:bonita-bpm-installation-overview.adoc[Installation overview].
 
 | Workspace API
 | The Workspace API is provided to generate `.bar` files from the command line, ready for production. .bar files are for deployment only and cannot be read by the studio. .bos files are for Studio interchange only and cannot be deployed to production. Each file format is optimal in terms of content and is optimized for the target use case
-| The Workspace API retains its 6.x capabilities. Moreover, it can export forms that are mapped to process instantiations or tasks, and pages that are mapped to a case overview. It cannot export application pages that are not elements of a process. For this reason the Workspace API has been deprecated in 7.7.0, and is replaced by the _LA builder_ included in the tooling suite of xref:{bcdDocVersion}@bcd::index.adoc [_Bonita Continuous Delivery_ add-on]. See xref:automating-builds.adoc[Automating builds]
+| The Workspace API retains its 6.x capabilities. Moreover, it can export forms that are mapped to process instantiations or tasks, and pages that are mapped to a case overview. It cannot export application pages that are not elements of a process. For this reason the Workspace API has been deprecated in 7.7.0, and is replaced by the _LA builder_ included in the tooling suite of xref:{bcdDocVersion}@bcd::index.adoc[_Bonita Continuous Delivery_ add-on]. See xref:automating-builds.adoc[Automating builds]
 |===
 
 == Feature improvements in Bonita Studio

--- a/modules/ROOT/pages/set-up-continuous-integration.adoc
+++ b/modules/ROOT/pages/set-up-continuous-integration.adoc
@@ -12,7 +12,7 @@ For Enterprise, Performance, Efficiency, and Teamwork editions only.
 [WARNING]
 ====
 * The solution described here relies on the BonitaStudioBuilder, which has been deprecated since Bonita 7.7.0. Instead, we strongly encourage you to use the LA builder included in the tooling suite of Bonita Continuous Delivery add-on. One added-value is that LA builder does not need a studio to be installed.
-* {bcdDocVersion}@bcd::index.adoc[Bonita Continuous Delivery add-on] comes with an out-of-the-box solution based on Jenkins CI.
+* xref:{bcdDocVersion}@bcd::index.adoc[Bonita Continuous Delivery add-on] comes with an out-of-the-box solution based on Jenkins CI.
 ====
 
 With Continuous Integration (CI) your processes are continuously built and tested while you are designing them. Collaborating on process design can be enhanced with CI by ensuring the integrity of your processes along the development phase.

--- a/modules/ROOT/pages/software-extensibility.adoc
+++ b/modules/ROOT/pages/software-extensibility.adoc
@@ -141,7 +141,7 @@ If a form uses some Javascript code based on an element in the HTML Document Obj
 You can customize this mapping by defining your own bean and override property. See xref:custom-authorization-rule-mapping.adoc[Authorization Rule Mapping]
 * *BonitaStudioBuilder*
 Bonita Enterprise editions include a script, BonitaStudioBuilder (also known as the Workspace API), for building a bar file from a process in a project. This intended to be used for automating process builds in a continuous integration and testing environment. You can use the BonitaStudioBuilder to build a bar file for processes stored in a project.
-WorkspaceAPI is deprecated since Bonita 7.7.0. Instead, we strongly encourage you to use the _LA builder_ included in the tooling suite of {bcdDocVersion}@bcd::bcd_cli.adoc[_Bonita Continuous Delivery_ add-on]. One added-value is that LA builder does not need a Studio to be installed.
+WorkspaceAPI is deprecated since Bonita 7.7.0. Instead, we strongly encourage you to use the _LA builder_ included in the tooling suite of xref:{bcdDocVersion}@bcd::bcd_cli.adoc[_Bonita Continuous Delivery_ add-on]. One added-value is that LA builder does not need a Studio to be installed.
 
 Only the elements listed on this page are intended to be used as extension points. For other elements, there is no guarantee of stability, and a high probability of changes across versions.
 For example, the following should not be considered to be extension points:

--- a/modules/ROOT/pages/user-application-overview.adoc
+++ b/modules/ROOT/pages/user-application-overview.adoc
@@ -31,7 +31,7 @@ After Studio validation, the application is imported or cloned; you can view its
 
 == Access in pre-Production and in Production
 
-To deploy the applications into a bundle or the Cloud, you can use {bcdDocVersion}@bcd::livingapp_manage_configuration.adoc[Bonita Continuous Delivery]'s {bcdDocVersion}@bcd::bcd_cli.adoc[CLI] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
+To deploy the applications into a bundle or the Cloud, you can use xref:{bcdDocVersion}@bcd::livingapp_manage_configuration.adoc[Bonita Continuous Delivery]'s xref:{bcdDocVersion}@bcd::bcd_cli.adoc[CLI] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
 Alternatively, you can deploy an application by importing all its components in the following order:
 
 * Organization then profiles

--- a/modules/ROOT/pages/what-is-bonita.adoc
+++ b/modules/ROOT/pages/what-is-bonita.adoc
@@ -1,5 +1,5 @@
 = What is Bonita?
-:description: Bonita is an open-source and extensible platform for business process automation and optimization. Bonita Platform accelerates the development and production of business applications, with clear separation between capabilities for visual programming and for coding. +
+:description: Bonita is an open-source and extensible platform for business process automation and optimization.
 
 Bonita is an open-source and extensible platform for business process automation and optimization. Bonita Platform accelerates the development and production of business applications, with clear separation between capabilities for visual programming and for coding. +
 BPMN (Business Process Modeling Notation), full extensibility, and reusable components allow smooth collaboration among the different profiles on the IT team, and with the business teams. +
@@ -17,7 +17,7 @@ Starting with Bonita 7.10, you can also handle Adaptive Case Management (ACM) wi
 ACM is like DPA in the sense that it allows to handle cases with some automation. But it also relies on strong principles that make it different from DPA:
 
 * Empower the actors:
-Actors in charge of the case have some autonomy to lead the case to its closure: not all process paths are pre-determined. Some tasks are optional, some are discretionnary.
+Actors in charge of the case have some autonomy to lead the case to its closure: not all process paths are pre-determined. Some tasks are optional, some are discretionary.
 Actors' specific knowledge make them fully able to choose the right next action for a case.
 * Expect the unexpected:
 A case can be stopped, resumed and can even change its state at any time without a path being predefined. New tasks may need to be created on the fly to reflect the specificity of a case while still benefiting from traceability.
@@ -31,7 +31,6 @@ To learn more about how to use ACM capabilities in Bonita, check the dedicated x
 === Bonita Studio
 
 image:images/getting-started-tutorial/what-is-bonita/architecture-bonita-studio.png[Bonita Studio architecture]
-// {.img-responsive .img-thumbnail}
 
 Bonita Studio contains all the elements needed to develop and compile a Bonita application. It is a graphical environment for creating processes, applications, data models, and users views (pages and forms). It contains three major design tools:
 
@@ -53,7 +52,7 @@ You can xref:bonita-bpm-installation-overview.adoc[install Bonita Studio] on you
 
 Bonita Studio is not intended for any use other than development. As a consequence, the Bonita stack embedded into the Bonita Studio can not be used for production purposes.
 
-Bonita Studio contains a *Bonita Runtime* (Tomcat, UI Designer, Bonita Portal, Bonita Engine, and an h2 database), suitable for testing an application that is in development. When you run a process, it is automatically deployed onto the development platform.
+Bonita Studio contains a *Bonita Runtime* (Tomcat, UI Designer, Bonita Portal, Bonita Engine, and an H2 database), suitable for testing an application that is in development. When you run a process, it is automatically deployed onto the development platform.
 
 Process forms, used to complete the human tasks, are created in the UI Designer, and use the data models created in the Studio.
 
@@ -64,7 +63,6 @@ Users can use Bonita Portal (_User_ profile) to view and complete the process ta
 === Bonita stack, runtime and server
 
 image:images/getting-started-tutorial/what-is-bonita/architecture-bonita-stack.png[Bonita stack architecture]
-// {.img-responsive .img-thumbnail}
 
 The "Bonita stack" refers to all the components you need to deploy in order to make applications available to end users in production. It includes the Bonita runtime and the two database schemas (one for the Bonita Engine and one for business data).
 


### PR DESCRIPTION
The Antora references missed the 'xref' part.

In addition
  - fix wrong description in `what-is-bonita.adoc`
  - Build PR workflow: remove extra inputs