### PR TITLE
docs(rest-api): add release note for REST API refactoring

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -46,12 +46,17 @@ This concerns the following endpoints:
 * `/API/bdm/businessDataReference/+{caseId}+/+{dataName}+`
 * `/API/bpm/activityReplay/+{activityInstanceId}+`
 * `/API/bpm/activityVariable/+{activityId}+/+{dataName}+`
-    - this API now returns `HTTP 404` when `activityId` or `dataName` is not found (instead of `HTTP 500`)
+    - ⚠️ this API now returns `HTTP 404` when `activityId` or `dataName` is not found (instead of `HTTP 500`)
 * `/API/bpm/archivedActivityVariable/+{activityId}+/+{variableName}+`
-    - this API now returns `HTTP 404` when `activityId` or `variableName` is not found (instead of `HTTP 500`)
+    - ⚠️ this API now returns `HTTP 404` when `activityId` or `variableName` is not found (instead of `HTTP 500`)
 * `/API/bpm/archivedCase/+{archivedCaseId}+/context`
-* `/API/bpm/archivedCaseVariable`
+* `/API/bpm/archivedCaseVariable?f=case_id=12005&p=0&c=10`
+    - ⚠️ this API now returns `HTTP 400` instead of `HTTP 500`:
+        . when `case_id` filter is not provided, or filter `f` completely absent
+        . when pagination parameter `p` is not provided
+        . when pagination parameter `c` is not provided
 * `/API/bpm/archivedCaseVariable/+{caseId}+/+{variableName}+`
+    - ⚠️ this API now returns `HTTP 404` when `caseId` or `variableName` is not found (instead of `HTTP 500`)
 * `/API/bpm/archivedUserTask/+{archivedTaskId}+/context`
 * `/API/bpm/case/+{caseId}+/context`
 * `/API/bpm/diagram/+{processId}+`

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -43,6 +43,10 @@ This concerns the following endpoints:
 
 * `/API/accessControl/bdm`
 * `/API/bdm/businessDataReference`
+    - ⚠️ this API now returns `HTTP 400` instead of `HTTP 500`:
+        . when `caseId` filter is not provided, or filter `f` completely absent
+        . when pagination parameter `p` is not provided
+        . when pagination parameter `c` is not provided
 * `/API/bdm/businessDataReference/+{caseId}+/+{dataName}+`
 * `/API/bpm/activityReplay/+{activityInstanceId}+`
 * `/API/bpm/activityVariable/+{activityId}+/+{dataName}+`

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -33,6 +33,46 @@ If you are updating from a previous version of Bonita, backward compatibility is
 
 See xref:data:bdm-query-response-formats.adoc[BDM Query Response Formats] for detailed migration guidance.
 
+
+=== Rest API refactoring
+
+Many Rest APIs have been refactored to better prepare evolutions in the future.
+(Technically, we moved the implementation from unmaintained Restlet to Spring MVC).
+
+This concerns the following endpoints:
+
+* `/API/accessControl/bdm`
+* `/API/bdm/businessDataReference`
+* `/API/bdm/businessDataReference/+{caseId}+/+{dataName}+`
+* `/API/bpm/activityReplay/+{activityInstanceId}+`
+* `/API/bpm/activityVariable/+{activityId}+/+{dataName}+`
+    - this API now returns `HTTP 404` when `activityId` or `dataName` is not found (instead of `HTTP 500`)
+* `/API/bpm/archivedActivityVariable/+{activityId}+/+{variableName}+`
+    - this API now returns `HTTP 404` when `activityId` or `variableName` is not found (instead of `HTTP 500`)
+* `/API/bpm/archivedCase/+{archivedCaseId}+/context`
+* `/API/bpm/archivedCaseVariable`
+* `/API/bpm/archivedCaseVariable/+{caseId}+/+{variableName}+`
+* `/API/bpm/archivedUserTask/+{archivedTaskId}+/context`
+* `/API/bpm/case/+{caseId}+/context`
+* `/API/bpm/diagram/+{processId}+`
+* `/API/bpm/message`
+* `/API/bpm/process/+{processDefinitionId}+/contract`
+* `/API/bpm/process/+{processDefinitionId}+/design`
+* `/API/bpm/process/+{processDefinitionId}+/expression/+{expressionId}+`
+* `/API/bpm/process/+{processDefinitionId}+/instantiation`
+* `/API/bpm/signal`
+* `/API/bpm/timerEventTrigger`
+* `/API/bpm/timerEventTrigger/+{id}+`
+* `/API/bpm/userTask/+{taskId}+/context`
+* `/API/bpm/userTask/+{taskId}+/contract`
+* `/API/bpm/userTask/+{taskId}+/execution`
+* `/API/form/mapping/+{id}+`
+* `/API/platform/license`
+* `/API/system/i18ntranslation`
+* `/API/tenant/bdm`
+
+The behaviour remains unchanged, even if some HTTP headers may be slightly different.
+
 == Support matrix changes
 
 


### PR DESCRIPTION
## Summary

- Add release note documenting the REST API refactoring from Restlet to Spring MVC
- List all affected endpoints (24 endpoints across multiple API groups)
- Note behavior changes for `activityVariable` and `archivedActivityVariable` endpoints (now return HTTP 404 instead of HTTP 500 for missing resources)
- Note behavior changes for `archivedCaseVariable` endpoints (now return HTTP 404 instead of HTTP 500 for missing resources)

## Test plan

- [x] Verify the release notes page renders correctly in Antora preview
- [x] Confirm all listed endpoints match the actual refactoring scope