### PR TITLE
docs: add macOS-specific setup instructions for Studio and UI Builder

### DIFF
--- a/modules/ROOT/pages/bonita-studio-download-installation.adoc
+++ b/modules/ROOT/pages/bonita-studio-download-installation.adoc
@@ -52,13 +52,14 @@ Then follow the installation wizard through to the end of the installation proce
          * Windows: `C:\BonitaStudioCommunity-x.y`
          * macOS: `/Applications/BonitaStudioCommunity-x.y`
 +
-==== macOS specific note
-+
-macOS applies strict security restrictions to the `/Applications` directory, which can prevent Docker from modifying files inside it. To avoid permission issues with features like UI Builder:
-+
+[NOTE,caption=MacOS specific note]
+====
+MacOS applies strict security restrictions to the `/Applications` directory, which can prevent Docker from modifying files inside it. To avoid permission issues with features like UI Builder:
+
 * *Option 1 (Recommended)*: Install Bonita Studio in a different directory during the installation process (for example `~/BonitaStudioCommunity-x.y` or `~/Documents/BonitaStudioCommunity-x.y`). This ensures both the Studio and its internal Docker operations can run without elevated permissions.
 * *Option 2*: If Studio is already installed in `/Applications`, make sure your workspace is located outside of `/Applications` (for example in `~/bonita-workspace`).
-+
+====
+
 . Confirmation that installation is about to start: click on "Next"
 . Actual installation: wait a little bit
 . License request. For the Subscription edition only. If you do not have your licence file ready, you can skip that; Bonita Studio will request the license at first start.

--- a/modules/ROOT/pages/bonita-studio-download-installation.adoc
+++ b/modules/ROOT/pages/bonita-studio-download-installation.adoc
@@ -25,7 +25,7 @@ When the download is finished, you should have one of the following files on you
 
 === Subscription edition
 
-Subcription editions cover the now unique Enterprise editions, but also the Performance, Efficiency, and Teamwork editions that are no longer sold but still supported at Bonitasoft. +
+Subscription editions cover the now unique Enterprise editions, but also the Performance, Efficiency, and Teamwork editions that are no longer sold but still supported at Bonitasoft. +
 To download the latest version of Bonita Studio Subscription edition, go to the {cscDownloadUrl}[Customer Service Center] and request the download of the version you need.
 
 When the download is complete, you have one of the following new files:
@@ -51,6 +51,14 @@ Then follow the installation wizard through to the end of the installation proce
   The default installation directories are:
          * Windows: `C:\BonitaStudioCommunity-x.y`
          * macOS: `/Applications/BonitaStudioCommunity-x.y`
++
+==== macOS specific note
++
+macOS applies strict security restrictions to the `/Applications` directory, which can prevent Docker from modifying files inside it. To avoid permission issues with features like UI Builder:
++
+* *Option 1 (Recommended)*: Install Bonita Studio in a different directory during the installation process (for example `~/BonitaStudioCommunity-x.y` or `~/Documents/BonitaStudioCommunity-x.y`). This ensures both the Studio and its internal Docker operations can run without elevated permissions.
+* *Option 2*: If Studio is already installed in `/Applications`, make sure your workspace is located outside of `/Applications` (for example in `~/bonita-workspace`).
++
 . Confirmation that installation is about to start: click on "Next"
 . Actual installation: wait a little bit
 . License request. For the Subscription edition only. If you do not have your licence file ready, you can skip that; Bonita Studio will request the license at first start.

--- a/modules/applications/pages/ui-builder/download-and-launch.adoc
+++ b/modules/applications/pages/ui-builder/download-and-launch.adoc
@@ -35,7 +35,7 @@ If Bonita is running on a port other than 8080, you need to update the `8080` in
 [NOTE]
 ====
 A volume is mounted to the local folder `./stacks` to store persistent data. In case the container crashes, your work will not be lost.
-Fill free to update the folder to another location on your local machine.
+Feel free to update the folder to another location on your local machine.
 ====
 
 [NOTE]
@@ -51,6 +51,11 @@ Once you got the credentials, you have to authenticate with the `docker login` c
 ----
 docker login {bonitasoft-registry}
 ----
+
+[NOTE]
+====
+*macOS users*: If you plan to launch UI Builder from Bonita Studio, additional Keychain configuration is required. See the xref:software-extensibility:bonita-repository-access.adoc#docker-configuration[macOS specific configuration] section.
+====
 
 Run the following command to launch Bonita UI Builder:
 [source,console]

--- a/modules/software-extensibility/pages/bonita-repository-access.adoc
+++ b/modules/software-extensibility/pages/bonita-repository-access.adoc
@@ -212,6 +212,29 @@ You may also log out at the end with the command
 docker logout {bonitasoft-registry}
 ----
 
+==== macOS specific configuration
+
+On macOS, Docker Desktop may require additional authentication setup to access the Bonita Artifact Repository. This is particularly important for features that start Docker containers automatically, such as UI Builder launched from Bonita Studio.
+
+To enable seamless Docker authentication on macOS, store your JFrog credentials in the macOS Keychain:
+
+[source, shell]
+----
+# 1. Get your JFrog token from https://bonitasoft.jfrog.io
+#    (Click on your profile → Edit Profile → Generate an Identity Token)
+
+# 2. Add credentials to macOS Keychain
+security add-generic-password -a "$USER" -s "jfrog_username" -w "your.email@bonitasoft.com"
+security add-generic-password -a "$USER" -s "jfrog_token" -w "your_jfrog_token"
+----
+
+[NOTE]
+====
+Replace `your.email@bonitasoft.com` with your subscription access login and `your_jfrog_token` with your actual JFrog token.
+
+These credentials will be automatically used by Docker when pulling images from the Bonita Artifact Repository, eliminating the need for repeated manual authentication.
+====
+
 === Pull Docker images from Bonita Artifact Repository
 
 Once authenticated, you can pull images with the `docker pull` command. For example:


### PR DESCRIPTION
  - Add warning about /Applications installation path restrictions on macOS
  - Document JFrog Keychain configuration for Docker authentication
  - Add cross-reference from UI Builder docs to Keychain setup
  - Fix typos: "Subcription" → "Subscription", "Fill free" → "Feel free"