### PR TITLE
fix: use specific version for engine code links

### DIFF
--- a/modules/api/pages/queriable-logging.adoc
+++ b/modules/api/pages/queriable-logging.adoc
@@ -37,7 +37,7 @@ for (Log log : searchedLogs.getResult()) {
 
 == Implementation details
 
-The queriable logger service stores log message in the Bonita Engine back-end database using the Hibernate library. The https://github.com/bonitasoft/bonita-engine/blob/master/services/bonita-log/src/main/java/org/bonitasoft/engine/services/QueriableLoggerService.java[interface] and the https://github.com/bonitasoft/bonita-engine/tree/master/services/bonita-log/src/main/java/org/bonitasoft/engine/services/impl[implementation] of the service are available from the source code repository on https://github.com/bonitasoft/[GitHub].
+The queriable logger service stores log message in the Bonita Engine back-end database using the Hibernate library. The https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-log/src/main/java/org/bonitasoft/engine/services/QueriableLoggerService.java[interface] and the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-log/src/main/java/org/bonitasoft/engine/services/impl[implementation] of the service are available from the source code repository on https://github.com/bonitasoft/[GitHub].
 
 
 == Disabling the Queriable logger

--- a/modules/identity/pages/rest-api-authorization.adoc
+++ b/modules/identity/pages/rest-api-authorization.adoc
@@ -201,7 +201,7 @@ If the platform has already been started:
 
 The `tenant_security_scripts` folder contains a script sample that can be used to write your own.
 Bonita also provides default scripts that should fit common usages. They are packages internally in the binaries, but the
-https://github.com/bonitasoft/bonita-engine/tree/master/bpm/bonita-core/bonita-process-engine/src/main/groovy/org/bonitasoft/permissions[source code is available].
+https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-process-engine/src/main/groovy/org/bonitasoft/permissions[source code is available].
 These provided scripts can be used as a base for you own scripts.
 
 If you write your own scripts:

--- a/modules/runtime/pages/database-configuration.adoc
+++ b/modules/runtime/pages/database-configuration.adoc
@@ -228,7 +228,7 @@ Use the default collation determined by the host OS's locale.
 ===== XA Transactions
 
 To support XA transactions, SQL Server requires a specific configuration.
-You can refer to https://msdn.microsoft.com/en-us/library/aa342335(v=sql.110).aspx[MSDN] for more information.
+You can refer to https://learn.microsoft.com/en-us/sql/connect/jdbc/understanding-xa-transactions[MSDN] for more information.
 Here is the list of steps to perform (as an example, the database name BONITA is used):
 
 . Download the zip package of https://learn.microsoft.com/en-us/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server[Microsoft SQL Server JDBC Driver] and unzip it.
@@ -275,7 +275,7 @@ ALTER DATABASE BONITA SET READ_COMMITTED_SNAPSHOT ON
 ALTER DATABASE BONITA SET MULTI_USER
 ----
 
-See https://msdn.microsoft.com/en-us/library/ms175095(v=sql.110).aspx[MSDN].
+See https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-set-options[MSDN].
 
 ===== Recommended configuration for in-doubt xact resolution
 
@@ -312,7 +312,7 @@ Edit the file `setup/tomcat-templates/bonita.xml` by adding the following attrib
 
 You must perform this for each Datasource.
 
-See https://msdn.microsoft.com/en-us/library/ms179586%28v%3Dsql.110%29.aspx[in-doubt xact resolution Server Configuration Option].
+See https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/in-doubt-xact-resolution-server-configuration-option[in-doubt xact resolution Server Configuration Option].
 
 ==== MySQL
 


### PR DESCRIPTION
Previously used the master branch, so code was not related to the documented version.

Also update MSDN links to the new learn.microsoft.com domain to avoid redirections.