### PR TITLE
docs(info): Update database-configuration wrong SQL queries

### DIFF
--- a/modules/ROOT/pages/database-configuration.adoc
+++ b/modules/ROOT/pages/database-configuration.adoc
@@ -184,7 +184,7 @@ SQL query >
 [source,sql]
 ----
 CREATE USER bonita IDENTIFIED BY bonita;
-GRANT connect, resource TO bonita IDENTIFIED BY bonita;
+GRANT connect, resource TO bonita;
 GRANT select ON sys.dba_pending_transactions TO bonita;
 GRANT select ON sys.pending_trans$ TO bonita;
 GRANT select ON sys.dba_2pc_pending TO bonita;
@@ -203,11 +203,11 @@ SQL query >
 [source,sql]
 ----
 CREATE USER business_data IDENTIFIED BY business_data;
-GRANT connect, resource TO business_data IDENTIFIED BY business_data;
+GRANT connect, resource TO business_data;
 GRANT create sequence TO business_data;
 GRANT select ON sys.dba_pending_transactions TO business_data;
 GRANT select ON sys.pending_trans$ TO business_data;
-GRANT select ON sys.dba_2pc_pending TO bonitbusiness_dataa;
+GRANT select ON sys.dba_2pc_pending TO business_data;
 GRANT execute ON sys.dbms_system TO business_data;
 GRANT execute ON sys.dbms_xa TO business_data;
 GRANT FORCE ANY TRANSACTION TO business_data;


### PR DESCRIPTION
Update database-configuration doc on wrong Oracle SQL queries proposed to create the 2 schemas for Bonita.

"identified by xxx" section in the 1st GRANT comment is not correct.
It must be removed.

Typo error on "TO bonitbusiness_dataa;" must be replaced by "TO business_data;"