### PR TITLE
refactor: update 2 links

### DIFF
--- a/modules/process/pages/groovy-in-bonita.adoc
+++ b/modules/process/pages/groovy-in-bonita.adoc
@@ -412,4 +412,4 @@ This object can then be used as a process variable type for example.
 == References
 
 * http://docs.groovy-lang.org/docs/groovy-3.0.7/html/documentation/[Groovy 3.0.7 official documentation]
-* https://mrhaki.blogspot.com/search/label/Groovy%3AGoodness[Groovy Goodness by MrHaki]
+* https://blog.mrhaki.com/2018/06/groovy-goodness-easy-object-creation.html[Groovy Goodness by MrHaki]

--- a/modules/setup-dev-environment/pages/migrate-a-svn-repository-to-github.adoc
+++ b/modules/setup-dev-environment/pages/migrate-a-svn-repository-to-github.adoc
@@ -92,4 +92,4 @@ You can now clone this git repository in Bonita Studio.
 
 For a more advanced migration read the following article
 
-* https://john.albin.net/git/convert-subversion-to-git
+* https://john.albin.net/blog/git/convert-subversion-to-git


### PR DESCRIPTION
The link to the article about the "conversion from Subversion to Git" involved a redirect. For a more direct access, use the new URL of the article.

The link to a Groovy article sent to a site using a wrong certificate that prevented to access to the article: "x509: certificate is not valid for any names, but wanted to match mrhaki.blogspot.com"
Use a new URL of a site with a valid certificate.

### Notes

Detected as part of https://github.com/bonitasoft/bonita-documentation-site/issues/430 and https://github.com/bonitasoft/bonita-documentation-site/issues/594.