### PR TITLE
fix(2023.1): fix broken in enforce-password-policy

### DIFF
--- a/modules/identity/pages/enforce-password-policy.adoc
+++ b/modules/identity/pages/enforce-password-policy.adoc
@@ -36,7 +36,7 @@ It will be applied to all users.
 [discrete]
 === Prerequisites
 
-You should have Maven installed and setup to access the xref:software-extensibility:bonita-repository-access#_bonita_maven_repository_declaration[Bonita Artifact Repository,target="_blank"].
+You should have Maven installed and setup to access the xref:software-extensibility:bonita-repository-access.adoc#bonita-artifact-repository[Bonita Artifact Repository,target="_blank"].
 
 === How to create a Java class containing your own password validation characteristics
 
@@ -67,7 +67,7 @@ Here are the steps to create and add a custom password validator:
       <snapshots>
           <enabled>false</enabled>
       </snapshots>
-      <url>https://maven.restlet.talend.com/</url>
+      <url>++https://maven.restlet.talend.com/++</url>
     </repository>
     <repository>
       <id>terracotta</id>
@@ -77,7 +77,7 @@ Here are the steps to create and add a custom password validator:
       <snapshots>
           <enabled>false</enabled>
       </snapshots>
-      <url>https://repo.terracotta.org/maven2/</url>
+      <url>++https://repo.terracotta.org/maven2/++</url>
      </repository>
 </repositories>
 ----


### PR DESCRIPTION
An anchor was broken and in the maven XML example, the links to the repositories includes an extra </url> at the end of the URLs.