### PR TITLE
docs(README): fix typo in AsciiDoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Bonita documentation resources
 
-This repository contains the sources of the https://documentation.bonitasoft.com/bonita[Bonita documentation site]. It uses https://docs.asciidoctor.org/asciidoc/latest/[Asciidoc] format for
+This repository contains the sources of the https://documentation.bonitasoft.com/bonita[Bonita documentation site]. It uses https://docs.asciidoctor.org/asciidoc/latest/[AsciiDoc] format for
 the documentation content.
 
 


### PR DESCRIPTION
AsciiDoc is a trademark and case matters.