### PR TITLE
fix: remove icon in the title of "performance-troubleshooting"

### DIFF
--- a/modules/runtime/pages/performance-troubleshooting.adoc
+++ b/modules/runtime/pages/performance-troubleshooting.adoc
@@ -1,4 +1,4 @@
-= image:troubleshooting.png[troubleshooting-icon] Performance troubleshooting
+= Performance troubleshooting
 :page-aliases: ROOT:performance-troubleshooting.adoc
 :description: Learn how to monitor your Bonita Platform and troubleshoot performance issues.
 


### PR DESCRIPTION
This causes issues in generated title attribute of the site manifest and in other places.