### PR TITLE
docs(release-notes): remove version in development

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -1,10 +1,6 @@
 = Release notes
 :description: This is the release notes for Bonita {bonitaVersion} versions
 
-[NOTE]
-====
-The {bonitaVersion} version is in development.
-====
 
 == New available values
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -520,7 +520,7 @@ The notable changes are:
 
 == Bug fixes
 
-=== Fixes in Bonita 2025.1 (2025-09-30)
+=== Fixes in Bonita 2025.1-u0 (2025-09-30)
 
 ==== Fixes in Bonita Runtime (including Bonita Applications)
 


### PR DESCRIPTION
Remove note "The 2025.1 version is in development."