### PR TITLE
ci: simplify xref validation

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -14,11 +14,8 @@ jobs:
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}
     steps:
       - name: Validate xref
-        # Branch of https://github.com/bonitasoft/bonita-documentation-site/pull/582
-        uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@feat/xref_validation
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@master
         with:
-          # Branch of https://github.com/bonitasoft/bonita-documentation-site/pull/582
-          doc-site-branch: feat/xref_validation
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -12,23 +12,13 @@ jobs:
     env:
       COMPONENT_NAME: bonita
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}
-      COMPONENT_VERSION: ${{ github.base_ref }} # The base_ref or target branch of the pull request in a workflow run.
-      # Required to pass xref validation
-      CLOUD_BRANCH: 'master'
-      DEPENDANT_BONITA_BRANCHES: '2021.1,2022.1,2022.2,2023.1'
-      # Needed to build the 'cloud' doc
-      BCD_BRANCHES: '3.6,4.0'
-      TOOLKIT_BRANCH: '1.0'
     steps:
       - name: Build PR preview
-        uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@master
+        # Branch of https://github.com/bonitasoft/bonita-documentation-site/pull/582
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@feat/xref_validation
         with:
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-
             ./build-preview.bash --use-multi-repositories
-            --start-page "${{ env.COMPONENT_VERSION }}"@"${{ env.COMPONENT_NAME }}"::index.adoc
-            --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_BRANCH_NAME }},${{ env.DEPENDANT_BONITA_BRANCHES }}"
-            --component-with-branches bcd:"${{ env.BCD_BRANCHES }}"
-            --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
-            --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"
+            --component "${{ env.COMPONENT_NAME }}" --branch "${{ env.COMPONENT_BRANCH_NAME }}" 

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -17,8 +17,10 @@ jobs:
         # Branch of https://github.com/bonitasoft/bonita-documentation-site/pull/582
         uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@feat/xref_validation
         with:
+          # Branch of https://github.com/bonitasoft/bonita-documentation-site/pull/582
+          doc-site-branch: feat/xref_validation
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-
-            ./build-preview.bash
+            ./build-preview.bash 
             --component "${{ env.COMPONENT_NAME }}" --branch "${{ env.COMPONENT_BRANCH_NAME }}" 

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -22,6 +22,6 @@ jobs:
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-
-            ./build-preview.bash 
-              --component "${{ env.COMPONENT_NAME }}"
-              --branch "${{ env.COMPONENT_BRANCH_NAME }}" 
+            ./build-preview.bash
+            --component "${{ env.COMPONENT_NAME }}"
+            --branch "${{ env.COMPONENT_BRANCH_NAME }}"

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -7,13 +7,13 @@ on:
       - 'antora.yml'
       - '.github/workflows/build-pr-preview.yml'
 jobs:
-  build_preview:
+  validate_xref:
     runs-on: ubuntu-20.04
     env:
       COMPONENT_NAME: bonita
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}
     steps:
-      - name: Build PR preview
+      - name: Validate xref
         # Branch of https://github.com/bonitasoft/bonita-documentation-site/pull/582
         uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@feat/xref_validation
         with:
@@ -23,4 +23,5 @@ jobs:
           # '-' No newline at end (strip)
           build-preview-command: >-
             ./build-preview.bash 
-            --component "${{ env.COMPONENT_NAME }}" --branch "${{ env.COMPONENT_BRANCH_NAME }}" 
+              --component "${{ env.COMPONENT_NAME }}"
+              --branch "${{ env.COMPONENT_BRANCH_NAME }}" 

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -20,5 +20,5 @@ jobs:
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-
-            ./build-preview.bash --use-multi-repositories
+            ./build-preview.bash
             --component "${{ env.COMPONENT_NAME }}" --branch "${{ env.COMPONENT_BRANCH_NAME }}" 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,14 +1,6 @@
 = Bonita Documentation
 :description: Learn how to get the most out of the Bonita Platform and all of its components.
 
-
-[CAUTION]
-====
-Unknown xref in this component version xref::do-not-exist_for_sure.adoc[BCD add-on].
-
-Unknown xref in another component xref:{bcdDocVersion}@bcd::do-not-exist_for_sure-in-bcd.adoc[BCD add-on].
-====
-
 Learn how to get the most out of the Bonita Platform and all of its components.
 
 [.card-section]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,6 +1,14 @@
 = Bonita Documentation
 :description: Learn how to get the most out of the Bonita Platform and all of its components.
 
+
+[CAUTION]
+====
+Unknown xref in this component version xref::do-not-exist_for_sure.adoc[BCD add-on].
+
+Unknown xref in another component xref:{bcdDocVersion}@bcd::do-not-exist_for_sure-in-bcd.adoc[BCD add-on].
+====
+
 Learn how to get the most out of the Bonita Platform and all of its components.
 
 [.card-section]


### PR DESCRIPTION
Use the new Antora Atlas feature. There is no more need to reference all dependent components/versions to validate xrefs.