### PR TITLE
docs(sca): removal of the property install-provided-pages

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -21,7 +21,7 @@ When configuring a xref:runtime:overview-of-bonita-bpm-in-a-cluster.adoc[Bonita 
 === Bonita UI Designer
 
 
-== Functionnal changes
+== Functional changes
 
 === REST API and file upload
 
@@ -33,7 +33,7 @@ When using the end point portal/fileUpload to upload a file before using it in B
 
 Since Bonita Studio 2021.2 it was not supported anymore to create custom connectors or actor filters in a Bonita project. Using the project composition with Maven extensions is the recommended way to integrate custom extensions.  +
 In this version, those deprecated custom extensions are removed from the project when importing a `.bos` file or cloning a Git repository from an older version.  +
-If you were coming from an older version of Bonita Studio with those custom connectors and actor filters, it will be required to migrate them into a separate Maven project using the dedicated archetypes. Visit their repsective documentation pages for xref:process:connector-migration.adoc[connectors] and xref:process:actor-filter-archetype.adoc[actor filters].
+If you were coming from an older version of Bonita Studio with those custom connectors and actor filters, it will be required to migrate them into a separate Maven project using the dedicated archetypes. Visit their respective documentation pages for xref:process:connector-migration.adoc[connectors] and xref:process:actor-filter-archetype.adoc[actor filters].
 
 === Provided Groovy classes
 
@@ -48,3 +48,9 @@ In order to improve Bonita property naming coherence, a work is in progress to c
 In this release, the following properties have been renamed:
 
 * [.line-through]#`bonita.tenant.session.duration`# has been renamed to `bonita.runtime.session.duration`. If you happened to customize this property, please update it in file `bonita-tenant-community-custom.properties` (The old property is **still supported** but will be removed in a later version)
+
+=== Removal of the property `install-provided-pages`
+
+With Bonita 2023.1, we introduced the new concept of xref:2023.1@ROOT:release-notes.adoc#_bonita_project_packaged_as_a_self_contained_application[Self-Contained Application] (SCA). When building an SCA, Bonita Admin Application and Bonita User Application are no longer installed after the packaging process. If the SCA is using pages from one of those applications, setting the property `bonita.runtime.custom-application.install-provided-pages` and its relative environment variable for Docker `INSTALL_PROVIDED_PAGES` will have those pages installed anyway at Bonita Runtime startup.
+
+Those two properties are no longer required and are removed. Instead, we detect the usage of Admin/User Application pages and install them automatically.

--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -397,12 +397,6 @@ Since Bonita 7.9 BONITA_SERVER_LOGGING_FILE and BONITA_SETUP_LOGGING_FILE can be
 
 `BONITA_SETUP_LOGGING_FILE` default value is `/opt/bonita/setup/logback.xml`
 
-=== INSTALL_PROVIDED_PAGES
-
-When building a link:++https://github.com/bonitasoft/bonita-application-packager#installation-of-bonita-admin--user-application-pages++[Self Contained Application], Bonita Admin Application and Bonita User Application are no longer installed after the packaging process. If your custom application is using pages from one of those applications, set this property to have those pages installed anyway at Bonita Runtime startup.
-
-Default value is `false`.
-
 [#logger_configuration]
 == Logger configuration
 


### PR DESCRIPTION
- Remove `INSTALL_PROVIDED_PAGES` environment variable description in Docker installation page
- Update Release Notes to explain why we remove this property and its relative environment variable