### PR TITLE
fix: Replace missing page aliases

### DIFF
--- a/modules/runtime/pages/platform-maintenance-mode.adoc
+++ b/modules/runtime/pages/platform-maintenance-mode.adoc
@@ -1,5 +1,5 @@
 = Put Runtime in maintenance mode
-:page-aliases: ROOT:platform-maintenance-mode.adoc
+:page-aliases: ROOT:platform-maintenance-mode.adoc, ROOT:pause-and-resume-bpm-services.adoc, runtime:pause-and-resume-bpm-services.adoc
 :description: Learn how to execute maintenance tasks by activating and deactivating Bonita Runtime maintenance mode.
 
 {description}


### PR DESCRIPTION
* When the page will be renamed, the initial page-aliases attribute will be not correct