### PR TITLE
docs(REST API extensions): Use new format for troubleshooting sections

### DIFF
--- a/modules/ROOT/pages/rest-api-extensions.adoc
+++ b/modules/ROOT/pages/rest-api-extensions.adoc
@@ -215,9 +215,13 @@ Those dependencies are automatically added when a REST API Extension is created 
 
 Be aware that a poor implementation of a custom REST API accessing BDM objects can lead to poor performance results. See the xref:bdm-in-rest-api.adoc[best practice] on this matter.
 
+[.troubleshooting-title]
 == Troubleshooting
 
-* I get the following stacktrace when using Java 8 Date types (LocalDate, LocalDateTime...) in my Rest API Extension
+[.troubleshooting-section]
+--
+[.symptom]
+I get the following stacktrace when using Java 8 Date types (LocalDate, LocalDateTime...) in my Rest API Extension
 
 [source,log]
 ----
@@ -250,8 +254,10 @@ java.lang.StackOverflowError
 	at groovy.json.JsonOutput.writeObject(JsonOutput.java:294)
 ----
 
+[.cause]#Cause#
 The http://docs.groovy-lang.org/2.4.4/html/gapi/groovy/json/JsonBuilder.html[`groovy.json.JSONBuilder`] does not support Java 8 Date types serialization for the groovy version currently used by Bonita.
 
+[.solution]#Solution#
 As a workaround you have to format dates in a new data structure before using the JSONBuilder.
 
 Example:
@@ -273,3 +279,4 @@ We do not recommend to manage time zone at the Rest API level, as the local of t
 So we encourage you to manipulate UTC dates only server-side.
 You can see how we xref:datetimes-management-tutorial.adoc#_date_and_time_displayed_in_the_user_time_zone[manage the time zone using the date time picker]. This time zone should only be managed in the end user interface.
 ====
+--


### PR DESCRIPTION
Update rest-api-extensions doc according to new troubleshooting format.
