### PR TITLE
docs(password-policy): Explain error in admin user list

### DIFF
--- a/modules/identity/pages/enforce-password-policy.adoc
+++ b/modules/identity/pages/enforce-password-policy.adoc
@@ -124,3 +124,9 @@ security.password.validator org.bonitasoft.ext.password.validator.PasswordLength
 To check that the validation is correct, you can type a password to force an error. An exception will be displayed listing all the non-filled criteria.
 
 If the password complies with the criteria in the new password policy, no exception error message will be displayed.
+
+[NOTE]
+====
+The default error message shown on the default admin user list page is `Password must be at least 10 characters long containing at least 3 digits, 2 upper case characters, and 2 special characters.`. 
+If you configured a custom password policy, you might need to create a custom page to change the error message.
+====


### PR DESCRIPTION
Explain how to display an error message for the custom password policy

Covers [RUNTIME-1049](https://bonitasoft.atlassian.net/browse/RUNTIME-1049)

Related to bonita-web-pages-sp PR (https://github.com/bonitasoft/bonita-web-pages-sp/pull/249)


[RUNTIME-1049]: https://bonitasoft.atlassian.net/browse/RUNTIME-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ