### PR TITLE
ci(push-content): use generic configuration to ease maintenance

### DIFF
--- a/.github/workflows/push-content.yml
+++ b/.github/workflows/push-content.yml
@@ -4,14 +4,15 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '2023.2'
+      - '202[0-9].[0-9]' # generic pattern for release branches like 2024.1, 2025.2, etc.
     paths:
       - 'modules/**'
       - 'antora.yml'
       - '.github/workflows/push-content.yml'
+
 jobs:
   triggerJob:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Notify content changes
         uses: peter-evans/repository-dispatch@v4
@@ -19,4 +20,4 @@ jobs:
           token: ${{secrets.GH_TOKEN_DOC_TRIGGER_WF}}
           repository: bonitasoft/bonita-documentation-site
           event-type: source_documentation_change
-          client-payload: '{ "component": "bonita", "branch": "2023.2" }'
+          client-payload: '{ "component": "bonita", "branch": "${{ github.ref_name }}" }'


### PR DESCRIPTION
This new configuration avoids the need to perform an update when setting up a new version.
It should be usable as is, without modification.

### Notes

Covers #472