### PR TITLE
fix: do not interpret local URL as external link

### DIFF
--- a/modules/identity/pages/single-sign-on-with-oidc.adoc
+++ b/modules/identity/pages/single-sign-on-with-oidc.adoc
@@ -1,8 +1,11 @@
 = OpenID Connect SSO configuration
 :page-aliases: ROOT:single-sign-on-with-oidc.adoc
-:description: Bonita can be configured to use the OpenID Connect (OIDC) protocol to provide single sign-on (SSO), as long as you already have an OpenID Connect Identity Provider server up and running (IdP). OIDC is an extension of OAuth 2.0. Contrary to the SSO support of SAML2, both Bonita Web User Interface and Bonita REST API can be secured and accessed using the OIDC/OAuth protocols (versus just the Web User Interface for SAML2).
+:description: Explain how to configure Bonita to use OpenID Connect for Single Sign-On authentication.
 
-{description}
+Bonita can be configured to use the OpenID Connect (OIDC) protocol to provide Single Sign-On (SSO), as long as you already have an OpenID Connect Identity Provider server up and running (IdP).
+OIDC is an extension of OAuth 2.0.
+
+Contrary to the SSO support of SAML2, both Bonita Web User Interface and Bonita REST API can be secured and accessed using the OIDC/OAuth protocols (versus just the Web User Interface for SAML2)
 
 [NOTE]
 ====
@@ -312,8 +315,7 @@ If your Bonita platform is configured to manage authentication over OIDC, when u
 Therefore, they are not logged out of all applications that are using the OIDC provider.
 To avoid this, you have two options :
 
-[discrete]
-==== Hide the logout button of the Bonita Layout
+=== Hide the logout button of the Bonita Layout
 
 This is the most commonly used solution. Users are logged in as long as they don't close their web browser and their session does not time out.
 To do this, set the `logout.link.hidden` option to `true` in `authenticationManager-config.properties` located in `<BUNDLE_HOME>/setup/platform_conf/initial/tenant_portal` for not initialized platform or `<BUNDLE_HOME>/setup/platform_conf/current/tenant_portal`.
@@ -325,8 +327,7 @@ When a user logs out from the IdP directly, Bonita Runtime's session will remain
 to the configured session timeout value upon each user interaction with the server.
 ====
 
-[discrete]
-==== Setup Bonita platform for OIDC logout
+=== Setup Bonita platform for OIDC logout
 
 https://openid.net/specs/openid-connect-rpinitiated-1_0.html[RP-Initiated logout] allows to log out from the OIDC provider as well as all the registered Service Providers when logging out from Bonita platform. This is required for example if users are on public computers.
 As OIDC Providers do not necessarily support OpenID logout and have different ways of handling it, Bonita only offers OIDC logout through an OIDC logout endpoint URL that the OIDC provider should provide and support.
@@ -338,9 +339,9 @@ To setup Bonita for OIDC logout:
 On the OIDC provider side, you need to configure Bonita OIDC service provider for:
 
 [#front-back-channel-logout]
-* either back-channel logout with the URL `<your bonita server URL>/keycloak/k_logout` (for example http://my.company.domain:8080/bonita/keycloak/k_logout) and a signature algorithm for the logout token (Logout JWT tokens must be signed).
+* either back-channel logout with the URL `<your bonita server URL>/keycloak/k_logout` (for example _++http://my.company.domain:8080/bonita/keycloak/k_logout++_) and a signature algorithm for the logout token (Logout JWT tokens must be signed).
 
-* or front-channel logout with the URL `<your bonita server URL>/logoutservice/oidc` (for example http://my.company.domain:8080/bonita/logoutservice/oidc). Front-channel logout is only supported since Bonita 2022.1-u6. If Bonita and the OIDC provider are not on the same domain, you must make sure the provider adds the session ID (`sid`) and issuer (`iss`) parameters to the logout request and you also need to configure the file `<BUNDLE_HOME>/setup/platform_conf/current/platform_portal/security-config.properties` to add the domain of the OIDC provider to the list of authorized frame-ancestors for Bonita applications (front channet logout request are sent in an Iframe by the OIDC provider) as follows:
+* or front-channel logout with the URL `<your bonita server URL>/logoutservice/oidc` (for example _++http://my.company.domain:8080/bonita/logoutservice/oidc++_). Front-channel logout is only supported since Bonita 2022.1-u6. If Bonita and the OIDC provider are not on the same domain, you must make sure the provider adds the session ID (`sid`) and issuer (`iss`) parameters to the logout request and you also need to configure the file `<BUNDLE_HOME>/setup/platform_conf/current/platform_portal/security-config.properties` to add the domain of the OIDC provider to the list of authorized frame-ancestors for Bonita applications (front channel logout request are sent in an Iframe by the OIDC provider) as follows:
 +
 ----
 #Content-Security-Policy response header value
@@ -402,7 +403,7 @@ We recommend that you use LDAP as your master source for information, synchroniz
 [NOTE]
 ====
 
-By default the xref:ROOT:ldap-synchronizer.adoc[LDAP synchronizer] sets the password of the accounts created with the same value as the username. So, even if you allow standard authentication (by setting the property `oidc.auth.standard.allowed` in *authenticationManager-config.properties*), users won't be able to log in with the Bonita login page directly without going through the OIDC provider authentication. +
+By default, the xref:ROOT:ldap-synchronizer.adoc[LDAP synchronizer] sets the password of the accounts created with the same value as the username. So, even if you allow standard authentication (by setting the property `oidc.auth.standard.allowed` in *authenticationManager-config.properties*), users won't be able to log in with the Bonita login page directly without going through the OIDC provider authentication. +
 ====
 
 [#rest-api]
@@ -423,11 +424,10 @@ This property allows Bonita OIDC filter to detect if the request is a REST API c
 
 To obtain the access token, there are several options depending on your OpenID Connect provider configuration and your use case:
 
-[discrete]
 ==== Resource Owner Credentials Grant
 
 In this scenario, the client application that needs to use Bonita REST API performs a request to the token end point of the OIDC provider with the username and password of the user account to use in Bonita. +
-For example, using a Keyclaok server as OIDC provider, with a realm named `bonita` and a client Id `bonitaOIDC`:
+For example, using a Keycloak server as OIDC provider, with a realm named `bonita` and a client ID `bonitaOIDC`:
 
 ----
   POST /auth/realms/bonita/protocol/openid-connect/token  HTTP/1.1
@@ -442,7 +442,6 @@ For example, using a Keyclaok server as OIDC provider, with a realm named `bonit
 The token endpoint of the OIDC provider will answer with an ID and an access token.
 Once you obtained the Access token, you can make your REST API request in a normal way, just adding a header `Authorization` with value `Bearer <Access token>` (replace the placeholder <Access token> with the token returned by the OIDC provider and make sure to keep the whitespace after `Bearer`).
 
-[discrete]
 ==== Authorization Code Grant
 
 Those scenarios work the same way as when you login into Bonita Runtime except, in this case, it is the client application that uses Bonita REST API which needs to trigger the authentication process by calling the OIDC provider authorization endpoint with Bonita OIDC client as `client_id`. The rest of the scenario is similar to what is described in the <<oidc-overview, OIDC Authorization Code Flow schema>>. +
@@ -471,7 +470,7 @@ If the OIDC provider returns opaque access token (non JWT), then Bonita OIDC cli
 [NOTE]
 ====
 
-When using <<multi-providers, multiple OIDC providers>>, the provider ID must be added as a query parameter to the API call URL (e.g.: `http://<host>:<port>/bonita/API/bpm/user/1?provider=oidc-provider-id`).
+When using <<multi-providers, multiple OIDC providers>>, the provider ID must be added as a query parameter to the API call URL (e.g.: `+http://<host>:<port>/bonita/API/bpm/user/1?provider=oidc-provider-id+`).
 ====
 
 === CORS
@@ -493,7 +492,7 @@ In the file *keycloak-oidc.json*, Make sure the property `enable-cors` is set to
   "cors-allowed-headers": "content-type,X-Requested-With,accept,Origin,Access-Control-Request-Method,Access-Control-Request-Headers,x-bonita-api-token,authorization",
   "cors-exposed-headers": "Access-Control-Allow-Origin,Access-Control-Allow-Credentials,x-bonita-api-token,content-type",
 ----
-You don't need to configure any xref:security:enable-cors-in-tomcat-bundle.adoc#_add_cors_filter[additional CORS filter] (which is the way to handle CORS when Bonita web application is not configured for Authentication with OIDC). Also make sure to update the xref:security:enable-cors-in-tomcat-bundle.adoc#_choose_cookies_samesite_policy[sameSiteCookies policy] of the Tomcat server and use xref:identity:ssl.adoc[HTTPS on your Bonita server].
+You don't need to configure any xref:security:enable-cors-in-tomcat-bundle.adoc#add-cors-filter[additional CORS filter] (which is the way to handle CORS when Bonita web application is not configured for Authentication with OIDC). Also make sure to update the xref:security:enable-cors-in-tomcat-bundle.adoc#_choose_cookies_samesite_policy[sameSiteCookies policy] of the Tomcat server and use xref:identity:ssl.adoc[HTTPS on your Bonita server].
 
 ==== Configure the Identity Provider
 

--- a/modules/security/pages/enable-cors-in-tomcat-bundle.adoc
+++ b/modules/security/pages/enable-cors-in-tomcat-bundle.adoc
@@ -6,7 +6,7 @@ How to enable Cross-Origin Resource Sharing (CORS) in Tomcat, and check it.
 
 If you try to call the REST API from a page hosted on another domain than the one of the Bonita server,
 you will face some issues due to the 'same-origin policy' enforced by web browsers.
-For instance you may see in your browser a message such as:
+For instance, you may see in your browser a message such as:
 
 ____
 Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at XXX.
@@ -23,6 +23,7 @@ When Bonita web application is configured for authentication with OpenID Connect
 
 == Tomcat configuration
 
+[#add-cors-filter]
 === Add CORS filter
 
 Edit the file `BUNDLE_HOME/webapps/bonita/WEB-INF/web.xml` to add the CORS filter:


### PR DESCRIPTION
Such links in the `identity/single-sign-on-with-oidc` AsciiDoc source generated broken links in the final documentation page. The latest broken link was recently introduced in eba3233.

In addition:
  - remove wrong "discrete" directive that was introduced during the migration from Markdown to AsciiDoc 4 years ago!
  - improve the description of the page (the former one was too long)
  - improve inner references by declaring named anchor (don't rely on the title text to ease maintenance)
  - fix some typos