### PR TITLE
fix: use correct URL for CSC downloads and license page

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -11,8 +11,8 @@ asciidoc:
     keycloakDocumentationVersion: 21.1.2
     cscRootUrl: https://csc.bonitacloud.bonitasoft.com/
     cscCustomerServices: '{cscRootUrl}/apps/CustomerServices'
-    cscDownloadUrl: '{cscRootUrl}/downloads'
-    cscLicenseUrl: '{cscRootUrl}/licenses'
+    cscDownloadUrl: '{cscCustomerServices}/downloads'
+    cscLicenseUrl: '{cscCustomerServices}/licenses'
     # ref versions of other components
     bcdDocVersion: '3.6'
     # page attributes


### PR DESCRIPTION
The URLs were wrong since fb433ded1455e8c6689474e35c80e10e821ca9d0.
They were missing the part leading to the application.