### PR TITLE
ci(2025.2): trigger publish to production when contents change

### DIFF
--- a/.github/workflows/push-content.yml
+++ b/.github/workflows/push-content.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '2025.1'
+      - '[0-9][0-9][0-9][0-9].[0-9]' # generic pattern for release branches like 2024.1, 2025.2, etc.
     paths:
       - 'modules/**'
       - 'antora.yml'
       - '.github/workflows/push-content.yml'
 jobs:
   triggerJob:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Notify content changes
         uses: peter-evans/repository-dispatch@v3
@@ -19,5 +19,4 @@ jobs:
           token: ${{secrets.GH_TOKEN_DOC_TRIGGER_WF}}
           repository: bonitasoft/bonita-documentation-site
           event-type: source_documentation_change
-          client-payload: '{ "component": "bonita", "branch": "2025.1" }'
-
+          client-payload: '{ "component": "bonita", "branch": "${{ github.ref_name }}" }'


### PR DESCRIPTION
Use generic glob for branch pattern and github context instead of using hard coded branch names.
In the future, this will prevent from having to update the workflow definition.


### Notes

Covers https://github.com/bonitasoft/bonita-documentation-site/issues/472