### PR TITLE
feat: Use new syntax for asciinema resources

### DIFF
--- a/modules/version-update/pages/update-with-migration-tool.adoc
+++ b/modules/version-update/pages/update-with-migration-tool.adoc
@@ -525,7 +525,7 @@ you need to redesign them in the Studio using Bonita UI designer, as explained i
 Example of output issued when running the tool:
 
 
-[asciinema,rows=32,autoPlay=true]
+[asciinema,rows=32]
 ----
 include::image$images/case_overview_update_mode-ascii.cast[]
 ----

--- a/modules/version-update/pages/update-with-migration-tool.adoc
+++ b/modules/version-update/pages/update-with-migration-tool.adoc
@@ -523,9 +523,12 @@ you need to redesign them in the Studio using Bonita UI designer, as explained i
 ====
 
 Example of output issued when running the tool:
-++++
-<asciinema-player src="_images/images/case_overview_update_mode-ascii.cast" speed="2" theme="monokai" title="Update case overview console output example" cols="240" rows="32"></asciinema-player>
-++++
+
+
+[asciinema,rows=32,autoPlay=true]
+----
+include::image$images/case_overview_update_mode-ascii.cast[]
+----
 
 === 6.x Application resources
 


### PR DESCRIPTION
* Since new theme release (v1.25), we are now integrated a easier syntax to declared a asciinema resources
* Unfortunately in preview, this display is broken

Cover bonitasoft/bonita-documentation-theme#130