### PR TITLE
ci: reduce runs of the 'contribution-check' workflow

### DIFF
--- a/.github/workflows/contribution-check.yml
+++ b/.github/workflows/contribution-check.yml
@@ -3,20 +3,24 @@ name: Contribution check
 on:
   pull_request:
     # 'edited': check the PR title on changes
-    types: [opened, edited, synchronize]
+    types: [opened, edited, reopened, synchronize]
 
 jobs:
   pr-title:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write # post comments if the PR title doesn't match the "Conventional Commits" rules
+    # here we don't want to check the pr-title when new code is pushed
+    if: github.event.action != 'synchronize'
     steps:
       - name: Lint pull request title
         uses: jef/conventional-commits-pr-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
   pr-content-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    # here we only want to check the files updated by the PR, so we don't care when the PR metadata (like title, labels, ...) change
+    if: github.event.action != 'edited'
     steps:
       - name: Check forbidden content
         uses: bonitasoft/actions/packages/pr-diff-checker@1.1.0

--- a/.github/workflows/contribution-check.yml
+++ b/.github/workflows/contribution-check.yml
@@ -9,7 +9,7 @@ jobs:
   pr-title:
     runs-on: ubuntu-22.04
     permissions:
-      pull-requests: write # post comments if the PR title doesn't match the "Conventional Commits" rules
+      pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
     # here we don't want to check the pr-title when new code is pushed
     if: github.event.action != 'synchronize'
     steps:


### PR DESCRIPTION
Do not check
  - the PR title when pushing new code
  - the "file changes" when editing the PR title

Also run all jobs of the workflow on Ubuntu 22 and when the PR is `reopened`.

### Resources

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request


### Tests

- ✔️ edit title: https://github.com/bonitasoft/bonita-doc/actions/runs/3410009937 and https://github.com/bonitasoft/bonita-doc/actions/runs/3410020288
- ✔️ push new content: https://github.com/bonitasoft/bonita-doc/actions/runs/3410036222
