### PR TITLE
docs(uib): mount volume for development mode

### DIFF
--- a/modules/applications/examples/ui-builder/development/docker-compose.yml
+++ b/modules/applications/examples/ui-builder/development/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       BONITA_API_URL: http://host.docker.internal:${BONITA_RUNTIME_PORT:-8080}/bonita/API
     ports:
       - "8090:80"
+    # Mount a volume to store persistent data
+    volumes:
+      - ./stacks:/appsmith-stacks
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/modules/applications/pages/ui-builder/download-and-launch.adoc
+++ b/modules/applications/pages/ui-builder/download-and-launch.adoc
@@ -30,6 +30,12 @@ include::example$ui-builder/development/docker-compose.yml[]
 
 [NOTE]
 ====
+A volume is mounted to the local folder `./stacks` to store persistent data. In case the container crashes, your work will not be lost.
+Fill free to update the folder to another location on your local machine.
+====
+
+[NOTE]
+====
 You can override and configure all xref:ui-builder-docker-installation.adoc#environment-variables[environment variables] in the `docker-compose.yml` file.
 ====
 


### PR DESCRIPTION
Update the `docker-compose.yml` used during development to store persistent data. In case the container crashes, the ongoing work won't be lost.