### PR TITLE
fix(2025.1): use valid links to GitHub

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -9,6 +9,7 @@ asciidoc:
     bonitasoft-registry: 'bonitasoft.jfrog.io'
     bonitasoft-docker-repository: '{bonitasoft-registry}/docker'
     bonitaTechnicalVersion: '10.3.0' # latest public community version
+    bonitaTagOrBranch: 'dev' # for links to the code hosted on GitHub
     minimalRequiredJavaVersion: '17'
     javadocVersion: '10.3'
     laDeployerVersion: '1.1.0'

--- a/modules/identity/pages/user-authentication-overview.adoc
+++ b/modules/identity/pages/user-authentication-overview.adoc
@@ -29,17 +29,17 @@ property in the Bonita web application deployment descriptor (a `web.xml`
 file located in `bonita/WEB-INF`).
 . Javascript in `index.html` will redirect the user to `/apps/appDirectoryBonita`
 (e.g. `+http://localhost:8080/bonita/apps/appDirectoryBonita+`).
-. https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/filter/AuthenticationFilter.java[AuthenticationFilter]
+. https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/filter/AuthenticationFilter.java[AuthenticationFilter]
 applied to the HTTP request send to `/apps/appDirectoryBonita`.
-The filter will check if the user is already authenticated. To do so, it will look in the HTTP session for an `apiSession` attribute (see https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/filter/AlreadyLoggedInRule.java[AlreadyLoggedInRule]).
+The filter will check if the user is already authenticated. To do so, it will look in the HTTP session for an `apiSession` attribute (see https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/filter/AlreadyLoggedInRule.java[AlreadyLoggedInRule]).
 If an `apiSession` attribute exists, this means a user is already authenticated.
 . If the attribute `apiSession` is not set, the user will be redirected to the login page.
 *Note:* Information about the original page the user tried to reach is included in a URL parameter named `redirectURL`.
-The login page URL is determined by the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
+The login page URL is determined by the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
 implementation. The implementation to use is configured in a file `authenticationManager-config.properties`
 (located in `setup/platform_conf/initial/tenant_portal` or `setup/platform_conf/current/tenant_portal` and updatable using the xref:runtime:bonita-platform-setup.adoc[platform setup tool]).
-The default https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
-is https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java[StandardAuthenticationManagerImpl].
+The default https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
+is https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java[StandardAuthenticationManagerImpl].
 Its behavior is to redirect to the `login.jsp` page embedded in the webapp.
 Supporting different implementations enables authentication on an external application (useful for SSO deployment for example).
 . `login.jsp` page will ask the user for the username
@@ -48,41 +48,41 @@ request is sent to `/loginservice`. The request includes the
 username, password, locale (optional, by priority order: provided
 in the URL, stored in HTTP cookie) and the `redirectURL`
 information.
-. URL `/loginservice` is handled by https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java[LoginServlet].
-. https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java[LoginServlet]
-calls `login` method of https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
-. https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
-searches for an https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
-implementation based on configuration file (xref:runtime:bonita-platform-setup.adoc[`authenticationManager-config.properties`]). The default https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
-is https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java[StandardAuthenticationManagerImpl].
-. `authenticate` method is called on the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager].
-`authenticate` method of https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java[StandardAuthenticationManagerImpl]
+. URL `/loginservice` is handled by https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java[LoginServlet].
+. https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java[LoginServlet]
+calls `login` method of https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
+. https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
+searches for an https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
+implementation based on configuration file (xref:runtime:bonita-platform-setup.adoc[`authenticationManager-config.properties`]). The default https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager]
+is https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java[StandardAuthenticationManagerImpl].
+. `authenticate` method is called on the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/AuthenticationManager.java[AuthenticationManager].
+`authenticate` method of https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java[StandardAuthenticationManagerImpl]
 implementation of this method does nothing (the subsequent engine login is enough to authenticate the user)
 . The authentication is considered successful if no Exception is thrown by the `authenticate` method.
-. https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
+. https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
 will then call engine API https://javadoc.bonitasoft.com/api/{javadocVersion}/org/bonitasoft/engine/api/LoginAPI.html#login(java.lang.String,%20java.lang.String)[LoginAPI.login()]
-. At this point, operations are processed on Bonita Engine side. Engine (see https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/LoginAPIImpl.java[LoginAPIImpl]
-class) verifies that the username and password are not empty. Then https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/LoginAPIImpl.java[LoginAPIImpl]
-will call https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-login/src/main/java/org/bonitasoft/engine/core/login/LoginService.java[LoginService]
-(one implementation available: https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-login/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginService]).
-. SecuredLoginService calls https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-authentication/src/main/java/org/bonitasoft/engine/authentication/GenericAuthenticationService.java[GenericAuthenticationService].
-The default implementation is: https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-authentication/src/main/java/org/bonitasoft/engine/authentication/impl/AuthenticationServiceImpl.java[AuthenticationServiceImpl].
-. The https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-authentication/src/main/java/org/bonitasoft/engine/authentication/impl/AuthenticationServiceImpl.java[AuthenticationServiceImpl]
+. At this point, operations are processed on Bonita Engine side. Engine (see https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/LoginAPIImpl.java[LoginAPIImpl]
+class) verifies that the username and password are not empty. Then https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/LoginAPIImpl.java[LoginAPIImpl]
+will call https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-core/bonita-login/src/main/java/org/bonitasoft/engine/core/login/LoginService.java[LoginService]
+(one implementation available: https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-core/bonita-login/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginService]).
+. SecuredLoginService calls https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/services/bonita-authentication/src/main/java/org/bonitasoft/engine/authentication/GenericAuthenticationService.java[GenericAuthenticationService].
+The default implementation is: https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/services/bonita-authentication/src/main/java/org/bonitasoft/engine/authentication/impl/AuthenticationServiceImpl.java[AuthenticationServiceImpl].
+. The https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/services/bonita-authentication/src/main/java/org/bonitasoft/engine/authentication/impl/AuthenticationServiceImpl.java[AuthenticationServiceImpl]
 verifies that your username and password are valid.
-. After call of the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-authentication/src/main/java/org/bonitasoft/engine/authentication/GenericAuthenticationService.java[GenericAuthenticationService],
-https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-login/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginServiceImpl]
-performs an extra check to verify that the provided username exists in the Bonita database (https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-login/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginServiceImpl]
-does not trust https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-authentication/src/main/java/org/bonitasoft/engine/authentication/impl/AuthenticationServiceImpl.java[AuthenticationServiceImpl]).
+. After call of the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/services/bonita-authentication/src/main/java/org/bonitasoft/engine/authentication/GenericAuthenticationService.java[GenericAuthenticationService],
+https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-core/bonita-login/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginServiceImpl]
+performs an extra check to verify that the provided username exists in the Bonita database (https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-core/bonita-login/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginServiceImpl]
+does not trust https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/services/bonita-authentication/src/main/java/org/bonitasoft/engine/authentication/impl/AuthenticationServiceImpl.java[AuthenticationServiceImpl]).
 *Note:* A specific behavior applies for the technical admin.
-. https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-login/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginServiceImpl]
-returns an object that represents the session. This is a server side only object (https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-session/src/main/java/org/bonitasoft/engine/session/model/SSession.java[SSession])
-. Call get back to https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/LoginAPIImpl.java[LoginAPIImpl]
-that converts https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-session/src/main/java/org/bonitasoft/engine/session/model/SSession.java[SSession]
-to https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-common/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession].
-. https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-common/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession]
-is provided back up to the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
+. https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-core/bonita-login/src/main/java/org/bonitasoft/engine/core/login/SecuredLoginServiceImpl.java[SecuredLoginServiceImpl]
+returns an object that represents the session. This is a server side only object (https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/services/bonita-session/src/main/java/org/bonitasoft/engine/session/model/SSession.java[SSession])
+. Call get back to https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/LoginAPIImpl.java[LoginAPIImpl]
+that converts https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/services/bonita-session/src/main/java/org/bonitasoft/engine/session/model/SSession.java[SSession]
+to https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-common/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession].
+. https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-common/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession]
+is provided back up to the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java[LoginManager]
 that will add session information as HTTP session attribute.
-. Call get back to https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java[LoginServlet]
+. Call get back to https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java[LoginServlet]
 that will redirect the user to the requested page.
 
 NOTE: If you xref:ROOT:single-sign-on-with-cas.adoc[configure your Bonita platform to use CAS], the logical flow of authentication is the same as above.
@@ -105,7 +105,7 @@ and corresponds to one user.
 
 *The Bonita Engine session*
 
-See https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-common/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession]
+See https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-common/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession]
 class. This session is created by Bonita Engine when the user submits a login page.
 
 *Session expiration*
@@ -115,7 +115,7 @@ an exception will be raised. Bonita Applications will catch this exception,
 invalidate the HTTP session and redirect the user to the login page.
 
 NOTE: The Bonita Engine default session duration is one hour (default value
-defined in https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-session/src/main/java/org/bonitasoft/engine/session/impl/SessionServiceImpl.java[SessionServiceImpl]).
+defined in https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/services/bonita-session/src/main/java/org/bonitasoft/engine/session/impl/SessionServiceImpl.java[SessionServiceImpl]).
 You can configure a different session duration by editing the `bonita.runtime.session.duration` property in `bonita-tenant-community-custom.properties`. Specify the duration in milliseconds.
 
 If the HTTP session has expired, Bonita Applications will redirect the user to the
@@ -136,7 +136,7 @@ Engine session and HTTP session will be invalidated.
 
 == How do Bonita Applications know if a user is authenticated?
 
-The Bonita Applications check if a valid Bonita Engine session (https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-common/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession]
+The Bonita Applications check if a valid Bonita Engine session (https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-common/src/main/java/org/bonitasoft/engine/session/APISession.java[APISession]
 object) is found in the
 `apiSession`
 attribute inside the HttpRequest. If the engine session is still valid, the user will have access to the required resource.

--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -585,9 +585,9 @@ docker run -v ~/my-config/log4j/:/opt/bonita/conf/logs/ ...
 ----
 
 The volume must contain the 2 files
-https://raw.githubusercontent.com/bonitasoft/bonita-distrib/{bonitaTechnicalVersion}/tomcat-resources/tomcat-distrib-for-bonita/src/main/resources/tomcat/server/conf/log4j2-loggers.xml[log4j2-loggers.xml]
+https://raw.githubusercontent.com/bonitasoft/bonita-distrib/{bonitaTagOrBranch}/tomcat-resources/tomcat-distrib-for-bonita/src/main/resources/tomcat/server/conf/log4j2-loggers.xml[log4j2-loggers.xml]
 and
-https://raw.githubusercontent.com/bonitasoft/bonita-distrib/{bonitaTechnicalVersion}/docker/files/log4j2/log4j2-appenders.xml[log4j2-appenders.xml]
+https://raw.githubusercontent.com/bonitasoft/bonita-distrib/{bonitaTagOrBranch}/docker/files/log4j2/log4j2-appenders.xml[log4j2-appenders.xml]
 
 [NOTE]
 ====

--- a/modules/setup-dev-environment/pages/logging.adoc
+++ b/modules/setup-dev-environment/pages/logging.adoc
@@ -53,7 +53,7 @@ Bonita Runtime uses Mapped Diagnostic Context (MDC) to bring contextual informat
 <Property name="LOG_PATTERN">%highlight{%d{ISO8601_OFFSET_DATE_TIME_HHMM} | ${hostName} | %-5p%notEmpty{[%marker]} | [%t|%T] %c{1.} - %m%notEmpty{ - %X}%n}{FATAL=Bright red, ERROR=red, WARN=yellow bold, INFO=Normal, DEBUG=green bold, TRACE=blue}</Property>
 ----
 
-`%X` brings all the contextual information in the log. You can also write your own pattern to pick specific information. E.g. use `%X\{userId\}` to get the id of the authenticated user. All the usable variables such as `userId` are in the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-commons/src/main/java/org/bonitasoft/engine/mdc/MDCConstants.java[MDCConstants class].
+`%X` brings all the contextual information in the log. You can also write your own pattern to pick specific information. E.g. use `%X\{userId\}` to get the id of the authenticated user. All the usable variables such as `userId` are in the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/services/bonita-commons/src/main/java/org/bonitasoft/engine/mdc/MDCConstants.java[MDCConstants class].
 
 
 ==== HTTP Request tracing configuration
@@ -210,7 +210,7 @@ image::logging/NewTraceCompassProject.gif[New Trace Compass project]
 \s*\D*\d*m([^+]*)\+\d*\s+\|\s+(\S*)\s+\|\s+(\S*)\s+\|\s+\[([\w-]*)\|(\d*)\]\s*([\w\.]*)\s*\-\s*(.*?)(?: \- \{(?:req.correlationId=(\w*)|req.requestId=(\w*)|req.requestURL=(\S*)|txUid=([\w:]*)|userId=([\d]*)|rootProcessInstanceId=([\d]*)|.*?)+\})?
 ----
 +
-You can add/remove as many `propertyName=([...]*)|` blocks as you want to match MDC variables from the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-commons/src/main/java/org/bonitasoft/engine/mdc/MDCConstants.java[MDCConstants class]. +
+You can add/remove as many `propertyName=([...]*)|` blocks as you want to match MDC variables from the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/services/bonita-commons/src/main/java/org/bonitasoft/engine/mdc/MDCConstants.java[MDCConstants class]. +
 Use `yyyy-MM-ddTHH:mm:ss,SSS` for Time Stamp value.
 Test your pattern on an example log line.
 +


### PR DESCRIPTION
The 2025.1 is under development, so we cannot use the `bonitaTechnicalVersion` AsciiDoc attribute in links as there is no release related to this version for now.

So, introduce a new bonitaTagOrBranch AsciiDoc attribute to be able to use the name of the dev branch. Its value could be updated when releasing the beta, RC or GA version.

### Notes

Detected with https://github.com/bonitasoft/bonita-documentation-site/pull/618