### PR TITLE
fix: display the "contributing" section in the navbar

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -38,4 +38,3 @@ nav:
   - modules/runtime/runtime-nav.adoc
   - modules/security/security-nav.adoc
   - modules/version-update/version-update-nav.adoc
-  - modules/ROOT/build-community-nav.adoc

--- a/antora.yml
+++ b/antora.yml
@@ -38,3 +38,4 @@ nav:
   - modules/runtime/runtime-nav.adoc
   - modules/security/security-nav.adoc
   - modules/version-update/version-update-nav.adoc
+  - modules/ROOT/contributing-nav.adoc

--- a/antora.yml
+++ b/antora.yml
@@ -38,4 +38,4 @@ nav:
   - modules/runtime/runtime-nav.adoc
   - modules/security/security-nav.adoc
   - modules/version-update/version-update-nav.adoc
-  - modules/ROOT/contributing-nav.adoc
+  - modules/contributing/contributing-nav.adoc


### PR DESCRIPTION
The file that was previously referenced in the Antora configuration didn't exist. Use the right one.


### Screenshots

![image](https://github.com/bonitasoft/bonita-doc/assets/27200110/aa25a8b9-bfa4-4a83-a33c-98417a546bcc)

**Note**: this screenshot was done on a site locally built as the surge preview is currently not always updated, and it wasn't after that the 004b247 commit was pushed

Command to locally build the site
```bash
./build-preview-dev.bash \
  --use-multi-repositories \
  --component-with-branches bonita:fix/remove_not_existing_navbar_file \
  --local-sources
```


### Notes

The new Antora versions now generate a warning when a nav entry cannot be resolved. This is how the problem has been detected.
Detected in https://github.com/bonitasoft/bonita-documentation-site/pull/736#issuecomment-2191256550
