### PR TITLE
ci: Use reusable workflow for contribution checks

### DIFF
--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -2,17 +2,9 @@ name: Contribution checks
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
 
 jobs:
-  pr-content-check:
-    runs-on: ubuntu-22.04
+  check_antora_content_guidelines:
     permissions:
-      pull-requests: write # post comments when the PR title doesn't match the "Guidelines"
-    steps:
-      - name: Check PR content
-        uses: bonitasoft/actions/packages/pr-antora-content-guidelines-checker@v2
-        with:
-          attributes-to-check: ':description:'
-          files-to-check: 'adoc'
-          forbidden-pattern-to-check: 'https://documentation.bonitasoft.com, link:https, link:http, link:, xref:https, xref:http, xref:_, xref:#, Bonita BPM'
+      pull-requests: write # "pr-antora-content-guidelines-checker" write PR comments when the PR doesn't match the "Guidelines"
+    uses: bonitasoft/bonita-documentation-site/.github/workflows/_reusable_pr-antora-content-guidelines-checker.yml@master


### PR DESCRIPTION
A reusable workflow is available on the documentation-site repository, so we will use it to simplify the configuration.

Covers https://github.com/bonitasoft/bonita-documentation-site/issues/591