### PR TITLE
feat: improve how the `la-deployer` version is documented

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,6 +8,7 @@ asciidoc:
     bonitasoft-docker-repository: '{bonitasoft-registry}/docker'
     bonitaTechnicalVersion: '9.0.0' # latest public community version
     javadocVersion: '9.0'
+    laDeployerVersion: '1.1.0'
     keycloakDocumentationVersion: 21.1.2
     cscRootUrl: 'https://csc.bonitacloud.bonitasoft.com'
     cscCustomerServices: '{cscRootUrl}/apps/CustomerServices'

--- a/modules/bcd/pages/deployer.adoc
+++ b/modules/bcd/pages/deployer.adoc
@@ -21,10 +21,12 @@ IMPORTANT: First make sure your maven installation is configured to access xref:
 
 You can download the `bonita-la-deployer` with a single maven command (that will reuse the credentials declared in your maven settings.xml configuration file).
 
+NOTE: The available versions of `bonita-la-deployer` and the Bonita versions they support are described in the xref:requirements-and-compatibility.adoc#la-deployer-versions [compatibility table].
+
 .Download with maven
-[source, bash]
+[source, bash, subs="attributes+"]
 ----
-mvn dependency:copy -Dartifact=com.bonitasoft.deployer:bonita-la-deployer:<deployer.version>:jar -Dmdep.stripVersion -Dmdep.stripClassifier -DoutputDirectory=./
+mvn dependency:copy -Dartifact=com.bonitasoft.deployer:bonita-la-deployer:{laDeployerVersion}:jar -Dmdep.stripVersion -Dmdep.stripClassifier -DoutputDirectory=./
 ----
 
 Then just use the CLI jar once downloaded :

--- a/modules/bcd/pages/requirements-and-compatibility.adoc
+++ b/modules/bcd/pages/requirements-and-compatibility.adoc
@@ -38,13 +38,14 @@ Example: to build a 2023.1 (8.0.0) bonita project, you have to use the 8.0.0 ver
 
 IMPORTANT: *Builder is not supported for Bonita project designed with Bonita Studio 2023.2 and above*. In those versions, a Bonita project can be built xref:build-run:build-application.adoc[using Maven].
 
+[#la-deployer-versions]
 === Bonita LA Deployer
 
 The following table shows which bonita-la-deployer CLI versions support specific Bonita releases. +
 
 |===
 | bonita-la-deployer version | Bonita release
-| 1.0.x       | 2021.2.x, 2022.1.x, 2022.2.x, 2023.1.x, 2023.2.x, 2024.1.x
+| 1.1.x       | 2021.2.x, 2022.1.x, 2022.2.x, 2023.1.x, 2023.2.x, 2024.1.x, 2024.2.x, 2024.3.x
 |===
 
 WARNING: If a Bonita release is not listed in the previous table, then it is not supported by the Bonita CI/CD suite offering.


### PR DESCRIPTION
Compatibility matrix: only reference the la-deployer 1.1.x which can manage all supported versions of Bonita (and some older versions).

In the example demonstrating the usage of the deployer, use a specific version to ensure that the documented command can be copied and used as it successfully.

The version is stored in an AsciiDoc attribute to ease maintenance: it can be used in various pages and updated easily in the next versions of the documentation.


### Notes

Closes https://bonitasoft.atlassian.net/browse/RUNTIME-1945

To be reviewed by the Support Team as they requested improvements of the related pages.

> [!IMPORTANT]
> When merging this in next versions of Bonita, the AsciiDoc attribute may not be applied to the antora.yml. In this case, the attribute resolution will fail and the new site won't be deployed.