### PR TITLE
docs(Engine's property): Update bonita-docker-installation.adoc

### DIFF
--- a/modules/runtime/pages/bonita-docker-installation.adoc
+++ b/modules/runtime/pages/bonita-docker-installation.adoc
@@ -553,6 +553,9 @@ Change the default value for the Bonita and/or the BDM datasource `minIdle`. Thi
 === BONITA_DS_CONNECTION_POOL_MAX_IDLE, BDM_DS_CONNECTION_POOL_MAX_IDLE
 Change the default value for the Bonita and/or the BDM datasource `maxIdle`. This is the maximum number of connections that should be kept in the pool at all times.
 
+=== BONITA_RUNTIME_CLASSLOADER_INITIALIZATION_TIMEOUT_MINUTES
+Change the default timeout value (5 minutes) used when the classloaders are initialized or refreshed.
+
 === DB_NAME, DB_USER, DB_PASS
 
 These variables are used in conjunction to create a new user, set that user's password, and create the bonita database.


### PR DESCRIPTION
addition of the BONITA_RUNTIME_CLASSLOADER_INITIALIZATION_TIMEOUT_MINUTES property following the fix of the BPA-204

versions: 2024.1 2024.2 2024.3 2025.1