### PR TITLE
refactor(session): renamed session duration property

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -38,3 +38,13 @@ If you were coming from an older version of Bonita Studio with those custom conn
 === Provided Groovy classes
 
 Deprecated since 2021.1, `BonitaUsers`, `BonitaSql`, `BonitaXML` and `BonitaTypes` Groovy classes are no more available. You may use suggested code templates in the Groovy script expression editor instead.
+
+
+== Configuration changes
+
+=== Runtime property renaming
+
+In order to improve Bonita property naming coherence, a work is in progress to change some property names.
+In this release, the following properties have been renamed:
+
+* [.line-through]#`bonita.tenant.session.duration`# has been renamed to `bonita.runtime.session.duration`. If you happened to customize this property, please update it in file `bonita-tenant-community-custom.properties` (The old property is **still supported** but will be removed in a later version)

--- a/modules/identity/pages/user-authentication-overview.adoc
+++ b/modules/identity/pages/user-authentication-overview.adoc
@@ -117,7 +117,7 @@ invalidate the HTTP session and redirect the user to the login page.
 
 NOTE: The Bonita Engine default session duration is one hour (default value
 defined in https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-session/bonita-session-impl/src/main/java/org/bonitasoft/engine/session/impl/SessionServiceImpl.java[SessionServiceImpl]).
-You can configure a different session duration by editing the `bonita.tenant.session.duration` property in `bonita-tenant-community-custom.properties`. Specify the duration in milliseconds.
+You can configure a different session duration by editing the `bonita.runtime.session.duration` property in `bonita-tenant-community-custom.properties`. Specify the duration in milliseconds.
 
 If the HTTP session has expired, Bonita Applications will redirect the user to the
 authentication page. The Bonita Engine session associated with the HTTP


### PR DESCRIPTION
property 'bonita.tenant.session.duration' renamed to 'bonita.runtime.session.duration'
