### PR TITLE
feat(migration): Describe how to stop Bonita with Docker compose

### DIFF
--- a/modules/version-update/pages/update-with-update-tool.adoc
+++ b/modules/version-update/pages/update-with-update-tool.adoc
@@ -258,13 +258,6 @@ For example, db.url=jdbc:mysql://localhost:3306/bonita-update?allowMultiQueries=
 // link to back up your runtime nodes => old module, new runtime
 . *IMPORTANT:* *Back up your xref:ROOT:back-up-bonita-bpm-platform.adoc[runtime nodes and databases].*
 
-If you are runing Bonita with xref:ROOT:bonita-docker-installation#_using_docker_compose[Docker Compose], you can stop your bonita node(s) or your custom application node(s) by scaling down to 0.
-[source,bash]
-----
-docker-compose up --scale bonita=0 --no-recreate -d
-----
-After updating your `.yml` file, scale up the service when you want to restart Bonita.
-
 === Run Bonita Update Tool
 . Go to the directory containing Bonita Update Tool/Bonita Migration Tool.
 . Run the appropriate update script:
@@ -371,6 +364,15 @@ cp BonitaSubscription-7.n-Jerome-myHosname-20171023-20180122.lic ./platform_conf
 
 [#special-cases]
 == Special cases
+
+=== If you are runing Bonita with Docker Compose
+When using the xref:ROOT:bonita-docker-installation#_using_docker_compose[Docker Compose installation], you can use scaling to stop and start your Bonita application in the `bonita` node(s).
+Stop your bonita node(s) or your custom application node(s) by scaling down to 0.
+[source,bash]
+----
+docker-compose up --scale bonita=0 --no-recreate -d
+----
+After updating the `docker-compose.yml` file to the image built with the new Bonita version, scale up the service when you want to restart Bonita.
 
 === Updating to Java 11 in Bonita 7.9 or a greater version
 Bonita 7.9 and greater versions support Java 11.

--- a/modules/version-update/pages/update-with-update-tool.adoc
+++ b/modules/version-update/pages/update-with-update-tool.adoc
@@ -258,6 +258,13 @@ For example, db.url=jdbc:mysql://localhost:3306/bonita-update?allowMultiQueries=
 // link to back up your runtime nodes => old module, new runtime
 . *IMPORTANT:* *Back up your xref:ROOT:back-up-bonita-bpm-platform.adoc[runtime nodes and databases].*
 
+If you are runing Bonita with xref:ROOT:bonita-docker-installation#_using_docker_compose[Docker Compose], you can stop your bonita node(s) or your custom application node(s) by scaling down to 0.
+[source,bash]
+----
+docker-compose up --scale bonita=0 --no-recreate -d
+----
+After updating your `.yml` file, scale up the service when you want to restart Bonita.
+
 === Run Bonita Update Tool
 . Go to the directory containing Bonita Update Tool/Bonita Migration Tool.
 . Run the appropriate update script:


### PR DESCRIPTION
Scaling can be used to stop the Bonita node when migrating.