### PR TITLE
docs(database-configuration): oracle search is no longer case-sensitive

### DIFF
--- a/modules/runtime/pages/database-configuration.adoc
+++ b/modules/runtime/pages/database-configuration.adoc
@@ -83,8 +83,6 @@ To create the database(s), we recommend that you refer to your RDBMS documentati
 [WARNING]
 ====
 Your database(s) must be configured to use the UTF-8 character set.
-
-Search in Bonita are case-insensitive on all RDBMS except Oracle. xref:api:using-list-and-search-methods.adoc#case_sensitivity[More details here.]
 ====
 
 [#specific_database_configuration]


### PR DESCRIPTION
Removes a warning saying that the search for Oracle is case-sensitive. It is no longer the case since this PR https://github.com/bonitasoft/bonita-doc/pull/2591