### PR TITLE
fix: clarify JRE requirements and version ranges in Update Tool section

### DIFF
--- a/modules/version-update/pages/update-with-update-tool.adoc
+++ b/modules/version-update/pages/update-with-update-tool.adoc
@@ -116,7 +116,7 @@ cd setup
 Starting with Bonita 2021.2 (Bonita Runtime 7.13), Bonita Applications replaced Bonita Portal. If you need to use some of the Portal Look&Feel assets in the themes of your applications, make sure you create backups of those files before launching the updating procedure.
 
 === JRE requirements
-Based on your target Bonita version, check whether JRE update is required in your environment before launching the update process:
+Based on your target Bonita version, check whether JRE update is required in your environment before launching the update tool:
 
 |===
 |*JRE version* |*Bonita version*

--- a/modules/version-update/pages/update-with-update-tool.adoc
+++ b/modules/version-update/pages/update-with-update-tool.adoc
@@ -120,9 +120,11 @@ Based on your target Bonita version, check whether JRE update is required in you
 
 |===
 |*JRE version* |*Bonita version*
-|JRE version 11 | If targeting an update to Bonita 2021.2 (7.13) or later
-|JRE version 17 | A JRE 17 is not required to run the update tool. But you will need one to run Bonita 2024.1 (10.0) or later
+|JRE version 11 | If targeting an update to Bonita versions between 2021.2 (7.13) and 2023.2 (9.0)
+|JRE version 11 or 17 | If targeting an update to Bonita versions between 2024.1 (10.0) and 2024.3 (10.2)
+|JRE version 17 | If targeting an update to Bonita version 2025.1 (10.3) or later
 |===
+Note: You will need JRE version 17 to run Bonita 2024.1 (10.0) or later.
 
 For more info, see Support Guide and xref:ROOT:hardware-and-software-requirements.adoc[Supported Environment Matrix for Server].
 


### PR DESCRIPTION
Clarified the JRE requirements in the Update Tool documentation:

+ Explicitly defined Java 11 applicability range (Bonita 2021.2 / 7.13 through 2023.2 / 9.0).

+ Clarified Java 11 or 17 support for Bonita 2024.1 (10.0) through 2024.3 (10.2).

+ Specified Java 17 requirement starting from Bonita 2025.1 (10.3).

+ Improved wording and formatting for better readability.

+ Removed ambiguity between JRE required for the Update Tool and JRE required to run Bonita after update.