### PR TITLE
refactor(style): remove extra comments

### DIFF
--- a/modules/ROOT/pages/admin-application-groups-list.adoc
+++ b/modules/ROOT/pages/admin-application-groups-list.adoc
@@ -7,7 +7,6 @@ Groups can be defined in the organization, users can then be added to groups, an
 
 Here is a view of this page:
 image:images/UI2021.1/admin-application-groups-list.png[Administrator groups list Portal]
-// {.img-responsive}
 
 On this page, an Administrator can:
 

--- a/modules/ROOT/pages/admin-application-process-list.adoc
+++ b/modules/ROOT/pages/admin-application-process-list.adoc
@@ -8,7 +8,6 @@ Those users can: install, enable and edit processes, categories, forms, entities
 Here is a view of the Process list page:
 
 image:images/UI2021.1/admin-process-list-portal.png[Administrator Process list in Portal]
-// {.img-responsive}
 
 == Install a new process
 

--- a/modules/ROOT/pages/admin-application-profiles-list.adoc
+++ b/modules/ROOT/pages/admin-application-profiles-list.adoc
@@ -9,7 +9,6 @@ In Enterprise, Performance, and Efficiency editions, Administrators can also cre
 
 Here is a view of this page:
 image:images/UI2021.1/admin-application-profiles-list.png[Profiles in Portal]
-// {.img-responsive}
 
 == View profile and profile mappings
 

--- a/modules/ROOT/pages/admin-application-resources-list.adoc
+++ b/modules/ROOT/pages/admin-application-resources-list.adoc
@@ -7,7 +7,6 @@ _Administrators_ can view a list of the resources filtered by type, search a res
 
 Here is a view of the page:
 image:images/UI2021.1/admin-application-resources-list.png[Administrator Resources]
-// {.img-responsive}
 
 == Resource definition
 

--- a/modules/ROOT/pages/admin-application-roles-list.adoc
+++ b/modules/ROOT/pages/admin-application-roles-list.adoc
@@ -7,7 +7,6 @@ Roles can be defined in the organization, users can then be added to roles, and 
 
 Here is a view of this page:
 image:images/UI2021.1/roles-portal.png[Administrator roles Portal]
-// {.img-responsive}
 
 On this page, an Administrator can:
 

--- a/modules/ROOT/pages/admin-application-task-list.adoc
+++ b/modules/ROOT/pages/admin-application-task-list.adoc
@@ -8,7 +8,6 @@ Those users can view the list of flow nodes in error, pending tasks, done tasks,
 
 Here is a view of the task list:
 image:images/UI2021.1/admin-application-task-list.png[Task list Administrator Application]
-// {.img-responsive}
 
 == View tasks and flow nodes
 

--- a/modules/ROOT/pages/admin-application-users-list.adoc
+++ b/modules/ROOT/pages/admin-application-users-list.adoc
@@ -5,7 +5,6 @@ This page explains what a user with the _Administrator_ profile can see and do a
 
 Here is a view of this page:
 image:images/UI2021.1/admin-application-users-list.png[Administrator user list Portal]
-// {.img-responsive}
 
 == View user's detailed information
 

--- a/modules/ROOT/pages/analytics.adoc
+++ b/modules/ROOT/pages/analytics.adoc
@@ -14,7 +14,6 @@ For Enterprise, Performance, Efficiency, and Teamwork editions only.
 
 Here is a view of the page:
 image:images/UI2021.1/analytics.png[Analytics]
-// {.img-responsive}
 
 == Provided reports
 

--- a/modules/ROOT/pages/applications.adoc
+++ b/modules/ROOT/pages/applications.adoc
@@ -5,7 +5,6 @@ This page defines the term "Application" and explains what a user with the Admin
 
 Here is a view of the page:
 image:images/UI2021.1/admin_applications.png[Administrator Applications]
-// {.img-responsive}
 
 == Application definition
 

--- a/modules/ROOT/pages/bdm-management-in-bonita-bpm-portal.adoc
+++ b/modules/ROOT/pages/bdm-management-in-bonita-bpm-portal.adoc
@@ -8,7 +8,6 @@ On top of that, it is possible to define access rights on some attributes of bus
 
 Here is a view of the page:
 image:images/UI2021.1/bdm-management.png[BDM in UI]
-// {.img-responsive}
 
 == Manage the BDM
 

--- a/modules/ROOT/pages/bo-multiple-refs-tutorial.adoc
+++ b/modules/ROOT/pages/bo-multiple-refs-tutorial.adoc
@@ -14,12 +14,10 @@ _Design a task contract and associated operations to update a business object wi
 Create an *Expense* business object like below.
 
 image:images/bdm-tuto/bdm-expense.png[Expense business object]
-// {.img-responsive}
 
 Then create *ExpenseReport* business object referencing multiple expenses by composition.
 
 image:images/bdm-tuto/bdm-expense-report.png[Expense report business object]
-// {.img-responsive}
 
 == Design the expense report process
 
@@ -53,7 +51,6 @@ image:images/bdm-tuto/bdm-expense-report.png[Expense report business object]
 * Create a contract like below
 
 image:images/bdm-tuto/contract.png[Contract]
-// {.img-responsive}
 
 _newExpenses_ input is used to gather a list of new expenses to add to the report
  _expensesToDelete_ input is used to gather a list of _Expense_ id to delete
@@ -163,9 +160,8 @@ It should display this result according to the initialization of the report busi
 * Perform the Update expense report task like below
 
 image:images/bdm-tuto/form1.png[Form 1]
-// {.img-responsive}
+
 image:images/bdm-tuto/form-2.png[Form 2]
-// {.img-responsive}
 
 * In a web browser, check the content of your report calling the following Rest API:
 http://localhost:8080/bonita/API/bdm/businessData/com.company.model.ExpenseReport/1/expenses

--- a/modules/ROOT/pages/cases.adoc
+++ b/modules/ROOT/pages/cases.adoc
@@ -7,7 +7,6 @@ Those users can view a list of open or archived cases, as well as cases with fai
 
 Here is a view of the page:
 image:images/UI2021.1/admin-case-list.png[Admin Case list]
-// {.img-responsive}
 
 == View the status of cases
 

--- a/modules/ROOT/pages/configure-email-connector.adoc
+++ b/modules/ROOT/pages/configure-email-connector.adoc
@@ -20,7 +20,6 @@ To avoid settings that are specific to a real email provider, use a tool for a f
 . Click on *Start server*
 +
 image:images/getting-started-tutorial/configure-email-connector/fakesmtp-configured-and-listening.png[FakeSMTP configured and listening]
-// {.img-responsive .img-thumbnail}
 
 Now that you have a fake email server running, configure the email connector on the _Deal with unsatisfied customer_ task:
 
@@ -46,7 +45,6 @@ Now that you have a fake email server running, configure the email connector on 
 . Click on *Finish*
 +
 image:images/getting-started-tutorial/configure-email-connector/configure-email-connector.gif[Email connector configuration]
-// {.img-responsive .img-thumbnail}
 
 Run the process with the connector configured, and see a new incoming email in the FakeSMTP user interface when task _Deal with unsatisfied customer_ becomes available.
 

--- a/modules/ROOT/pages/create-web-user-interfaces.adoc
+++ b/modules/ROOT/pages/create-web-user-interfaces.adoc
@@ -27,7 +27,6 @@ Start with the process instantiation form:
 . Click on *Save* to save the form with its new name
 +
 image:images/getting-started-tutorial/create-web-user-interfaces/create-instantiation-form.gif[Create process instantiation form based on contract definition]
-// {.img-responsive .img-thumbnail}
 
 Customize the form appearance. For example, you can switch from a one line text widget to a text area widget:
 
@@ -39,11 +38,9 @@ Customize the form appearance. For example, you can switch from a one line text 
 . Click on *Save* to save your modifications
 +
 image:images/getting-started-tutorial/create-web-user-interfaces/switch-widget.gif[Switch to a different widget type]
-// {.img-responsive .img-thumbnail}
 
 [NOTE]
 ====
-
 The xref:widgets.adoc[switch menu option] can be used to replace one widget with another one while keepiing the current configuration.
 ====
 

--- a/modules/ROOT/pages/custom-user-information-in-bonita-bpm-portal.adoc
+++ b/modules/ROOT/pages/custom-user-information-in-bonita-bpm-portal.adoc
@@ -7,7 +7,6 @@ Administrators can view and update Custom User Information.
 
 Here is a view of this page:
 image:images/UI2021.1/custom-user-info.png[Custom User Information UI]
-// {.img-responsive}
 
 == Overview
 

--- a/modules/ROOT/pages/deactivate-a-user.adoc
+++ b/modules/ROOT/pages/deactivate-a-user.adoc
@@ -14,7 +14,6 @@ In consequence, the _Add membership_ button is not displayed for an inactive use
 
 Here is a view of this page:
 image:images/UI2021.1/user-deactivate.png[Administrator user deactivation]
-// {.img-responsive}
 
 == Deactivate a user
 

--- a/modules/ROOT/pages/declare-business-variables.adoc
+++ b/modules/ROOT/pages/declare-business-variables.adoc
@@ -16,7 +16,6 @@ In our process we will deal with a single object: a claim. The claim object will
 . Select the process pool, the rectangle that contains events and tasks.
 +
 image:images/getting-started-tutorial/declare-business-variable/select-process-pool.gif[Select the pool]
-// {.img-responsive .img-thumbnail}
 
 . At the bottom of the Bonita Studio screen, go to menu:Data[Pool variables]
 . Click on *Add...* next to *Business variables*
@@ -25,7 +24,6 @@ image:images/getting-started-tutorial/declare-business-variable/select-process-p
 . Click on *Finish*
 +
 image:images/getting-started-tutorial/declare-business-variable/declare-business-variable.gif[Declare business variable]
-// {.img-responsive .img-thumbnail}
 
 Now that a business variable is declared, use it in the transition condition definition:
 
@@ -43,17 +41,14 @@ You can also enter the Groovy script directly: `claim.satisfactionLevel < 3`
 ====
 
 image:images/getting-started-tutorial/declare-business-variable/define-condition.gif[Define transition condition using business variable value]
-// {.img-responsive .img-thumbnail}
 
 [NOTE]
 ====
-
 The script configured for the transition condition will return `true` if the satisfaction level given is lower than 3, as the transition to _Deal with unsatisfied customer_ will be activated.
 ====
 
 [NOTE]
 ====
-
 The business variable has never been initialized so it will remain empty. There are several options available to initialize a business variable:
 
 * business variable default value

--- a/modules/ROOT/pages/declare-contracts.adoc
+++ b/modules/ROOT/pages/declare-contracts.adoc
@@ -27,11 +27,9 @@ Create the contract for process instantiation:
 . You can ignore the information message and click on *OK*
 +
 image:images/getting-started-tutorial/declare-contracts/declare-process-instantiation-contract.gif[Declare process instantiation contract]
-// {.img-responsive .img-thumbnail}
 
 [NOTE]
 ====
-
 You now have a contract named _claimedInput_ of type "COMPLEX," with one attribute, _description_ of type "TEXT".
 ====
 
@@ -49,16 +47,13 @@ Now let's create the contract for the user task _Review and answer claim_:
 . Ignore the information and warning messages and click on *OK*
 +
 image:images/getting-started-tutorial/declare-contracts/declare-user-task-contract.gif[Declare user task contract]
-// {.img-responsive .img-thumbnail}
 
 [NOTE]
 ====
-
 We now have a contract for the step. This contract does not create a new claim, but updates an attribute of the claim (which is created when we start the process).
 The attribute update is performed by an operation (generated for you) on the task. Select menu:Execution[Operations] to view the operation that updates the _answer_ attribute, as shown in this image:
 
 image:images/getting-started-tutorial/declare-contracts/operation.png[Operation]
-// {.img-responsive .img-thumbnail}
 ====
 
 Create the contract for the _Read the answer and rate it_ task:

--- a/modules/ROOT/pages/define-who-can-do-what.adoc
+++ b/modules/ROOT/pages/define-who-can-do-what.adoc
@@ -14,7 +14,6 @@ The first step in the configuration of "who can do what" is to create xref:pools
 . Select the _employee lane_ and click on the down arrow icon to move it, so it becomes the middle lane
 +
 image:images/getting-started-tutorial/define-who-can-do-what/add-and-organize-lanes.gif[Add and organize lanes]
-// {.img-responsive .img-thumbnail}
 
 . Select _Lane1_, go to the menu:General[Lane] tab, and rename it _Customer lane_
 . Select  _Lane2_, go to the menu:General[Lane] tab and rename it _Manager lane_
@@ -22,11 +21,9 @@ image:images/getting-started-tutorial/define-who-can-do-what/add-and-organize-la
 . Select the _Deal with unsatisfied customer_ task and move it to the _Manager lane_. Do the same with the end event _End client unsatisfied_
 +
 image:images/getting-started-tutorial/define-who-can-do-what/diagrams-with-lanes.png[Diagrams with lanes]
-// {.img-responsive .img-thumbnail}
 
 [NOTE]
 ====
-
 A lane is used to group together user tasks that are to be done by the same set of users.
 ====
 
@@ -40,14 +37,12 @@ Now we need to define "actors," one for each lane, and map them to the lane they
 . Select the _Customer actor_ and click on *Set as initiator*. This will add a flag on this actor, to mark it as the one who can start the process
 +
 image:images/getting-started-tutorial/define-who-can-do-what/add-rename-actors-set-initiator.gif[Add and rename actors, define initiator]
-// {.img-responsive .img-thumbnail}
 
 . Select _Customer lane_ (click on the lane name)
 . Go to menu:General[Actors] and in the drop down list, select _Customer actor_
 . Do the same for the _Manager lane_ with the _Manager actor_
 +
 image:images/getting-started-tutorial/define-who-can-do-what/map-actor-to-lane.gif[Map actor to lane]
-// {.img-responsive .img-thumbnail}
 
 "Actor" identifies a collection of users. To define the actual users, we need to configure the actors and map them with groups, roles, users, etc of an organization. We will use the Bonita Acme test organization for this example:
 
@@ -59,7 +54,6 @@ image:images/getting-started-tutorial/define-who-can-do-what/map-actor-to-lane.g
 . Click on *Finish*
 +
 image:images/getting-started-tutorial/define-who-can-do-what/configure-actor-mapping.gif[Configure actor mapping for customer actor]
-// {.img-responsive .img-thumbnail}
 
 . Select *Customer actor*
 . Click on *Groups...*
@@ -82,7 +76,6 @@ To refine this, we will configure xref:actor-filtering.adoc[actor filters].
 
 [NOTE]
 ====
-
 The actor filter produces a list of users based on input information and internal logic. It overrides the actor configuration. +
 The actor filter will be executed when the process reaches a step to which the filter is mapped.
 ====
@@ -98,7 +91,6 @@ First configure the *initiator* actor filter:
 . Click on *Finish*
 +
 image:images/getting-started-tutorial/define-who-can-do-what/configure-initiator-actor-filter.gif[Configure initiator actor filter on Customer lane]
-// {.img-responsive .img-thumbnail}
 
 Now we will configure the *manager* actor filter:
 
@@ -133,7 +125,6 @@ import org.bonitasoft.engine.search.SearchResult
 . Click on *Finish*
 +
 image:images/getting-started-tutorial/define-who-can-do-what/configure-user-manager-actor-filter.gif[Configure user manager actor filter for manager lane]
-// {.img-responsive .img-thumbnail}
 
 Run the process again, and this time only _mauro.zetticci_ should have access to _Review and answer claim_ and only _michael.morrison_ should have access to _Deal with unsatisfied customer_ (as the manager of both users who can complete the task _Review and answer claim_).
 

--- a/modules/ROOT/pages/design-application-page.adoc
+++ b/modules/ROOT/pages/design-application-page.adoc
@@ -21,18 +21,16 @@ For this example, we will build a basic page that displays, in a table, all the 
 . Click on *Create*
 +
 image:images/getting-started-tutorial/design-application-page/creation-of-an-application-page.gif[Creation of an application page]
-// {.img-responsive .img-thumbnail}
 
 On the new page, using the xref:data-management.adoc[data management] capabilities, the UI Designer can automatically create xref:variables.adoc[variables] to retrieve business data and generate the user interface:
 
-. At the top left corner of the UI Designer, click on  *Data model* image:images/getting-started-tutorial/design-application-page/data-model.png[Data model button]
+. In the top left corner of the UI Designer, click on  *Data model* image:images/getting-started-tutorial/design-application-page/data-model.png[Data model button]
 . In the list of business objects, select the _Claim_ object and drag and drop it into the empty space of the page
 . In the popup window, change *Variable name* from _claim_ to _claims_
-. In *Additionnal queries*, select _find_
+. In *Additional queries*, select _find_
 . Click on *Save*
 +
 image:images/getting-started-tutorial/design-application-page/declare-claims-page-variable.gif[Declare claims page variable]
-// {.img-responsive .img-thumbnail}
 
 The UI Designer automatically created 2 variables which will be used to retrieve and display business data in the application page:
 
@@ -40,7 +38,6 @@ The UI Designer automatically created 2 variables which will be used to retrieve
 * `claim_selected`` of type *String* which returns the list of claims
 +
 image:images/getting-started-tutorial/design-application-page/variables.png[variables]
-// {.img-responsive .img-thumbnail}
 
 A dashboard page is also automatically generated in the whiteboard. It follows the master/details pattern using xref:widgets.adoc[containers]:
 
@@ -48,20 +45,17 @@ A dashboard page is also automatically generated in the whiteboard. It follows t
 * The details section maps each Business Object attribute to a corresponding widget (for instance, an Input widget for an attribute of type String)
 +
 image:images/getting-started-tutorial/design-application-page/dashboard-page.png[dashboard page]
-// {.img-responsive .img-thumbnail}
 
 . Click on *Save* in the UI Designer
 . Click on *Preview* to get a preview of your page
 
 [WARNING]
 ====
-
 In order for preview to access the data, a user needs to be logged in to the Bonita Portal. You can click on *Portal* in the Bonita Studio tool bar to make sure a user is logged in.
 ====
 
 The preview should look like this:
 
 image:images/getting-started-tutorial/design-application-page/dashboard-page-preview.png[dashboard page preview]
-// {.img-responsive .img-thumbnail}
 
 Now you have your first application page. It's time to move to the xref:create-application.adoc[next chapter] and create the xref:create-application.adoc[application] that will include the page.

--- a/modules/ROOT/pages/diagram-tasks.adoc
+++ b/modules/ROOT/pages/diagram-tasks.adoc
@@ -140,7 +140,6 @@ First, create a new diagram. Then model the process in the first pool:
 The pool is shown here:
 
 image:images/leave_request_management_process_tasklist.png[Process]
-// {.img-responsive .img-thumbnail}
 
 ==== Data model
 
@@ -175,7 +174,6 @@ The default values of business data attributes mapped to contract inputs are aut
 . In the *Execution* pane > *Contract* tab, a complex contract input is created, mapped to the selected attributes of the *leaveRequest* business variable, as shown here:
 
 image:images/contract_for_tasklist.png[Contract]
-// {.img-responsive .img-thumbnail}
 
 In actual BPM projects, we recommend you to also add a description to each contract input. It will be used as input field caption for end-users in the auto-generated form, if you decide to use such forms up to the User Acceptance Test phase of your project.
 
@@ -227,7 +225,6 @@ For the sake of this howto, do not specify any contract or form on the task, but
 The operation is shown here:
 
 image:images/operation_on_status.png[Operation on status]
-// {.img-responsive .img-thumbnail}
 
 There you go. The process is ready. So how can you set a unique name for tasks, to be displayed in the user task list?
 
@@ -324,7 +321,6 @@ The table settings have changed to display the *Description* column. It will be 
 You can see the description field, showing the status: "submitted", as shown here:
 
 image:images/display_task_name_and_description.png[display task name and description]
-// {.img-responsive .img-thumbnail}
 
 . Logout
 . Login with helen.kelly / bpm credentials (since Helen Kelly is Walter Bates' manager)
@@ -334,7 +330,6 @@ image:images/display_task_name_and_description.png[display task name and descrip
 The *Description* column now shows the description after completion, with an edited status as well as the name of who performed the task, as shown here :
 
 image:images/description_after_completion.png[description after completion]
-// {.img-responsive .img-thumbnail}
 
 If you don't use the description after completion field, the *Description* column will still show the "display description" information.
 

--- a/modules/ROOT/pages/draw-bpmn-diagram.adoc
+++ b/modules/ROOT/pages/draw-bpmn-diagram.adoc
@@ -40,7 +40,6 @@ The first step is the design of the process "happy path."
 
 [NOTE]
 ====
-
 While drawing the model, you will use and learn about some basic BPMN elements used in most process diagrams:
 
 * xref:pools-and-lanes.adoc[Pool]: a pool is a container for a process in a diagram.
@@ -55,7 +54,6 @@ Create a new diagram:
 . In the Bonita Studio menu, click on menu:File[New diagram].
 +
 image:images/getting-started-tutorial/draw-bpmn-diagram/new-diagram.gif[Add user task]
-// {.img-responsive .img-thumbnail}
 
 The new diagram includes:
 
@@ -203,17 +201,14 @@ You can now build, package, deploy and execute this process definition in the Bo
 . Click on the *View case overview* action (i.e. the "eye" icon) to display the overview form with information about process execution
 
 image:images/getting-started-tutorial/draw-bpmn-diagram/run-process.gif[Process execution]
-// {.img-responsive .img-thumbnail}
 
 [NOTE]
 ====
-
 When you click on the *Run* button, the process definition and its dependencies are built, packaged and deployed in the Bonita Studio test environment. A user is logged in by default (username: _walter.bates_, password: _bpm_) and the auto-generated start form for the process is opened in your web browser. If you submit the instantiation form, it will start a new process instance (or case) and load the user task list in the Bonita Portal. In the task list, you can't immediately submit a user task because, by default, all users (of the test organization) are candidates to perform the tasks of the process. In order to act on the task you need first to "claim" it, which then makes you the only one - among all the possible candidates - who can do perform an action on it.
 ====
 
 [NOTE]
 ====
-
 You can view process instance information in the xref:cases.adoc[*Cases*] section of the Bonita Portal. Switch between *Open cases* and *Archived cases* to view the ongoing process instances or see completed ones. Note that if you want to start a second case (i.e. a process instance), you must go into the Bonita Portal *Processes* menu and click on the *Start a new case* button (i.e. the "play" icon in the *Action* column) next to the process definition name. If you click on *Run* from Bonita Studio, it will clean / overwrite any information related to any process with same name and version, including previous cases. Note that if you did any modifications to your project, you probably want to click on *Run* to be sure that the latest version is deployed.
 ====
 

--- a/modules/ROOT/pages/group.adoc
+++ b/modules/ROOT/pages/group.adoc
@@ -7,7 +7,6 @@ Groups can be defined in the organization, attached to users and used to map pro
 
 Here is a view of this page:
 image:images/UI2021.1/groups-portal.png[Administrator groups list Portal]
-// {.img-responsive}
 
 == Create a group
 
@@ -18,7 +17,6 @@ image:images/UI2021.1/groups-portal.png[Administrator groups list Portal]
 
 [NOTE]
 ====
-
 Bonita doesn't accept the '/' character in the group name field. A group name that contains a '/' may lead to unstable behaviour.
 ====
 

--- a/modules/ROOT/pages/import-export-an-organization.adoc
+++ b/modules/ROOT/pages/import-export-an-organization.adoc
@@ -1,24 +1,21 @@
 = Install/export an organization
-:description: This page explains what a user with the _Administrator_ profile in Bonita Portal or in the Bonita Administrator Application can see and do about the Organization of Bonita users (an .xml file).
+:description: This page explains what a user with the Administrator profile in Bonita Portal or in the Bonita Administrator Application can see and do about the Organization of Bonita users (an .xml file).
 
 This page explains what a user with the _Administrator_ profile in Bonita Portal or in the Bonita Administrator Application can see and do about the Organization of Bonita users (an .xml file).
 
 Here is a view of this page:
 image:images/UI2021.1/install-export.png[Install export organization]
-// {.img-responsive}
 
 == How to install an organization
 
 [WARNING]
 ====
-
 This will import a file containing your whole organization data. This organization data will be merged with existing data. +
 In case of conflict, the priority is given to the data in the imported file. Take care not to overwrite information that has been updated in Bonita Portal since the last installation of the organization.
 ====
 
 [NOTE]
 ====
-
 In 6.3 there was a change to the structure of the .xml file. This means that you cannot install into Bonita Portal 6.3.0 or later an organization .xml file that was created in 6.2.x or earlier. +
 You will need to first install the organization file into Bonita Studio and re-export it, so it is compatible.
 ====

--- a/modules/ROOT/pages/languages.adoc
+++ b/modules/ROOT/pages/languages.adoc
@@ -57,7 +57,6 @@ To select another language, if the application uses the default xref:bonita-layo
 . Close the modal window
 
 image:images/UI2021.1/select-language.png[Select language]
-// {.img-responsive}
 
 == Select a language in a custom application
 
@@ -68,7 +67,6 @@ If the layout has been customized, users need to refer to the internally documen
 
 [NOTE]
 ====
-
 Instructions below assume that the language you want to add is already available in the Community translation project. If translation is not available see <<Translate_BonitaB_PM_Portal,Translate Bonita Portal>> for instruction about how to collaborate to a new or ongoing translation.
 ====
 
@@ -103,7 +101,6 @@ Instructions below explain how to add a language to Bonita Portal. Steps below i
 
 [WARNING]
 ====
-
 The `mobile_xxxx.po/.pot` files used for the language of the xref:mobile-portal.adoc[Bonita Mobile Portal] may contain some keys missing translation. For the Mobile Portal to be displayed correctly in the new language, these keys must not be empty.
 
 On the other hand, some of the keys in the `mobile_xxxx.po/.pot` files are duplicates from the ones in other non-mobile `.po/.pot` files. These keys must all have the same value (whether translated or chosen to be left in English) across all the `.po/.pot` files.

--- a/modules/ROOT/pages/log-in-and-log-out.adoc
+++ b/modules/ROOT/pages/log-in-and-log-out.adoc
@@ -37,7 +37,6 @@ For Bonita Portal:
 . Click on *Logout*
 
 image:images/UI2021.1/logout.png[Logout]
-// {.img-responsive}
 
 For an application:
 
@@ -45,12 +44,10 @@ For an application:
 . Click on *Sign out*
 
 image:images/UI2021.1/sign-out.png[Sign out]
-// {.img-responsive}
 
 [NOTE]
 ====
-
-Note: in a system that uses a solution to provide single sign-on (with SAML, CAS, etc...), the administrator can remove the logout option. In this case, to log out of the portal or an application, you must log out of the SSO system or close your browser.
+In a system that uses a solution to provide single sign-on (with SAML, CAS, etc...), the administrator can remove the logout option. In this case, to log out of the portal or an application, you must log out of the SSO system or close your browser.
 ====
 
 See also xref:first-steps-after-setup.adoc[First steps after setup]

--- a/modules/ROOT/pages/manage-jar-files.adoc
+++ b/modules/ROOT/pages/manage-jar-files.adoc
@@ -17,7 +17,6 @@ You can also access the *Manage dependencies...* dialog from the process configu
 == Known integration issues
 
 Duplicate libraries
-// {.h2}
 
 There is a problem at integration if you have several elements in your platform that use certain libraries that cannot be included in more than one classloader.
 Typically, this occurs when a process contains data of type Java or multiple connectors (notably with the Webservice, Alfresco, and CMIS connectors).

--- a/modules/ROOT/pages/navigation.adoc
+++ b/modules/ROOT/pages/navigation.adoc
@@ -5,7 +5,6 @@
 
 The default Portal profile is User. From there, the user can navigate to their other profiles. +
 image:images/UI2021.1/navigation-portal.png[Navigation Portal]
-// {.img-responsive}
 
 == In Bonita Applications
 
@@ -16,4 +15,3 @@ In both cases, the user can navigate between applications they have the permissi
 . The user clicks on the _mosaïc_ icon in the Application header
 . The user selects the tile of the application to navigate to
 image:images/UI2021.1/navigation-application.png[Navigation Application]
-// {.img-responsive}

--- a/modules/ROOT/pages/optimize-user-tasklist.adoc
+++ b/modules/ROOT/pages/optimize-user-tasklist.adoc
@@ -28,7 +28,6 @@ First, create a new diagram. Then model the process in the first pool:
 The pool is shown here:
 
 image:images/leave_request_management_process_tasklist.png[Process]
-// {.img-responsive .img-thumbnail}
 
 === Data model
 
@@ -65,7 +64,6 @@ The default values of business data attributes mapped to contract inputs are aut
 . In the *Execution* pane > *Contract* tab, a complex contract input is created, mapped to the selected attributes of the *leaveRequest* business variable, as shown here:
 
 image:images/contract_for_tasklist.png[Contract]
-// {.img-responsive .img-thumbnail}
 
 In actual BPM projects, we recommend you to also add a description to each contract input. It will be used as input field caption for end-users in the auto-generated form, if you decide to use such forms up to the User Acceptance Test phase of your project.
 
@@ -117,7 +115,6 @@ For the sake of this howto, do not specify any contract or form on the task, but
 The operation is shown here:
 
 image:images/operation_on_status.png[Operation on status]
-// {.img-responsive .img-thumbnail}
 
 There you go. The process is ready. So how can you set a unique name for tasks, to be displayed in the user task list?
 
@@ -210,7 +207,6 @@ The table settings have changed to display the *Description* column. It will be 
 You can see the description field, showing the status: "submitted", as shown here:
 +
 image:images/display_task_name_and_description.png[display task name and description]
-// {.img-responsive .img-thumbnail}
 +
 . Logout
 . Login with helen.kelly / bpm credentials (since Helen Kelly is Walter Bates' manager)
@@ -220,7 +216,6 @@ image:images/display_task_name_and_description.png[display task name and descrip
 The *Description* column now shows the description after completion, with an edited status as well as the name of who performed the task, as shown here :
 +
 image:images/description_after_completion.png[description after completion]
-// {.img-responsive .img-thumbnail}
 +
 If you don't use the description after completion field, the *Description* column will still show the "display description" information.
 +

--- a/modules/ROOT/pages/portal-user-case-list.adoc
+++ b/modules/ROOT/pages/portal-user-case-list.adoc
@@ -10,7 +10,6 @@ Then on a given case, they can view the case overview, access the case details, 
 
 Here is a view of the User case list.
 image:images/UI2021.1/user-case-list.png[User Case list]
-// {.img-responsive}
 
 This list displays the cases in which the logged user is involved:
 
@@ -82,7 +81,7 @@ Depending on the quality of the Internet connexion, less items will display fast
 At the begining of each row, the case Id is a clickable link to see more details for the case.
 Here is an example of the case details page.
 image:images/UI2021.1/user-case-details.png[User Case details]
-// {.img-responsive}
+
 It displays:
 
 * At the top, all metadata about the case
@@ -97,7 +96,6 @@ From the case details (button on the top right), or from the case list (_eye_ ic
 To know more about the customization of the case overview, go to the xref:uid-case-overview-tutorial.adoc[Case overview] page.
 Here is an example of the case overview provided by Bonita.
 image:images/UI2021.1/case-overview.png[Case Overview]
-// {.img-responsive}
 
 It displays:
 

--- a/modules/ROOT/pages/processes.adoc
+++ b/modules/ROOT/pages/processes.adoc
@@ -8,7 +8,6 @@ Those users can: install, enable and edit processes, categories, forms, entities
 Here is a view of the Process list page:
 
 image:images/UI2021.1/admin-application-process-list.png[Process list in Administrator Application]
-// {.img-responsive}
 
 == Install a new process
 

--- a/modules/ROOT/pages/profile-list-portal.adoc
+++ b/modules/ROOT/pages/profile-list-portal.adoc
@@ -7,7 +7,6 @@ In Enterprise, Performance, and Efficiency editions, they can also create new pr
 
 Here is a view of this page:
 image:images/UI2021.1/profiles-portal.png[Profiles in Portal]
-// {.img-responsive}
 
 == View profiles
 

--- a/modules/ROOT/pages/repeat-a-container-for-a-collection-of-data.adoc
+++ b/modules/ROOT/pages/repeat-a-container-for-a-collection-of-data.adoc
@@ -36,7 +36,6 @@ In this example, the collection of data is a list of fruits. You want to display
 . Check the Preview, which should look something like this:
 
 image:images/images-6_0/UID_ContainerSimpleFruits.png[Simple collection repeated]
-// {.img-responsive}
 
 A user can modify the name of a fruit by typing in the input field.
 

--- a/modules/ROOT/pages/resource-management.adoc
+++ b/modules/ROOT/pages/resource-management.adoc
@@ -7,7 +7,6 @@ _Administrators_ can view a list of the resources filtered by type, install new 
 
 Here is a view of the page:
 image:images/UI2021.1/admin_resources_portal.png[Administrator Resources]
-// {.img-responsive}
 
 == Resource definition
 

--- a/modules/ROOT/pages/role.adoc
+++ b/modules/ROOT/pages/role.adoc
@@ -6,7 +6,6 @@ Roles can be defined in the organization, attached to users and used to map acto
 
 Here is a view of this page:
 image:images/UI2021.1/roles-portal.png[Administrator roles Portal]
-// {.img-responsive}
 
 == Create a role
 

--- a/modules/ROOT/pages/rta-mail-template.adoc
+++ b/modules/ROOT/pages/rta-mail-template.adoc
@@ -23,7 +23,6 @@ The process consists of a :
 The process will look like this:
 
 image:images/rta-mail/rta-mail-template-ooomprocess.png[Out of office message process]
-// {.img-responsive}
 
 Conditions are set on the transition out of the _Check Email content_ task allowing to know which path to use.
 
@@ -35,7 +34,6 @@ We create a *Business Data Model* to hold the user informations :
 * _body_: the mail body as a *STRING* with a _length_ of 2048
 
 image:images/rta-mail/rta-mail-template-ooom-bdm.png[Out of office message business model]
-// {.img-responsive}
 
 A business object variable will be created at pool level, named *outOfOfficeMessage*. It will to be initialized via a Groovy script with the mail template of the out of office message. +
 The template will be filled with the initiator information and its manager contact:
@@ -87,12 +85,10 @@ This variable needs to be mapped with a contract data too.
 The contract will look like this :
 
 image:images/rta-mail/rta-mail-template-ooom-check-mail-contract.png[Out of office message - Check email content - contract]
-// {.img-responsive}
 
 And the operation pane will look like this:
 
 image:images/rta-mail/rta-mail-template-ooom-check-mail-operations.png[Out of office message - Check email content - contract]
-// {.img-responsive}
 
 ==== Out transition
 
@@ -143,7 +139,6 @@ It will look like this:
 On 'Check Email content' task, in the menu:Execution[Form] pane, use the pencil icon to generate a default form from the contract. +
 
 image:images/rta-mail/rta-mail-template-ooom-check-mail-initial-form.png[Out of office message - Check email content - form]
-// {.img-responsive}
 
 For a better usability, we can  :
 
@@ -172,7 +167,6 @@ It will look like this:
 
 +
 image:images/rta-mail/rta-mail-template-ooom-check-mail-select-properties.png[Out of office message - Check email content - select properties]
-// {.img-responsive}
 
 We need to retrieve the business object _outOfOfficeMessage_ which contains the mail contents. +
 We use an _External API_ variable named *outOfOfficeMessage* which uses the *context* variable business object reference link: `../{{context.outOfOfficeMessage_ref.link}}`
@@ -196,7 +190,6 @@ return {
 The variable pane will look like this:
 
 image:images/rta-mail/rta-mail-template-ooom-check-mail-variables.png[Out of office message - Check email content - mail variables]
-// {.img-responsive}
 
 We will take advantage of the *Rich text area* widget to have a nice way to visualize the mail body.
 
@@ -211,7 +204,6 @@ Add a *Rich text area* widget below the _title_ *input* widget:
 Click on preview. And the form will look like:
 
 image:images/rta-mail/rta-mail-template-ooom-check-mail-form-preview.png[Out of office message - Check email content - form preview]
-// {.img-responsive}
 
 == Run the process
 
@@ -223,4 +215,3 @@ An instance of the process is started and a task is available. +
 Take it and you will see the following form:
 
 image:images/rta-mail/rta-mail-template-ooom-check-mail-form.png[Out of office message - Check email content - form]
-// {.img-responsive}

--- a/modules/ROOT/pages/tasks.adoc
+++ b/modules/ROOT/pages/tasks.adoc
@@ -8,7 +8,6 @@ Those users can view the list of flow nodes in error, pending tasks, done tasks,
 
 Here is a view of the task list:
 image:images/UI2021.1/admin-task-list-portal.png[Administrator Task list Portal]
-// {.img-responsive}
 
 == View tasks
 

--- a/modules/ROOT/pages/ui-designer-overview.adoc
+++ b/modules/ROOT/pages/ui-designer-overview.adoc
@@ -138,8 +138,7 @@ You started your Studio today, and when you try to open a form from your process
 
 The UI Designer has a log file that you can consult, either from the Studio Menu > Bonita UI-Designer log: +
 image:images/ui-designer-troubleshooting/uid-logs.png[Open UI Designer log from the Studio]
-// {.img-responsive}
- +
++
 Or from your file system here: `STUDIO_HOME/workspace/.metadata/.plugins/org.bonitasoft.studio.designer/.extract/logs/ui-designer.log`. +
 When reading the log file, you see this kind of error: +
 `Could not load component, unexpected structure in the file [timelineWidget.json]`

--- a/modules/ROOT/pages/uid-vertical-tabs-container-tutorial.adoc
+++ b/modules/ROOT/pages/uid-vertical-tabs-container-tutorial.adoc
@@ -15,17 +15,14 @@ In counterpart, in the version v0.30.1 of bootstrap there is no provided style t
 To have a tab container displayed on all devices (mobile / desktop) modifying display based on devices size you could use css as described below, but feel free to extend it to match your specific needs.
 
 image:images/vertical-tabs-container-tutorial/mobile.png[Vertical tabs container on mobile]
-// {.img-responsive .img-thumbnail}
 
 image:images/vertical-tabs-container-tutorial/desktop.png[Vertical tabs container on desktop]
-// {.img-responsive .img-thumbnail}
 
 == Step 1: Configure the tabs container
 
 The Tabs container will be configured `Vertically`, add a css class tab-vertical as follows.
 Remember that we recommend to switch type from tabs to `pills`, rendering is nicer in pills than default style as tabs.
 image:images/vertical-tabs-container-tutorial/configuration.png[Vertical tabs container configuration]
-// {.img-responsive .img-thumbnail}
 
 == Step 2: Add css rules in a css file
 
@@ -47,4 +44,3 @@ Add following css rules in style.css asset, a new asset, or even on your applica
 ----
 
 image:images/vertical-tabs-container-tutorial/css.png[Vertical tabs container css]
-// {.img-responsive .img-thumbnail}

--- a/modules/ROOT/pages/user-application-case-list.adoc
+++ b/modules/ROOT/pages/user-application-case-list.adoc
@@ -15,7 +15,6 @@ It features:
 
 Here is a view of the User Case list
 image:images/UI2021.1/user-case-list-app.png[User Case list in Bonita Application]
-// {.img-responsive}
 
 == Cases listed
 
@@ -106,11 +105,9 @@ Technically, cases change their Id when going from _open_ to _archived_ status. 
 Sorting options are the same as in the equivalent Portal page, except they have been brought to the top of the page instead of in the table headers.
 Here are the Portal sorting options. +
 image:images/UI2021.1/user-case-sort-Portal.png[User Case sorting options - Portal]
-// {.img-responsive}
 
 Here are the Application sorting options. +
 image:images/UI2021.1/user-case-sort-App.png[User Case sorting options - Application]
-// {.img-responsive}
 
 The list can be sorted by:
 
@@ -133,7 +130,6 @@ The "Load more cases" link cannot be clicked anymore.
 This page has also been re-created with the UI Designer. It is responsive and customizable.
 Here is an example of a case details page.
 image:images/UI2021.1/user-case-details-App.png[User Case case details - Application]
-// {.img-responsive}
 
 This page displays:
 
@@ -156,9 +152,8 @@ It displays:
 * The documents currently managed by the case
 * A bottom-up chronology of some events that happened in the case: case start and human tasks executed, each one with a timestamp and actor.
 
-Is is used both in Bonita Portal and in Bonita Applications. +
+It is used both in Bonita Portal and in Bonita Applications. +
 Here is an example of the case overview provided by Bonita.
 image:images/UI2021.1/case-overview.png[Case Overview]
-// {.img-responsive}
 
 To know more about the customization of the case overview, go to the xref:uid-case-overview-tutorial.adoc[Case overview] page.

--- a/modules/ROOT/pages/user-process-list.adoc
+++ b/modules/ROOT/pages/user-process-list.adoc
@@ -10,19 +10,16 @@ _Users_ can view a list of the processes they have the permission to start, and 
 This list displays the processes that the logged user can start.
 
 image:images/UI2021.1/user_process_list.png[User Process list]
-// {.img-responsive}
 
 The ability to start a process has been stated in the Studio, by mapping the _initiator_ actor of the pool with entities of the organization the user is part of.
 
 In the pool configuration, here is how to map an actor to the entities of the organization.
 
 image:images/UI2021.1/Actor-mapping.png[Actor mapping]
-// {.img-responsive}
 
 In the Pool properties, here is how to set an actor as the initiator.
 
 image:images/UI2021.1/Set-as-initiator.png[Set an actor as the process initiator]
-// {.img-responsive}
 
 == Start a process
 

--- a/modules/ROOT/pages/user-task-list.adoc
+++ b/modules/ROOT/pages/user-task-list.adoc
@@ -15,21 +15,18 @@ Here are the values of the user task list:
 * _Panel expand_ feature, to display wide forms in a large modal window
 
 image:images/tasklist-elements.png[]
-// {.img-responsive .img-thumbnail}
+
 image:images/tasklist-popup.png[]
-// {.img-responsive .img-thumbnail}
 
 * List settings: number of tasks in a page, choice of columns, columns ordering
 * Easy access to case information, one tab away from the form. This case information is the case overview page, that the development team can customize
 * Easy access to case comments, also one tab away from the form or case information
 
 image:images/tasklist-settings-and-tabs.png[]
-// {.img-responsive .img-thumbnail}
 
 * Alternate "full width" list, with task information displayed in a large modal window
 
 image:images/tasklist-fullpage.png[]
-// {.img-responsive .img-thumbnail}
 
 This list also leverages two legacy features (prior to Bonita 7.3.0):
 


### PR DESCRIPTION
They have been automatically generated during the Markdown to AsciiDoc conversion but are not relevant. For the record, the comments was generally something like `// {.img-responsive}`.