### PR TITLE
feat(uipath): better explain connector 2.3.0 requirements

### DIFF
--- a/modules/process/pages/uipath.adoc
+++ b/modules/process/pages/uipath.adoc
@@ -11,7 +11,7 @@ All connectors share common authentication settings, and have other specific set
 
 [CAUTION]
 ====
-Connector versions 2.3.0 and later require Bonita Studio released after October 2025. +
+Connector versions 2.3.0 and later require Bonita Studio released after October 2025 when using the *Cloud authentication*. +
 Supported Studio versions: 2023.2-u11, 2024.1-u9, 2024.2-u7, 2024.3-u5, and 2025.1-u1 or newer.
 
 If you are using an earlier version of Bonita Studio, please use a connector version prior to 2.3.0.


### PR DESCRIPTION
Usage of the new Studio version is only required when using the Cloud Authentication.