### PR TITLE
ci: make the "Vale action" use the latest release

### DIFF
--- a/.github/workflows/contribution-check.yml
+++ b/.github/workflows/contribution-check.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           format: 'json'
       - name: Check content writing
-        uses: errata-ai/vale-action@reviewdog
+        uses: errata-ai/vale-action@v2.0.1
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:

--- a/.github/workflows/contribution-check.yml
+++ b/.github/workflows/contribution-check.yml
@@ -2,11 +2,14 @@ name: Contribution check
 
 on:
   pull_request:
+    # 'edited': check the PR title on changes
     types: [opened, edited, synchronize]
 
 jobs:
   pr-title:
     runs-on: ubuntu-20.04
+    permissions:
+      pull-requests: write # post comments if the PR title doesn't match the "Conventional Commits" rules
     steps:
       - name: Lint pull request title
         uses: jef/conventional-commits-pr-action@v1
@@ -15,7 +18,7 @@ jobs:
   pr-content-check:
     runs-on: ubuntu-20.04
     steps:
-      - name: Check PR content
+      - name: Check forbidden content
         uses: bonitasoft/actions/packages/pr-diff-checker@1.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Vale action was set to 'reviewdog' branch by error. It is not stable and the action failed to run from time to time.

In addition, restore permissions for the 'pr-title' job that was removed by mistake in c2e10ec6.