### PR TITLE
ci: make "contribution checks" work on forked repo PR

### DIFF
--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -1,7 +1,7 @@
 name: Contribution checks
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   check_antora_content_guidelines:


### PR DESCRIPTION
The workflow now runs on `pull_request_target` events.
There is no security issue here. The checks are done only on the updated file of the PR without doing tool installation, cache update or branch checkout. Only the GitHub API is used.
Using this event allows to create PR comment when the PR is created from a forked repository.

### Notes

Covers https://github.com/bonitasoft/bonita-documentation-site/issues/685

This change has been validated with https://github.com/bonitasoft/bonita-labs-doc/pull/155