### PR TITLE
docs(release-notes): add OAuth2 authentication support for REST and Email connectors

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -9,7 +9,7 @@ New functionalities and improvements are on dedicated UIB xref:applications:ui-b
 
 === REST Connector OAuth2 Authentication Support
 
-The REST connectors now support OAuth2 authentication methods. This includes:
+The REST connectors now provide built-in OAuth2 authentication support.
 
 * **OAuth2 Client Credentials Flow**: For machine-to-machine authentication (RFC 6749)
 * **OAuth2 Authorization Code Flow**: For user-specific authentication with optional PKCE support (RFC 7636)

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -7,6 +7,27 @@ During development, the Bonita Studio now allows you to launch Bonita UI Builder
 
 New functionalities and improvements are on dedicated UIB xref:applications:ui-builder/ui-builder-release-notes.adoc#release-uib-integration[release notes].
 
+=== REST Connector OAuth2 Authentication Support
+
+The REST connectors now support OAuth2 authentication methods. This includes:
+
+* **OAuth2 Client Credentials Flow**: For machine-to-machine authentication (RFC 6749)
+* **OAuth2 Authorization Code Flow**: For user-specific authentication with optional PKCE support (RFC 7636)
+* **OAuth2 Bearer Token**: For using pre-obtained access tokens
+* **OAuth2 Token Retrieval Connector**: A dedicated connector to obtain OAuth2 access tokens that can be reused across multiple API calls
+
+The OAuth2 Token Retrieval connector allows you to obtain an access token once and reuse it for subsequent REST API calls using the Bearer authentication mode.
+
+See xref:process:rest-connector.adoc[REST Connectors documentation] for more information.
+
+=== Email Connector OAuth2 Authentication Support
+
+The Email connector now supports OAuth2 authentication using the XOAUTH2 mechanism, enabling secure email sending through modern email providers such as Gmail and Office 365/Exchange Online that require OAuth2 authentication.
+
+This feature allows the Email connector to authenticate using a pre-obtained OAuth2 access token (for example using the new OAuth2 Token Retrieval connector) instead of traditional username/password authentication, providing better security and compliance with modern authentication requirements.
+
+See xref:process:messaging.adoc[Email Connector documentation] for more information.
+
 == Notable changes
 
 


### PR DESCRIPTION
## Summary

Updates the 2025.2 release notes to document the new OAuth2 authentication features added to the REST and Email connectors.

## Changes

Added two new sections in the "New available values" section:

### REST Connector OAuth2 Authentication Support
- OAuth2 Client Credentials Flow for machine-to-machine authentication
- OAuth2 Authorization Code Flow for user-specific authentication with PKCE support
- OAuth2 Bearer Token for pre-obtained access tokens
- OAuth2 Token Retrieval Connector for obtaining and reusing access tokens

### Email Connector OAuth2 Authentication Support
- OAuth2 XOAUTH2 authentication mechanism
- Support for modern email providers (Gmail, Office 365/Exchange Online)
- Integration with OAuth2 Token Retrieval connector

## Related PRs

- #3157: REST connector OAuth2 support documentation
- #3156: Email connector OAuth2 support documentation

## Test Plan

- [x] Release notes accurately describe both OAuth2 features
- [x] Links to connector documentation pages are correct
- [x] Content is clear and concise for users
- [x] Formatting follows existing release notes structure