### PR TITLE
ci(test): check preview links when Antora manages latest/next versions

### DIFF
--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -15,8 +15,11 @@ jobs:
       pull-requests: write # surge-preview write PR comments
     steps:
       - name: Build and publish pr preview
-        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@master
+# TMP to test https://github.com/bonitasoft/bonita-documentation-site/pull/520
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@latest_next_versions
         with:
+          doc-site-branch: latest_next_versions
+# END OF - TMP to test https://github.com/bonitasoft/bonita-documentation-site/pull/520
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           component-name: bonita

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,7 +1,7 @@
 = Bonita Documentation
 :description: Learn how to get the most out of the Bonita Platform and all of its components.
 
-WARNING: this is a modified page to test changes in doc-site generation!
+WARNING: this is a modified page to test changes in doc-site generation !
 
 Learn how to get the most out of the Bonita Platform and all of its components.
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,7 +1,7 @@
 = Bonita Documentation
 :description: Learn how to get the most out of the Bonita Platform and all of its components.
 
-WARNING: this is a modified page to test changes in doc-site generation !
+WARNING: this is a modified page to test changes in doc-site generation!
 
 Learn how to get the most out of the Bonita Platform and all of its components.
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,6 +1,8 @@
 = Bonita Documentation
 :description: Learn how to get the most out of the Bonita Platform and all of its components.
 
+WARNING: this is a modified page to test changes in doc-site generation!
+
 Learn how to get the most out of the Bonita Platform and all of its components.
 
 [.card-section]

--- a/modules/integration/pages/event-handlers.adoc
+++ b/modules/integration/pages/event-handlers.adoc
@@ -4,6 +4,8 @@
 
 {description}
 
+WARNING: this is a modified page to test changes in doc-site generation!
+
 [NOTE]
 ====
 For Subscription editions only.


### PR DESCRIPTION
**POC to test https://github.com/bonitasoft/bonita-documentation-site/pull/520
⚠️ DO NOT MERGE, DO NOT CLOSE ⚠️** 

The wf uses the branch of the PR introducing the Antora version management.

Introduce artificial changes to generate links to updated pages.
