### PR TITLE
fix(identity): remove obsolete Maven repositories from password policy example

### DIFF
--- a/modules/identity/pages/enforce-password-policy.adoc
+++ b/modules/identity/pages/enforce-password-policy.adoc
@@ -57,30 +57,6 @@ Here are the steps to create and add a custom password validator:
           <scope>provided</scope>
       </dependency>
  </dependencies>
-
-<!-- Add required additional repositories -->
-<repositories>
-   <repository>
-      <id>restlet</id>
-      <releases>
-          <enabled>true</enabled>
-      </releases>
-      <snapshots>
-          <enabled>false</enabled>
-      </snapshots>
-      <url>++https://maven.restlet.talend.com/++</url>
-    </repository>
-    <repository>
-      <id>terracotta</id>
-      <releases>
-          <enabled>true</enabled>
-      </releases>
-      <snapshots>
-          <enabled>false</enabled>
-      </snapshots>
-      <url>++https://repo.terracotta.org/maven2/++</url>
-     </repository>
-</repositories>
 ----
 
 


### PR DESCRIPTION
## Summary
- Remove unused `restlet` and `terracotta` Maven repository declarations from the custom password validation example POM in the enforce password policy page

## Test plan
- [ ] Verify the remaining XML snippet is valid and complete
- [ ] Check Antora preview build passes