### PR TITLE
fix(asciidoc): workaround wrong Maven pom xml display

### DIFF
--- a/modules/ROOT/pages/custom-authorization-rule-mapping.adoc
+++ b/modules/ROOT/pages/custom-authorization-rule-mapping.adoc
@@ -37,7 +37,7 @@ In this example, Custom authorization rule is a maven-based java project that ne
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="\http://maven.apache.org/POM/4.0.0 \http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.bonitasoft.example</groupId>

--- a/modules/ROOT/pages/event-handlers.adoc
+++ b/modules/ROOT/pages/event-handlers.adoc
@@ -64,7 +64,7 @@ pom.xml :
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="\http://maven.apache.org/POM/4.0.0 \http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.bonitasoft.example</groupId>


### PR DESCRIPTION
Works around issue https://github.com/asciidoctor/asciidoctor/issues/3128

closes [RUNTIME-969](https://bonitasoft.atlassian.net/browse/RUNTIME-969)
closes [RUNTIME-1652](https://bonitasoft.atlassian.net/browse/RUNTIME-1652)

[RUNTIME-969]: https://bonitasoft.atlassian.net/browse/RUNTIME-969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUNTIME-1652]: https://bonitasoft.atlassian.net/browse/RUNTIME-1652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ