### PR TITLE
docs(OIDC): document cors-allowed-origins configuration property

### DIFF
--- a/modules/identity/pages/single-sign-on-with-oidc.adoc
+++ b/modules/identity/pages/single-sign-on-with-oidc.adoc
@@ -183,7 +183,7 @@ NOTE: Activating this option means any user authorized by the IdP to access Boni
  ** the `ssl-required` property value may need to be changed if Bonita Runtime and the IdP are not both accessed via HTTPS. Possible values for this property are: `all`, `external`, and `none`. For `all`, all requests must come in via HTTPS. For `external`, only non-private IP addresses must come over via HTTPS. For `none`, no requests are required to come over via HTTPS (not recommended for production). For instance, using Entra ID (formerly Azure AD) as OIDC provider requires this property to be set to `all`.
  ** the `principal-attribute` value indicates the OIDC Tokens attribute/claim to use to be considered as user identifier in the client application. It should match the username in Bonita. Possible values are: `sub`, `preferred_username`, `email`, `name`, `nickname`, `given_name`, `family_name`, `middle_name`, `profile`. Using another claim is also possible as long as it is not part of the specified OIDC token standard claims (which are reserved). If the OIDC provider defines a custom claim whose value matches the username of Bonita accounts, just use this claim's name as value for `principal-attribute`.
  ** `public-client` needs to be set to `false` if the OIDC provider requires the client requests to be authenticated (with a client secret for example). In this case you also need to use the `credentials` property. If this property is set to `true`, then no client Authentication header will be sent to the OIDC provider.
- ** `enable-cors` is required only if you want to be able to use Bonita REST API from a web application located on a different domain from your Bonita installation's. It comes with additional options `cors-max-age`, `cors-allowed-methods`, `cors-allowed-headers`, `cors-exposed-headers`. You can check the https://www.keycloak.org/docs/{keycloakDocumentationVersion}/securing_apps/index.html#_java_adapter_config[Keycloak client adapter config documentation] for more information.
+ ** `enable-cors` is required only if you want to be able to use Bonita REST API from a web application located on a different domain from your Bonita installation's. It comes with additional options `cors-max-age`, `cors-allowed-methods`, `cors-allowed-headers`, `cors-exposed-headers` and (since Bonita 2024.1-u9), `cors-allowed-origins`. You can check the https://www.keycloak.org/docs/{keycloakDocumentationVersion}/securing_apps/index.html#_java_adapter_config[Keycloak client adapter config documentation] for more information.
  ** `credentials` defines the https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication[authentication method] used for token requests to the OIDC provider when Bonita client is configured with a confidential access type to the OIDC provider (`public-client` is set to `false`). You can set this property with an object containing just a `secret` (in this case `client_secret_basic` authentication method is used) or, since Bonita 2022.1-u6, you can specify the authentication method explicitly (for older versions see the https://www.keycloak.org/docs/{keycloakDocumentationVersion}/securing_apps/index.html#_client_authentication_adapter[Keycloak client authentication documentation] for the configuration of this property). Supported keys are: `client-secret-basic`, `client-secret-post`, `client-secret-jwt` (or `secret-jwt`), `private-key-jwt` (or `jwt`). Here are some examples:
 +
 ----
@@ -438,7 +438,7 @@ A limitation prevents CORS requests from working with Open ID Connect authentica
 
 ==== Configure Bonita Bundle with OIDC for CORS
 
-In the file *keycloak-oidc.json*, Make sure the property `enable-cors` is set to true and the properties `cors-allowed-methods`, `cors-allowed-headers`, `cors-exposed-headers` have the correct values. For a basic configuration, you can use the following values:
+In the file *keycloak-oidc.json*, make sure the property `enable-cors` is set to true and the properties `cors-allowed-methods`, `cors-allowed-headers`, `cors-exposed-headers` have the correct values. For a basic configuration, you can use the following values:
 
 ----
   "enable-cors": true,
@@ -446,6 +446,18 @@ In the file *keycloak-oidc.json*, Make sure the property `enable-cors` is set to
   "cors-allowed-headers": "content-type,X-Requested-With,accept,Origin,Access-Control-Request-Method,Access-Control-Request-Headers,x-bonita-api-token,authorization",
   "cors-exposed-headers": "Access-Control-Allow-Origin,Access-Control-Allow-Credentials,x-bonita-api-token,content-type",
 ----
+
+Additionally (since Bonita 2024.1-u9), you can configure the `cors-allowed-origins` property to explicitly specify which origins are allowed to make cross-origin requests:
+
+----
+  "cors-allowed-origins": "https://example.com,https://app.example.com",
+----
+
+[NOTE]
+====
+The `cors-allowed-origins` property is particularly useful when your Identity Provider issues opaque (non-JWT) access tokens. In this case, Bonita cannot extract allowed origins from the token itself and relies on this configuration property instead. If you use `*` as a value, all origins will be allowed. If this property is not set, Bonita will rely on the allowed origins configured in the Identity Provider (via the JWT token's `allowed-origins` claim) or allow all origins for opaque tokens.
+====
+
 You don't need to configure any xref:security:enable-cors-in-tomcat-bundle.adoc#_add_cors_filter[additional CORS filter] (which is the way to handle CORS when Bonita web application is not configured for Authentication with OIDC). Also make sure to update the xref:security:enable-cors-in-tomcat-bundle.adoc#_choose_cookies_samesite_policy[sameSiteCookies policy] of the Tomcat server and use xref:identity:ssl.adoc[HTTPS on your Bonita server].
 
 ==== Configure the Identity Provider


### PR DESCRIPTION
## Summary
- Document the new `cors-allowed-origins` configuration property for OIDC CORS setup
- Add explanation of when this property is useful (opaque/non-JWT access tokens)
- Add configuration examples with comma-separated origins
- Clarify that IdP's `Allowed CORS web origins` may not be enforced with opaque tokens

## Context
This documentation update covers the functionality introduced in bonitasoft/bonita-engine-sp#3603, which adds support for the `cors-allowed-origins` property and gracefully handles both JWT and opaque tokens.

## Changes
- Updated the CORS configuration section to include the new `cors-allowed-origins` property
- Added a NOTE block explaining use cases for opaque tokens
- Added version annotation (since Bonita 2024.1-u9) where applicable
- Added clarification note under "Configure the Identity Provider" section

Covers [BPA-244](https://bonitasoft.atlassian.net/browse/BPA-244)

[BPA-244]: https://bonitasoft.atlassian.net/browse/BPA-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ