### PR TITLE
docs(SAML): session cookie samesite attribute in cluster

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -17,7 +17,7 @@ Our dedicated team will be here to guide you through this new updated mode, answ
 
 ====
 
-=== User sharing session mechanism between nodes
+=== User session sharing mechanism between nodes
 Service continuity is a key element of operational performance, so we are introducing a new native capability to help to ensure access to applications. Even when a node experiences downtime, users will remain seamlessly connected and will be able to continue working without interruptions, ensuring smooth operations and increased user satisfaction.
 
 === Test toolkit V2

--- a/modules/identity/pages/single-sign-on-with-saml.adoc
+++ b/modules/identity/pages/single-sign-on-with-saml.adoc
@@ -521,6 +521,11 @@ When first accessing Bonita, a JSESSIONID cookie is created and the requested UR
 ----
     <CookieProcessor sameSiteCookies="none" />
 ----
+For a xref:runtime:overview-of-bonita-bpm-in-a-cluster.adoc[Bonita cluster] (Enterprise and Performance editions only), HTTP sessions are handled by Spring Session, and in order to set the sameSite attribute to None, you need to add to the file bonita-platform-sp-cluster.properties located in `<BUNDLE_HOME>/setup/platform_conf/current/platform_engine/`, the property:
+[source,properties]
+----
+server.servlet.session.cookie.same-site=None
+----
 * If your Bonita runtime server is not configured for HTTPS, then the only solution to keep the initially requested URL after being authenticated is to have the IdP and Bonita server in the same domain so that cookies are sent even with the default sameSite policy (using a reverse proxy for example).
 * Another option to not be redirected to Bonita home page after the authentication is to Force the systematic redirection to a specific application home page by defining it in the query string of the ACS URL in the IdP server's configuration : `http[s]://<bundle host>:<port>/bonita/saml?redirectTo=bonita/apps/myApp/home/`. However, with this solution, users will always be redirected to the same place after logging in.
 --

--- a/modules/identity/pages/single-sign-on-with-saml.adoc
+++ b/modules/identity/pages/single-sign-on-with-saml.adoc
@@ -521,7 +521,7 @@ When first accessing Bonita, a JSESSIONID cookie is created and the requested UR
 ----
     <CookieProcessor sameSiteCookies="none" />
 ----
-For a xref:runtime:overview-of-bonita-bpm-in-a-cluster.adoc[Bonita cluster] (Enterprise and Performance editions only), HTTP sessions are handled by Spring Session, and in order to set the sameSite attribute to None, you need to add to the file bonita-platform-sp-cluster.properties located in `<BUNDLE_HOME>/setup/platform_conf/current/platform_engine/`, the property:
+* For a xref:runtime:overview-of-bonita-bpm-in-a-cluster.adoc[Bonita cluster] (Enterprise and Performance editions only), HTTP sessions are handled by Spring Session, and in order to set the sameSite attribute to None, you need to add to the file bonita-platform-sp-cluster.properties located in `<BUNDLE_HOME>/setup/platform_conf/current/platform_engine/`, the property:
 [source,properties]
 ----
 server.servlet.session.cookie.same-site=None

--- a/modules/runtime/pages/install-a-bonita-bpm-cluster.adoc
+++ b/modules/runtime/pages/install-a-bonita-bpm-cluster.adoc
@@ -197,7 +197,7 @@ If your Bonita installation is behind a proxy or is installed inside a Docker co
 
 === Configure sessions and session cookies
 
-Since Bonita 2023.2, HTTP sessions are handled (and shared between nodes) by Spring Session instead of Tomcat.
+Since Bonita 2023.2, HTTP sessions are handled (and shared between nodes) using Spring Session instead of Tomcat.
 As a result, in order to override the default session timeout or the session cookies attributes, Tomcat configuration may be irrelevant. But the following properties can be added and configured in the file `platform_engine/bonita-platform-sp-cluster-custom.properties` instead:
 
 [source,properties]
@@ -211,6 +211,7 @@ server.servlet.session.cookie.domain=
 server.servlet.session.cookie.path=/
 spring.session.timeout=1800
 ----
+NOTE: These properties can also be set using environment variables or system properties.
 
 == Cluster management
 

--- a/modules/runtime/pages/install-a-bonita-bpm-cluster.adoc
+++ b/modules/runtime/pages/install-a-bonita-bpm-cluster.adoc
@@ -198,7 +198,7 @@ If your Bonita installation is behind a proxy or is installed inside a Docker co
 === Configure sessions and session cookies
 
 Since Bonita 2023.2, HTTP sessions are handled (and shared between nodes) by Spring Session instead of Tomcat.
-As a result, in order to override the default session timeout or the session cookies attributes, Tomcat configuration may be irrelevant, but the following properties can be added to the file `platform_engine/bonita-platform-sp-cluster-custom.properties`:
+As a result, in order to override the default session timeout or the session cookies attributes, Tomcat configuration may be irrelevant. But the following properties can be added and configured in the file `platform_engine/bonita-platform-sp-cluster-custom.properties` instead:
 [source,properties]
 ----
 server.servlet.session.cookie.name=JSESSIONID

--- a/modules/runtime/pages/install-a-bonita-bpm-cluster.adoc
+++ b/modules/runtime/pages/install-a-bonita-bpm-cluster.adoc
@@ -195,6 +195,22 @@ If your Bonita installation is behind a proxy or is installed inside a Docker co
 
 <<install_first_node,Install a first node part>>.
 
+=== Configure sessions and session cookies
+
+Since Bonita 2023.2, HTTP sessions are handled (and shared between nodes) by Spring Session instead of Tomcat.
+As a result, in order to override the default session timeout or the session cookies attributes, Tomcat configuration may be irrelevant, but the following properties can be added to the file `platform_engine/bonita-platform-sp-cluster-custom.properties`:
+[source,properties]
+----
+server.servlet.session.cookie.name=JSESSIONID
+server.servlet.session.cookie.same-site=Lax
+server.servlet.session.cookie.secure=false
+server.servlet.session.cookie.http-only=true
+server.servlet.session.cookie.max-age=-1
+server.servlet.session.cookie.domain=
+server.servlet.session.cookie.path=/
+spring.session.timeout=1800
+----
+
 == Cluster management
 
 === Stop a node

--- a/modules/runtime/pages/install-a-bonita-bpm-cluster.adoc
+++ b/modules/runtime/pages/install-a-bonita-bpm-cluster.adoc
@@ -199,6 +199,7 @@ If your Bonita installation is behind a proxy or is installed inside a Docker co
 
 Since Bonita 2023.2, HTTP sessions are handled (and shared between nodes) by Spring Session instead of Tomcat.
 As a result, in order to override the default session timeout or the session cookies attributes, Tomcat configuration may be irrelevant. But the following properties can be added and configured in the file `platform_engine/bonita-platform-sp-cluster-custom.properties` instead:
+
 [source,properties]
 ----
 server.servlet.session.cookie.name=JSESSIONID


### PR DESCRIPTION
* document new properties to configure session timeout and session cookie in cluster

Relates to [RUNTIME-1877](https://bonitasoft.atlassian.net/browse/RUNTIME-1877)

Should be merged on 9.0.5 release

[RUNTIME-1877]: https://bonitasoft.atlassian.net/browse/RUNTIME-1877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ