### PR TITLE
fix(monitoring): fix wrong logger name

### DIFF
--- a/modules/runtime/pages/runtime-monitoring.adoc
+++ b/modules/runtime/pages/runtime-monitoring.adoc
@@ -83,7 +83,7 @@ Metrics exposed by the JMX publisher can be consulted by any JMX tool, like the 
 
 === Log file Publisher
 
-The log file publisher publishes to a file using the logger `com.bonitasoft.engine.configuration.monitoring.LoggingMeterRegistry`
+The log file publisher publishes to a file using the logger `com.bonitasoft.engine.monitoring.LoggingMeterRegistry`
 with the log level `INFO`.
 
 It can be enabled using the property `org.bonitasoft.engine.monitoring.publisher.logging.enable` set to `true`.


### PR DESCRIPTION
Documentation was wrong

See class package: https://github.com/bonitasoft/bonita-engine-sp/blob/683dc14b84fd46fff4fd2453d786130fe177e21c/subscription/services/bonita-monitoring/src/main/java/com/bonitasoft/engine/monitoring/LoggingMeterRegistry.java#L9C1-L9C1