### PR TITLE
refactor: move the dependencies index page to a dedicated module

### DIFF
--- a/modules/dependencies/pages/index.adoc
+++ b/modules/dependencies/pages/index.adoc
@@ -1,18 +1,17 @@
 = Dependencies
 :description: You will find below the list of dependencies used by Bonita.
+:page-aliases: ROOT:dependencies-index.adoc
 
 {description}
 
 == Development suite
 
-[discrete]
-==== Bonita Studio
+=== Bonita Studio
 
 The list of Bonita Studio dependencies are directly available in the Bonita Studio:
 Click on the menu *Help* \-> *About* \-> *Installation Details*
 
-[discrete]
-==== Others
+=== Others
 
 xref:ROOT:bonita-ui-designer-dependencies.adoc[List of UI Designer dependencies]
 


### PR DESCRIPTION
This makes easier to ignore such URL.
The pages detailing the dependencies are not moved here because they are generated and updated by CI/CD jobs. They could be moved when the related jobs will be updated.

### Notes

Covers https://github.com/bonitasoft/bonita-documentation-site/issues/430 and https://github.com/bonitasoft/bonita-documentation-site/issues/594. 