### PR TITLE
docs(SCA): add note on authentication modes not SCA compliant

### DIFF
--- a/modules/identity/pages/active-directory-or-ldap-authentication.adoc
+++ b/modules/identity/pages/active-directory-or-ldap-authentication.adoc
@@ -9,6 +9,11 @@
 For Subscription editions only.
 ====
 
+[NOTE]
+====
+The configuration steps detailed in this page include some modifications to the Tomcat configuration. This is not compliant with the Application deployment mode introduced with Bonita 2023.2. If you want your application container to work with an Active Directory/LDAP authentication, you will need to build the docker image of the application first and then configure the container (using a volume for example).
+====
+
 *Important notes:*
 
 * This documentation applies to an existing and working Bonita installation (see the xref:runtime:runtime-installation-index.adoc[installation instructions]).

--- a/modules/identity/pages/single-sign-on-with-cas.adoc
+++ b/modules/identity/pages/single-sign-on-with-cas.adoc
@@ -9,6 +9,11 @@
 For Subscription editions only.
 ====
 
+[NOTE]
+====
+The configuration steps detailed in this page include some modifications to the Tomcat configuration and common lib folder. This is not compliant with the Application deployment mode introduced with Bonita 2023.2. If you want your application container to work with a CAS SSO authentication, you will need to build the docker image of the application first and then configure the container (using a volume for example).
+====
+
 This information applies to a Bonita platform deployed from a bundle, not to the Engine launched from Bonita Studio.
 
 CAS configuration is at tenant level. Each tenant can use a different CAS service.

--- a/modules/identity/pages/single-sign-on-with-kerberos.adoc
+++ b/modules/identity/pages/single-sign-on-with-kerberos.adoc
@@ -7,6 +7,11 @@
 For Subscription editions only.
 ====
 
+[NOTE]
+====
+The configuration steps detailed in this page include some modifications to the Tomcat configuration. This is not compliant with the Application deployment mode introduced with Bonita 2023.2. If you want your application container to work with a Kerberos/Spnego SSO authentication, you will need to build the docker image of the application first and then configure the container (using a volume for example).
+====
+
 {description.} It assumes you already have a Correctly configured Windows Domain (AD/KDC/DNS services).
 
 This information applies to a Bonita platform deployed from a bundle, not to the Engine launched from Bonita Studio. `<BUNDLE_HOME>` refers to the root directory of the bundle.


### PR DESCRIPTION
The following authentication mode are not fully SCA compliant :
- Kerberos SSO
- CAS SSO
- LDAP auth

* Add note at the top of the page