### PR TITLE
fix(2025.1): use latest API version

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -26,7 +26,7 @@ asciidoc:
     # ref versions of other components
     bcdDocVersion: '4.0'
     testToolkitVersion: '3.0'
-    openApiLatestVersion: '1.0.4' # latest compatible version of bonita openApi with this Bonita version
+    openApiLatestVersion: '1.0.5' # latest compatible version of bonita openApi with this Bonita version
     # page attributes (global configuration)
     page-pagination: true # display links to previous/next pages at the bottom of the page
     page-editable: true

--- a/antora.yml
+++ b/antora.yml
@@ -26,7 +26,7 @@ asciidoc:
     # ref versions of other components
     bcdDocVersion: '4.0'
     testToolkitVersion: '3.0'
-    openApiLatestVersion: '1.0.3' # latest compatible version of bonita openApi with this Bonita version
+    openApiLatestVersion: '1.0.4' # latest compatible version of bonita openApi with this Bonita version
     # page attributes (global configuration)
     page-pagination: true # display links to previous/next pages at the bottom of the page
     page-editable: true


### PR DESCRIPTION
The version 1.0.3 version is no longer available, use version 1.0.5 instead.

### Notes
Prior deploying version 1.0.5, there was no redirect for old 1.0.x versions, so users received a http 404 when trying to access to version 1.0.3.
Some redirects have been manually added for old 1.0.x versions.

Detected with https://github.com/bonitasoft/bonita-documentation-site/actions/runs/16315985942/job/46081884287#step:9:85
> bonita/next/applications/ui-builder/resources.html
  Non-OK status: 404 --- bonita/next/applications/ui-builder/resources.html --> https://api-documentation.bonitasoft.com/1.0.3
bonita/next/applications/ui-builder/rest-api.html
  Non-OK status: 404 --- bonita/next/applications/ui-builder/rest-api.html --> https://api-documentation.bonitasoft.com/1.0.3#tag/Authentication/operation/login
