### PR TITLE
fix(release-notes): use attribute instead of hard coded version

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -3,7 +3,7 @@
 
 [NOTE]
 ====
-The 2024.1 version is in development.
+The {bonitaVersion} version is in development.
 ====
 
 == New available values


### PR DESCRIPTION
This facilitates maintenance, particularly when it comes to initiating the content of a new version from the current branch.