### PR TITLE
fix: add missing redirect for insert-data-in-a-docx-odt-template.adoc

### DIFF
--- a/modules/process/pages/insert-data-in-a-docx-odt-template.adoc
+++ b/modules/process/pages/insert-data-in-a-docx-odt-template.adoc
@@ -1,4 +1,5 @@
 = Insert data in a .docx/.odt template connector
+:page-aliases: ROOT:insert-data-in-a-docx-odt-template.adoc
 :description: The *insert data in a .docx/.odt template* fills a specified template file by inserting values coming from the current process instance.
 
 The *insert data in a .docx/.odt template* fills a specified template file by inserting values coming from the current process instance.


### PR DESCRIPTION
The page moved from 2021.1 to 2021.2 but the alias was missing.