### PR TITLE
docs: correct all notes for subscription editions

### DIFF
--- a/modules/ROOT/pages/bonita-studio-download-installation.adoc
+++ b/modules/ROOT/pages/bonita-studio-download-installation.adoc
@@ -49,7 +49,7 @@ When the download is finished, you should have one of the following files on you
 * Linux: `BonitaStudioCommunity-x.y-x86_64.run`
 
 === Subscription edition
-Subscription editions cover the now unique Enterprise editions, but also the Performance, Efficiency, and Teamwork editions that are no longer sold but still supported at Bonitasoft. +
+Subscription editions cover the now unique Enterprise editions, but also the Subscription editions that are no longer sold but still supported at Bonitasoft. +
 To download the latest version of Bonita Studio Subscription edition, go to the https://customer.bonitasoft.com/download/request[Customer Service Center] and request the download of the version you need.
 
 When the download is complete, you have one of the following new files:

--- a/modules/identity/pages/admin-api-permissions.adoc
+++ b/modules/identity/pages/admin-api-permissions.adoc
@@ -278,7 +278,7 @@ This profile is linked to the Bonita Administrator Application by default. More 
 
 == Subscription Editions
 
-These are additional REST APIs that you have access to when you are using the Enterprise, Performance, Efficiency or Teamwork edition of Bonita.
+These are additional REST APIs that you have access to when you are using the Subscription editions of Bonita.
 
 === Additional accessible pages
 * Monitoring

--- a/modules/identity/pages/bdm-access-control.adoc
+++ b/modules/identity/pages/bdm-access-control.adoc
@@ -5,7 +5,7 @@
 
 [NOTE]
 ====
-For Enterprise, Performance and Efficiency editions only. +
+For Subscription editions only. +
 ====
 
 == Overview

--- a/modules/identity/pages/profile-creation.adoc
+++ b/modules/identity/pages/profile-creation.adoc
@@ -41,7 +41,7 @@ Default profiles (Administrator and User) belong to the file `default_profiles.x
 This file can only contain default profiles. It cannot be renamed or deleted.
 Neither can be the default profiles within: only the mapping between default profiles and entities of the organization can be edited.
 
-Only Enterprise, Performance and Efficiency editions can create new file of profiles, in order to create custom profiles.
+Only Subscription editions can create new file of profiles, in order to create custom profiles.
 
 The purpose of grouping profiles in one file is to manage together profiles related to a same business application. +
 For example, if you want to create a leave management application for four kinds of users (Employees, Managers, Human Resources officers, and Administrators), then you will have to create four applications and four profiles, and to bind each profile to the related application. As for the four applications, the four profiles should be managed together, and so grouped in the same file of profiles.
@@ -54,7 +54,7 @@ Therefore, you could have a "profiles_dev.xml", a "profiles_UAT.xml", and a "pro
 [NOTE]
 ====
 
-All Bonita subscription editions come with an .xml editor for this feature. Only Enterprise, Performance and Efficiency editions also come with a graphical UI.
+All Bonita subscription editions come with an .xml editor for this feature. Only Subscription editions also come with a graphical UI.
 ====
 
 From Bonita Studio, use the *new* button in the Studio coolbar or click on *Organization* \-> *Profile* \-> *New...*
@@ -88,5 +88,5 @@ For adding an application to a profile, open the application and assign the requ
 == Enable a profile
 
 To enable a profile, it must be installed into the Bonita Administrator Application. +
-For development purposes, the Studio can *deploy* profiles into the Bonita Administrator Application for you (_only for Performance and Efficiency editions_). +
+For development purposes, the Studio can *deploy* profiles into the Bonita Administrator Application for you (_only for Subscription editions_). +
 On a production environment, it is done via the menu:Organization[Profiles] tab of the Bonita Administrator Application.

--- a/modules/identity/pages/profiles-overview.adoc
+++ b/modules/identity/pages/profiles-overview.adoc
@@ -41,7 +41,7 @@ NOTE: In Bonita ACME organization, all users have the role *Member*, and the rol
 
 == Custom profiles
 
-In addition to the default profiles, users of Enterprise, Performance and Efficiency editions can create custom profiles. +
+In addition to the default profiles, users of Subscription editions can create custom profiles. +
 Custom profiles must be created and updated in the xref:identity:profile-creation.adoc[profile editor] of Bonita studio.
 To make a custom profile accessible to users, it has to be mapped to entities of the organization. +
 If a custom profile is created to give access to custom content in the portal, its _Portal menu_ (navigation structure and pages) must also be defined in the profile.

--- a/modules/identity/pages/rest-api-authorization.adoc
+++ b/modules/identity/pages/rest-api-authorization.adoc
@@ -139,7 +139,7 @@ In this example, the `custom_process_manager_permission` can be defined in the `
 
 [NOTE]
 ====
-For Enterprise, Performance, Efficiency, and Teamwork editions only.
+For Subscription editions only.
 ====
 
 [WARNING]
@@ -357,7 +357,7 @@ For example, to add the permission to the user walter.bates (username), add the 
 
 == Restricting access to a BDM object or its attributes
 
-Starting with the Bonita efficiency subscription edition, you can use a simpler mechanism to grant or deny access to BDM objects or some of their attributes to specific profiles, using the BDM Access Control feature.
+Starting with the Bonita Subscription edition, you can use a simpler mechanism to grant or deny access to BDM objects or some of their attributes to specific profiles, using the BDM Access Control feature.
 It is also possible to protect instances of the BDM objects, using REST API authorizations.
 For more details see : xref:bdm-access-control.adoc[BDM access control]
 

--- a/modules/identity/pages/super-admin-api-permissions.adoc
+++ b/modules/identity/pages/super-admin-api-permissions.adoc
@@ -170,7 +170,7 @@ This user is linked to the Bonita Super Administrator Application by default. Mo
 
 == Subscription Editions
 
-These are additional REST APIs that you have access to when you are using the Enterprise, Performance, Efficiency or Teamwork edition of Bonita.
+These are additional REST APIs that you have access to when you are using the Subscription editions of Bonita.
 
 === Additional accessible pages
 * License page

--- a/modules/process/pages/process-testing-index.adoc
+++ b/modules/process/pages/process-testing-index.adoc
@@ -22,7 +22,7 @@ If you have already created your own xref:ROOT:actors-index.adoc[actors] for you
 
 [NOTE]
 ====
-For Enterprise, Performance, Efficiency and Teamwork editions only.
+For Subscription editions only.
 ====
 
 To write automated integration test scenarios for your automation project you can use the Bonita Test Toolkit. It provides powerful methods to execute all the steps of a process and check the corresponding outputs (statuses, business data, tasks used)

--- a/modules/process/pages/sap-jco-3.adoc
+++ b/modules/process/pages/sap-jco-3.adoc
@@ -92,7 +92,7 @@ There is below a step by step procedure on Windows. It is assumed that the Studi
 
 == Advanced features in Subscription Editions
 
-In the Efficiency, Performance and Enterprise editions, the SAP wizard has advanced features: You do not need to know the names of the functions by heart, as the functions are suggested in a dropdown menu.
+In the Subscription editions, the SAP wizard has advanced features: You do not need to know the names of the functions by heart, as the functions are suggested in a dropdown menu.
 
 * Filter functions by group: a dropdown list listing all the functions by group
 * Function description: a dropdown list listing all the functions. Auto complete (just type the first letter e.g. G to give a list of *Get* functions

--- a/modules/runtime/pages/admin-application-process-list.adoc
+++ b/modules/runtime/pages/admin-application-process-list.adoc
@@ -128,7 +128,7 @@ After you created a category and added it to the process, you can add other proc
 
 == Start a case for another user
 
-This feature is available with the Enterprise, Performance, and Efficiency editions. +
+This feature is available with the Subscription editions. +
 To start a case for another user:
 
 . Go to _BPM_>__Processes__
@@ -141,7 +141,7 @@ To start a case for another user:
 The case is started as though the specified user had started it.
 For example, if you start a case for user A and a subsequent task is to be done by the manager of the user, it is assigned to user A's manager, not to your manager.
 
-All of what follows belong to the xref:live-update.adoc[Live update feature] and are only available in for the Enterprise, Performance, and Efficiency editions.
+All of what follows belong to the xref:live-update.adoc[Live update feature] and are only available in for the Subscription editions.
 
 == Edit the actor mapping
 

--- a/modules/runtime/pages/admin-application-task-list.adoc
+++ b/modules/runtime/pages/admin-application-task-list.adoc
@@ -41,7 +41,7 @@ A pending or failed task can be assigned and reassigned to another user if neces
 
 == Do a task for another user
 
-With the Enterprise, Performance, and Efficiency editions, an Administrator can do a task for another user. +
+With the Subscription editions, an Administrator can do a task for another user. +
 This is useful for unblocking a case if the assigned user cannot perform the task.
 
 . Go to _BPM_>__Tasks__

--- a/modules/runtime/pages/bdm-management-in-bonita-applications.adoc
+++ b/modules/runtime/pages/bdm-management-in-bonita-applications.adoc
@@ -27,7 +27,7 @@ The Business Objects must match the structure used by the deployed processes. Ma
 [NOTE]
 ====
 The deployment of a Business Data Model requires xref:ROOT:platform-maintenance-mode.adoc[activating the maintenance mode] during the operation, so that the update can be performed without affecting ongoing processes.
-For Enterprise, Efficiency and Performance editions, you must have no <<installAccessControl,access control>> file installed in order to be able to install or update the Business Data Model.
+For Subscription editions, you must have no <<installAccessControl,access control>> file installed in order to be able to install or update the Business Data Model.
 ====
 
 To do so:
@@ -128,7 +128,7 @@ Apply this sql script to your BDM database
 
 [NOTE]
 ====
-For Enterprise, Performance, and Efficiency editions only.
+For Subscription editions only.
 ====
 
 It is possible to define Business Data Model access control rules in Bonita Studio and import them in Bonita Super Administrator Application. +

--- a/modules/runtime/pages/engine-architecture-overview.adoc
+++ b/modules/runtime/pages/engine-architecture-overview.adoc
@@ -181,7 +181,7 @@ Notes: Store categories with the persistence service
 |  |
 
 | Description:
-| For the Enterprise, Performance, Efficiency, and Teamwork editions, manage parameters of a process. Parameters are set for the scope of a process definition and are designed to be used as global configuration of a process, for example, you could store the URL of a database you use in some connectors.
+| For the Subscription editions, manage parameters of a process. Parameters are set for the scope of a process definition and are designed to be used as global configuration of a process, for example, you could store the URL of a database you use in some connectors.
 
 | Used by:
 | Engine, APIs, ExpressionService (using the contributed evaluator) when reading and updating parameters
@@ -344,7 +344,7 @@ Generic services  perform actions that are not related to BPM but are required f
 | Any service storing objects: ?deleted activity[..]?  Scheduler service: ?Job executed [...]?
 
 | Implementations:
-| org.bonitasoft.engine.services.impl.SyncBusinessLoggerServiceImpl (Community edition: insert logs directly in database)  org.bonitasoft.engine.log.api.impl.BatchBusinessLoggerImpl (Teamwork, Efficiency, Performance, and Enterprise editions: inserts all logs in batch at the end of the transaction)
+| org.bonitasoft.engine.services.impl.SyncBusinessLoggerServiceImpl (Community edition: insert logs directly in database)  org.bonitasoft.engine.log.api.impl.BatchBusinessLoggerImpl (Subscription editions: inserts all logs in batch at the end of the transaction)
 |===
 
 === Caching in Bonita

--- a/modules/runtime/pages/tomcat-bundle.adoc
+++ b/modules/runtime/pages/tomcat-bundle.adoc
@@ -18,7 +18,7 @@ The Tomcat bundle is a regular .zip archive based on Tomcat zip distribution.
 
 For the Community edition:
 
-* Go to the http://www.bonitasoft.com/downloads-v2[Bonitasoft website] and get the Bonita Community edition Tomcat bundle.
+* Go to the https://www.bonitasoft.com/downloads[Bonitasoft website] and get the Bonita Community edition Tomcat bundle.
 
 For a Subscription edition:
 

--- a/modules/runtime/pages/user-application-overview.adoc
+++ b/modules/runtime/pages/user-application-overview.adoc
@@ -47,7 +47,7 @@ To access its content:
 
 == Access in Non-Production and Production environments
 
-To deploy the applications into a bundle or the Cloud, you can use xref:{bcdDocVersion}@bcd::index.adoc[Bonita Continuous Delivery]'s xref:{bcdDocVersion}@bcd::deployer.adoc[CLI] (for Enterprise, Performance, Efficiency, and Teamwork editions, and using BCD).
+To deploy the applications into a bundle or the Cloud, you can use xref:{bcdDocVersion}@bcd::index.adoc[Bonita Continuous Delivery]'s xref:{bcdDocVersion}@bcd::deployer.adoc[CLI] (for Subscription editions, and using BCD).
 Alternatively, you can deploy an application by importing all its components in the following order:
 
 * Organization then profiles


### PR DESCRIPTION
* Use *Subscription editions* instead *Enterprise, Performance, and Efficiency editions*
* Updated download links and all subscription editions description 