### PR TITLE
feat(docker): Add custom certificates to trust store

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -26,7 +26,7 @@ Following the Java 17 update, it is now required to specify the following jvm ar
 
 ==== Docker image parent update
 
-The `bonita` and `bonitasoft.jfrog.io/docker/bonita-subscription` images now inherit from the official https://hub.docker.com/_/eclipse-temurin[eclipse-temurin] image in its alpine flavor. As a consequence you may have to update your xref:runtime:bonita-docker-installation.adoc#_adding_internal_ca_certificates_to_the_truststore[internal certificates configuration]. It also affects your Self Contained Application images.
+The `bonita` and `bonitasoft.jfrog.io/docker/bonita-subscription` images now inherit from the official https://hub.docker.com/_/eclipse-temurin[eclipse-temurin] image in its alpine flavor. As a consequence, if you need to add additional Certificate Authority in the Java TrustStore you may proceed like xref:runtime:bonita-docker-installation.adoc#adding-ca-certificates[described here]. It also applies to to Self Contained Application images.
 
 
 ==== Second-Level Cache available in a Bonita clustered environment

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -24,6 +24,10 @@ Following the Java 17 update, it is now required to specify the following jvm ar
 --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED
 ----
 
+==== Docker image parent update
+
+The `bonita` and `bonitasoft.jfrog.io/docker/bonita-subscription` images now inherit from the official https://hub.docker.com/_/eclipse-temurin[eclipse-temurin] image in its alpine flavor. As a consequence you may have to update your xref:runtime:bonita-docker-installation.adoc[internal certificates configuration]. It also affects your Self Contained Application images.
+
 
 ==== Second-Level Cache available in a Bonita clustered environment
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -26,7 +26,7 @@ Following the Java 17 update, it is now required to specify the following jvm ar
 
 ==== Docker image parent update
 
-The `bonita` and `bonitasoft.jfrog.io/docker/bonita-subscription` images now inherit from the official https://hub.docker.com/_/eclipse-temurin[eclipse-temurin] image in its alpine flavor. As a consequence you may have to update your xref:runtime:bonita-docker-installation.adoc[internal certificates configuration]. It also affects your Self Contained Application images.
+The `bonita` and `bonitasoft.jfrog.io/docker/bonita-subscription` images now inherit from the official https://hub.docker.com/_/eclipse-temurin[eclipse-temurin] image in its alpine flavor. As a consequence you may have to update your xref:runtime:bonita-docker-installation.adoc#_adding_internal_ca_certificates_to_the_truststore[internal certificates configuration]. It also affects your Self Contained Application images.
 
 
 ==== Second-Level Cache available in a Bonita clustered environment

--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -411,6 +411,7 @@ docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ \
 --
 ====
 
+[#adding-ca-certificates]
 == Adding internal CA certificates to the truststore
 
 Add your certificates to `/certificates` inside the container (e.g. by using a volume) and set the environment variable `USE_SYSTEM_CA_CERTS` on the container to any value. With Docker CLI this might look like this:

--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -411,6 +411,36 @@ docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ \
 --
 ====
 
+== Adding internal CA certificates to the truststore
+
+Add your certificates to /certificates inside the container (e.g. by using a volume) and set the environment variable USE_SYSTEM_CA_CERTS on the container to any value. With Docker CLI this might look like this:
+
+[tabs]
+====
+Community edition::
++
+--
+[source,shell,subs="+macros,+attributes"]
+----
+docker run --name bonita \
+    -v $(pwd)/certs:/certificates/ \
+    -e USE_SYSTEM_CA_CERTS=1 \
+    -d -p 8080:8080 bonita:pass:a[{bonitaVersion}]
+----
+--
+
+Subscription editions::
++
+--
+[source,shell,subs="+macros,+attributes"]
+----
+docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ \
+    -v $(pwd)/certs:/certificates/ \
+    -e USE_SYSTEM_CA_CERTS=1 \
+    -d -p 8080:8080 {bonitasoft-docker-repository}/bonita-subscription:pass:a[{bonitaVersion}]
+----
+--
+====
 
 [#environment-variables]
 == Environment variables

--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -442,6 +442,8 @@ docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ \
 --
 ====
 
+The certificates would get added to the system CA store, which would in turn be converted to Java's truststore.
+
 [#environment-variables]
 == Environment variables
 

--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -413,7 +413,7 @@ docker run --name bonita -h <hostname> -v ~/bonita-lic/:/opt/bonita_lic/ \
 
 == Adding internal CA certificates to the truststore
 
-Add your certificates to /certificates inside the container (e.g. by using a volume) and set the environment variable USE_SYSTEM_CA_CERTS on the container to any value. With Docker CLI this might look like this:
+Add your certificates to `/certificates` inside the container (e.g. by using a volume) and set the environment variable `USE_SYSTEM_CA_CERTS` on the container to any value. With Docker CLI this might look like this:
 
 [tabs]
 ====


### PR DESCRIPTION
With the update of the base image to [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin), the way to configure the certificates in the trust store has changed