### PR TITLE
fix: Add troubleshooting for 404 application error on development

### DIFF
--- a/modules/applications/pages/ui-builder/builder-declare-interface-in-bonita.adoc
+++ b/modules/applications/pages/ui-builder/builder-declare-interface-in-bonita.adoc
@@ -52,11 +52,11 @@ Once your application descriptor is done, don't forget to deploy it by clicking 
 [.troubleshooting-section]
 --
 [.symptom]
-After deploy an application link from a Studio, you can't access to the application from application directory and got a 404 error page.
+After deployment of an application link from a Studio, you can't access to the application from application directory and get a 404 error page.
 
 [.cause]#Cause#
-The url in the browser are probaly wrong and you tryed to access to the something like `http://localhost:<Runtime-port>/app/<app-token>`.
+The url in the browser is probably wrong and you tried to access to something like `http://localhost:<Runtime-port>/app/<app-token>`.
 
 [.solution]#Solution#
-The workaround for this issue is to remove the port in the url and try to access to directly to `http://localhost/app/<app-token>`.
+The workaround for this issue is to remove the port in the url and try to access directly to `http://localhost/app/<app-token>`.
 --

--- a/modules/applications/pages/ui-builder/builder-declare-interface-in-bonita.adoc
+++ b/modules/applications/pages/ui-builder/builder-declare-interface-in-bonita.adoc
@@ -46,3 +46,17 @@ Once your application descriptor is done, don't forget to deploy it by clicking 
 
 
 
+[.troubleshooting-title]
+== Troubleshooting
+
+[.troubleshooting-section]
+--
+[.symptom]
+After deploy an application link from a Studio, you can't access to the application from application directory and got a 404 error page.
+
+[.cause]#Cause#
+The url in the browser are probaly wrong and you tryed to access to the something like `http://localhost:<Runtime-port>/app/<app-token>`.
+
+[.solution]#Solution#
+The workaround for this issue is to remove the port in the url and try to access to directly to `http://localhost/app/<app-token>`.
+--


### PR DESCRIPTION
* If user try to access to a application link with the port in the url, he got a 404 error.