### PR TITLE
docs(email-connector): document OAuth2 XOAUTH2 authentication support

### DIFF
--- a/modules/process/pages/messaging.adoc
+++ b/modules/process/pages/messaging.adoc
@@ -34,14 +34,24 @@ The expression must return a value of the required type. To specify the message 
 | Check the box if STARTTLS security authorization is required
 |
 
+| Authentication > Authentication type
+| Select authentication method: "Basic authentication" (username/password) or "OAuth (XOAUTH2)" for modern email providers (available in version 1.5.0+)
+| Radio button
+
 | Authentication > Username
-| User name for the host account
+| User name for the host account (for Basic authentication and OAuth)
 | String
 
 | Authentication > Password
-| User password for the host account
+| User password for the host account (for Basic authentication)
+| String
+
+| Authentication > OAuth2 Access Token
+| OAuth2 access token for XOAUTH2 authentication (for OAuth authentication type). Required for providers like Gmail and Office 365/Exchange Online that use OAuth2
 | String
 |===
+
+NOTE: OAuth2 authentication (XOAUTH2 SASL) is supported in connector version 1.5.0 and later. This authentication method is required for modern email providers like Gmail and Office 365/Exchange Online that no longer support basic username/password authentication. You must obtain an OAuth2 access token from your email provider before using this authentication type.
 
 *Addressing information:*
 

--- a/modules/process/pages/messaging.adoc
+++ b/modules/process/pages/messaging.adoc
@@ -51,8 +51,7 @@ The expression must return a value of the required type. To specify the message 
 | String
 |===
 
-NOTE: OAuth2 authentication (XOAUTH2 SASL) is supported in connector version 1.5.0 and later. This authentication method is required for modern email providers like Gmail and Office 365/Exchange Online that no longer support basic username/password authentication. You must obtain an OAuth2 access token from your email provider before using this authentication type.
-
+NOTE: OAuth2 authentication (XOAUTH2 SASL) is supported in connector version 1.5.0 and later. This authentication method is required for modern email providers like Gmail and Office 365/Exchange Online that don't support basic username/password authentication. You must obtain an OAuth2 access token from your email provider before using this authentication type. You can use Bonita REST connector for that.
 *Addressing information:*
 
 |===

--- a/modules/process/pages/messaging.adoc
+++ b/modules/process/pages/messaging.adoc
@@ -52,6 +52,7 @@ The expression must return a value of the required type. To specify the message 
 |===
 
 NOTE: OAuth2 authentication (XOAUTH2 SASL) is supported in connector version 1.5.0 and later. This authentication method is required for modern email providers like Gmail and Office 365/Exchange Online that don't support basic username/password authentication. You must obtain an OAuth2 access token from your email provider before using this authentication type. You can use Bonita REST connector for that.
+
 *Addressing information:*
 
 |===


### PR DESCRIPTION
## Summary

Documents the new OAuth2 authentication support added to the email connector in version 1.5.0.

## Changes

- Added documentation for the new Authentication Type radio button selection
- Documented the OAuth2 Access Token parameter for XOAUTH2 authentication
- Added note explaining OAuth2 support for modern email providers (Gmail, Office 365/Exchange Online)
- Updated authentication section to reflect both Basic and OAuth authentication methods

## Related

- Email connector PR: https://github.com/bonitasoft/bonita-connector-email/pull/111
- Implements BPA-194

## Test Plan

- [x] Documentation accurately reflects the new OAuth2 authentication feature
- [x] All authentication parameters are documented
- [x] Version information (1.5.0+) is specified
- [x] Note about OAuth2 token requirements is included