### PR TITLE
fix: use the right version for 2024.2-u2 in the version list

### DIFF
--- a/modules/version-update/pages/product-versioning.adoc
+++ b/modules/version-update/pages/product-versioning.adoc
@@ -38,7 +38,7 @@ Here is a Bonita Platform version / Technical Id / UI Designer version correspon
 | Release date | Bonita Platform version | Technical Id | UI Designer version
 
 | 2024-09-10
-| 2024.1-u2
+| 2024.2-u2
 | 10.1.2
 | 1.19.0
 


### PR DESCRIPTION
This was a typo. 2024.1-u2 was used instead.

### Notes

Detected by a feedback from an external contributor: https://github.com/bonitasoft/bonita-documentation-site/issues/798
Remaining typo not fixed as part of #2849