### PR TITLE
fix(2025.1): use the specific tag in GitHub code links

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,14 +1,13 @@
 name: bonita
 title: Bonita
 version: 2025.1
-# TODO: When releasing beta version, replace alpha by beta. Remove when releasing GA
 asciidoc:
   attributes:
     bonitaVersion: 2025.1
     bonitasoft-registry: 'bonitasoft.jfrog.io'
     bonitasoft-docker-repository: '{bonitasoft-registry}/docker'
     bonitaTechnicalVersion: '10.3.0' # latest public community version
-    bonitaTagOrBranch: 'dev' # for links to the code hosted on GitHub
+    bonitaTagOrBranch: '10.3.0' # for links to the code hosted on GitHub. Use 'dev' for a development version, or the version number (same as bonitaTechnicalVersion) for released versions
     minimalRequiredJavaVersion: '17'
     javadocVersion: '10.3'
     laDeployerVersion: '1.2.0'

--- a/modules/api/pages/queriable-logging.adoc
+++ b/modules/api/pages/queriable-logging.adoc
@@ -39,7 +39,7 @@ for (Log log : searchedLogs.getResult()) {
 
 == Implementation details
 
-The queriable logger service stores log message in the Bonita Engine back-end database using the Hibernate library. The https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-log/src/main/java/org/bonitasoft/engine/services/QueriableLoggerService.java[interface] and the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/services/bonita-log/src/main/java/org/bonitasoft/engine/services/impl[implementation] of the service are available from the source code repository on https://github.com/bonitasoft/[GitHub].
+The queriable logger service stores log message in the Bonita Engine back-end database using the Hibernate library. The https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/services/bonita-log/src/main/java/org/bonitasoft/engine/services/QueriableLoggerService.java[interface] and the https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/services/bonita-log/src/main/java/org/bonitasoft/engine/services/impl[implementation] of the service are available from the source code repository on https://github.com/bonitasoft/[GitHub].
 
 
 == Disabling the Queriable logger

--- a/modules/identity/pages/rest-api-authorization.adoc
+++ b/modules/identity/pages/rest-api-authorization.adoc
@@ -206,7 +206,7 @@ If the platform has already been started:
 
 The `tenant_security_scripts` folder contains a script sample that can be used to write your own.
 Bonita also provides default scripts that should fit common usages. They are packages internally in the binaries, but the
-https://github.com/bonitasoft/bonita-engine/blob/{bonitaTechnicalVersion}/bpm/bonita-core/bonita-process-engine/src/main/groovy/org/bonitasoft/permissions[source code is available].
+https://github.com/bonitasoft/bonita-engine/blob/{bonitaTagOrBranch}/bpm/bonita-core/bonita-process-engine/src/main/groovy/org/bonitasoft/permissions[source code is available].
 These provided scripts can be used as a base for you own scripts.
 
 If you write your own scripts:


### PR DESCRIPTION
Previously, the links targeted the dev branch because an AsciiDoc attribute hadn't been correctly updated when the GA version was released.
Also fix 3 links that were still using the wrong AsciiDoc attribute.