### PR TITLE
docs(connectors): add note pointing to native SharePoint connector

### DIFF
--- a/modules/process/pages/sharepointexample.adoc
+++ b/modules/process/pages/sharepointexample.adoc
@@ -1,6 +1,11 @@
 = Sharepoint integration example
 :description: The page provides instructions on integrating Bonita applications with Microsoft 365 using Graph API, focusing on SharePoint integration.
 
+[NOTE]
+====
+Bonita now provides a **native SharePoint connector** with built-in authentication, automatic retry, and resumable upload support. For new projects, we recommend using the xref:sharepoint-connector.adoc[SharePoint connector] instead of the manual REST approach described below.
+====
+
 This article will help you explore one of the possible ways to integrate your Bonita applications with Microsoft 365 - using Graph API.
 https://docs.microsoft.com/en-us/graph/overview[Microsoft Graph] is a single endpoint, providing access to data and services in the Microsoft cloud.
 It exposes REST APIs to access data on Microsoft 365 services like OneDrive, Outlook, Sharepoint, Team etc. Using it, you can imagine different kinds of applications that let you handle your meetings based on process tasks, generate excel files in your OneDrive with the data handled by your processes, …


### PR DESCRIPTION
## Summary

- Add a `[NOTE]` box at the top of the existing REST-based SharePoint integration example page (`sharepointexample.adoc`), directing users to the new native SharePoint connector for new projects

## Related

- #3267 — SharePoint connector documentation page (native connector)
- Connector repo: https://github.com/bonitasoft/bonita-connector-sharepoint

## Test plan

- [ ] Verify the note renders correctly in the Antora preview
- [ ] Verify the xref link to `sharepoint-connector.adoc` resolves (requires #3267 to be merged first, or both merged together)

🤖 Generated with [Claude Code](https://claude.com/claude-code)