### PR TITLE
fix: use new link to hazelcast perfmance tips page

### DIFF
--- a/modules/runtime/pages/performance-tuning.adoc
+++ b/modules/runtime/pages/performance-tuning.adoc
@@ -358,7 +358,7 @@ hibernate_second_level_cache_requests_total{entityManagerFactory="persistence",r
 * if the `hit` / `miss` ratio is low, it means configuration is not optimal, according to your usage. +
 See the following pages for fine-tuning your cache configuration:
   ** https://docs.hazelcast.com/hazelcast/latest/capacity-planning#benchmarking-and-sizing-examples[Hazelcast benchmarking]
-  ** https://docs.hazelcast.com/hazelcast/latest/cluster-performance/performance-tuning[Hazelcast performance tuning]
+  ** https://docs.hazelcast.com/hazelcast/latest/cluster-performance/performance-tips[Hazelcast performance tuning]
 
 
 Example of cache configuration, extracted from file `hazelcast.xml`:


### PR DESCRIPTION
The former link is no longer available; the page has probably been renamed without configuring a redirect.

### Notes

Detected by https://github.com/bonitasoft/bonita-documentation-site/actions/runs/18897661500/job/53938435912#step:9:131