### PR TITLE
docs:  Use latest version for ui-builder

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -16,7 +16,7 @@ asciidoc:
     cscDownloadUrl: '{cscRootUrl}/downloads'
     cscLicenseUrl: '{cscRootUrl}/licenses'
     # UI Builder attributes
-    bonita-ui-builder-version: 'latest'
+    bonita-ui-builder-version: '1.0.0-beta.2'
     bonita-ui-builder-image: '{bonitasoft-docker-repository}/bonita-ui-builder'
     # ref versions of other components
     bcdDocVersion: '4.0'

--- a/antora.yml
+++ b/antora.yml
@@ -16,7 +16,7 @@ asciidoc:
     cscDownloadUrl: '{cscRootUrl}/downloads'
     cscLicenseUrl: '{cscRootUrl}/licenses'
     # UI Builder attributes
-    bonita-ui-builder-version: '1.0.0-beta.1'
+    bonita-ui-builder-version: 'latest'
     bonita-ui-builder-image: '{bonitasoft-docker-repository}/bonita-ui-builder'
     # ref versions of other components
     bcdDocVersion: '4.0'

--- a/modules/applications/examples/ui-builder/development/docker-compose.yml
+++ b/modules/applications/examples/ui-builder/development/docker-compose.yml
@@ -1,7 +1,7 @@
 # Use for running a bonita-ui-builder during development.
 services:
   bonita-ui-builder:
-    image: ${IMAGE_NAME:-pass:a[{bonita-ui-builder-image}]:pass:a[{bonita-ui-builder-version}]}
+    image: ${IMAGE_NAME:-pass:a[{bonita-ui-builder-image}]:latest}
     container_name: bonita-ui-builder
     environment:
       BONITA_API_URL: http://host.docker.internal:${BONITA_RUNTIME_PORT:-8080}/bonita/API


### PR DESCRIPTION
* Since we restore the `latest` version for uib, we can use it in the docs.