### PR TITLE
ci: disable vale-action

### DIFF
--- a/.github/workflows/contribution-check.yml
+++ b/.github/workflows/contribution-check.yml
@@ -28,16 +28,17 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           diffDoesNotContain: '["https://documentation.bonitasoft.com/", "Bonita BPM"]'
           extensionsToCheck: '[".adoc"]'
-      - uses: actions/checkout@v3
-      - id: files
-        name: Detect changed files
-        uses: jitterbit/get-changed-files@v1
-        with:
-          format: 'json'
-      - name: Check content writing
-        uses: errata-ai/vale-action@v2.0.1
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        with:
-          files: ${{ steps.files.outputs.added_modified }}
+      # Temporarily disable vale-action, see https://github.com/bonitasoft/bonita-documentation-site/issues/464
+      #- uses: actions/checkout@v3
+      #- id: files
+      #  name: Detect changed files
+      #  uses: jitterbit/get-changed-files@v1
+      #  with:
+      #    format: 'json'
+      #- name: Check content writing
+      #  uses: errata-ai/vale-action@v2.0.1
+      #  env:
+      #    GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      #  with:
+      #    files: ${{ steps.files.outputs.added_modified }}
 


### PR DESCRIPTION
It marks the workflow as failed whereas it is set to provide help to contributors.
All Pull Requests are currently marked in error: disable the action until we find a way to fix the problem/


covers https://github.com/bonitasoft/bonita-documentation-site/issues/464
