### PR TITLE
chore: Update merge policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,5 @@ modules/ROOT/pages/bonita-data-repository-dependencies.adoc merge=ours
 modules/ROOT/pages/bonita-engine-dependencies.adoc merge=ours
 modules/ROOT/pages/bonita-web-dependencies.adoc merge=ours
 modules/ROOT/pages/portal-js-dependencies.adoc merge=ours
-modules/ROOT/pages/product-versioning.adoc merge=ours
+modules/version-update/pages/product-versioning.adoc merge=ours
 antora.yml merge=ours


### PR DESCRIPTION
* Since this version, the product-versionning page moved to a specific module but without adapt the merge policy