### PR TITLE
docs: use the new troubleshooting format in cluster-administration.adoc

### DIFF
--- a/modules/ROOT/pages/cluster-administration.adoc
+++ b/modules/ROOT/pages/cluster-administration.adoc
@@ -14,12 +14,6 @@ Discover how to administer, monitor and manage a Bonita cluster.
 Back up your cluster in the same as you would xref:back-up-bonita-bpm-platform.adoc[back up a standalone Bonita system], by backing up the database.
 You also need to back up the load balancer (see your load balancer documentation for details of how to do this).
 
-== Troubleshooting
-
-Each Bonita Engine maintains its own log file on the node at `<BUNDLE_HOME>/logs/bonita.`_`date`_`.log`, where _`date`_ is the date the file is created.
-In addition, there is an incident file `<BUNDLE_HOME>/logs/tenants/[TENANT_ID]/incident.log` (where `[TENANT_ID]` is the ID of the tenant on which the error
-occurred) that is used as a last resort to record an error that cannot be handled, such as failure to access the database.
-
 == Monitoring a process
 
 To monitor a process in a cluster, use the Bonita Portal as usual. The information presented applies to process activity on all nodes in the cluster.
@@ -36,3 +30,15 @@ You can also xref:manage-a-process.adoc[deploy a process using the API], exactly
 == Managing your organization in a cluster
 
 The organization data used by Bonita is stored in the database, so only has to be configured once. It can be maintained from any Bonita Portal in the cluster.
+
+[.troubleshooting-title]
+== Troubleshooting
+
+[.troubleshooting-section]
+--
+[.symptom]
+_Each Bonita Engine maintains its own log file on the node
+
+[.symptom-description]
+You can find it under <BUNDLE_HOME>/logs/bonita.``date`.log`, where `date` is the date the file is created.
+In addition, there is an incident file <BUNDLE_HOME>/logs/tenants/[TENANT_ID]/incident.log (where [TENANT_ID] is the ID of the tenant on which the error occurred) that is used as a last resort to record an error that cannot be handled, such as failure to access the database.

--- a/modules/ROOT/pages/cluster-administration.adoc
+++ b/modules/ROOT/pages/cluster-administration.adoc
@@ -37,7 +37,7 @@ The organization data used by Bonita is stored in the database, so only has to b
 [.troubleshooting-section]
 --
 [.symptom]
-_Each Bonita Engine maintains its own log file on the node
+Each Bonita Engine maintains its own log file on the node
 
 [.symptom-description]
 You can find it under <BUNDLE_HOME>/logs/bonita.``date`.log`, where `date` is the date the file is created.


### PR DESCRIPTION
Versions: 2021.1, 2021.2, 2022.1 and 2022.2

Update the troubleshooting section by using the new format proposed by Benjamin