### PR TITLE
ci: use ubuntu 22.04 in all workflows

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/build-pr-preview.yml'
 jobs:
   build_preview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COMPONENT_NAME: bonita
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -10,7 +10,7 @@ on:
       - '.github/workflows/publish-pr-preview.yml'
 jobs:
   build_preview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write # surge-preview write PR comments
     steps:

--- a/.github/workflows/push-content.yml
+++ b/.github/workflows/push-content.yml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/push-content.yml'
 jobs:
   triggerJob:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Notify content changes
         uses: peter-evans/repository-dispatch@v2


### PR DESCRIPTION
Some workflows were still using ubuntu 20.04