### PR TITLE
fix(2023.1): correctly generate links to the javadoc v8.0

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -7,7 +7,7 @@ asciidoc:
     bonitasoft-registry: 'bonitasoft.jfrog.io'
     bonitasoft-docker-repository: '{bonitasoft-registry}/docker'
     bonitaTechnicalVersion: '8.0.0' # latest public community version
-    javadocVersion: 8.0
+    javadocVersion: '8.0'
     # ref versions of other components
     bcdDocVersion: '4.0'
     # page attributes


### PR DESCRIPTION
Fix issue on link to javadoc