### PR TITLE
fix: replace hard coded api version

### DIFF
--- a/modules/runtime/pages/platform-maintenance-mode.adoc
+++ b/modules/runtime/pages/platform-maintenance-mode.adoc
@@ -33,7 +33,7 @@ To perform that you need to:
 [NOTE]
 ====
 - If you made some changes to the bonita layout page or applicationDirectoryBonita page, you need consider adapting it with the latest versions.
-- You still can use the https://api-documentation.bonitasoft.com/latest/Maintenance[Maintenance API], if you want to get maintenance sate over external applications.
+- You still can use the {openApiUrl}/{openApiLatestVersion}/#tag/Maintenance[Maintenance API], if you want to get maintenance sate over external applications.
 ====
 
 == Enable maintenance mode


### PR DESCRIPTION
Also fix the URL to the Maintenance API.

### Notes

This hard coded URL had been introduced prior it is detected by automatic validation checks run in PR.
The broken URL was detected by https://github.com/bonitasoft/bonita-documentation-site/actions/runs/16315985942/job/46081884287#step:9:30
> bonita/2023.2/runtime/platform-maintenance-mode.html
  Non-OK status: 404 --- bonita/2023.2/runtime/platform-maintenance-mode.html --> https://api-documentation.bonitasoft.com/latest/Maintenance
