### PR TITLE
fix(software): fix wrong CentOS version

### DIFF
--- a/modules/runtime/pages/hardware-and-software-requirements.adoc
+++ b/modules/runtime/pages/hardware-and-software-requirements.adoc
@@ -48,7 +48,7 @@ Software required for Bonita Platform.
 | 8.x & 9.x 64 bits
 
 | CentOS
-| 7 - 64 bits
+| 8.4 64 bits
 
 | Ubuntu
 | 20.04 LTS 64 bits


### PR DESCRIPTION
that was probably retrograded erroneously.

This commit restores the version supported from 7 to 8.4