### PR TITLE
fix: remove hard coded reference to CSC

### DIFF
--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -42,7 +42,7 @@ docker run --rm -h <hostname> -it {bonitasoft-docker-repository}/bonita-subscrip
 
 Answer the questions related to the license you want. This will print out the request key and exit automatically from the running container.
 
-Then complete the form on the https://customer.bonitasoft.com/license/request[Customer Service Center] to request a license (use the request key previously generated). Follow the requested steps to download the license file (`.lic` extension).
+Then complete the form on the {cscLicenseUrl}[Customer Service Center] to request a license (use the request key previously generated). Follow the requested steps to download the license file (`.lic` extension).
 
 Copy the license file into a folder that will be mounted as a volume of the docker container. In this example, we will use `~/bonita-lic/`.
 


### PR DESCRIPTION
Use an AsciiDoc attribute instead.

### Notes

This problem was detected in #2970