### PR TITLE
fix(2025.1): add missing "bonita-ui-proxy-image" asciidoctor attribute

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -9,6 +9,7 @@ asciidoc:
     bonitasoft-registry: 'bonitasoft.jfrog.io'
     bonitasoft-docker-repository: '{bonitasoft-registry}/docker'
     bonitaTechnicalVersion: '10.3.0' # latest public community version
+    # TODO move above and backport changes from the 2024.3 branch
     bonita-ui-builder-version: '1.0.0-beta.1'
     bonita-ui-builder-image: '{bonitasoft-docker-repository}/bonita-ui-builder'
     minimalRequiredJavaVersion: '17'

--- a/antora.yml
+++ b/antora.yml
@@ -9,15 +9,16 @@ asciidoc:
     bonitasoft-registry: 'bonitasoft.jfrog.io'
     bonitasoft-docker-repository: '{bonitasoft-registry}/docker'
     bonitaTechnicalVersion: '10.3.0' # latest public community version
-    # TODO move above and backport changes from the 2024.3 branch
-    bonita-ui-builder-version: '1.0.0-beta.1'
-    bonita-ui-builder-image: '{bonitasoft-docker-repository}/bonita-ui-builder'
     minimalRequiredJavaVersion: '17'
     javadocVersion: '10.3'
     openApiUrl: 'https://api-documentation.bonitasoft.com'
     cscRootUrl: https://csc.bonitacloud.bonitasoft.com/apps/CustomerServices
     cscDownloadUrl: '{cscRootUrl}/downloads'
     cscLicenseUrl: '{cscRootUrl}/licenses'
+    # UI Builder attributes
+    bonita-ui-builder-version: '1.0.0-beta.3'
+    bonita-ui-builder-image: '{bonitasoft-docker-repository}/bonita-ui-builder'
+    bonita-ui-proxy-image: '{bonitasoft-docker-repository}/bonita-ui-proxy'
     # ref versions of other components
     bcdDocVersion: '4.0'
     testToolkitVersion: '3.0'


### PR DESCRIPTION
The attribute wasn't defined in the antora.yml file (the version to version automatic script doesn't apply changes to this file).
The attribute was added in the 2024.3 branch in 6f6a9cff1ea210200c3a4f71b140d650e8ed88a3.
Apply the latest available values from the 2024.3 branch: f23e74288d8b76b4871368da14bebbbe3df61608

### Notes

Detected in https://github.com/bonitasoft/bonita-documentation-site/actions/runs/10590673724/job/29346831467?pr=773#step:7:121 / https://github.com/bonitasoft/bonita-documentation-site/pull/773
The workflow builds a branch for each component (the latest branch declared in the antora-playbook.yml)
```
 [05:21:34.928] WARN (asciidoctor): skipping reference to missing attribute: bonita-ui-proxy-image
    file: modules/applications/pages/ui-builder/download-and-launch.adoc
    source: https://github.com/bonitasoft/bonita-doc.git (branch: 2025.1)
[05:21:34.997] WARN (asciidoctor): skipping reference to missing attribute: bonita-ui-proxy-image
    file: modules/applications/pages/ui-builder/ui-builder-docker-installation.adoc
    source: https://github.com/bonitasoft/bonita-doc.git (branch: 2025.1)
```