### PR TITLE
docs: add beta section to connectors index

### DIFF
--- a/modules/process/pages/connectors-index.adoc
+++ b/modules/process/pages/connectors-index.adoc
@@ -97,3 +97,8 @@ xref:ROOT:twitter.adoc[[.card-title]#Twitter# [.card-body.card-content-overflow]
 --
 xref:ROOT:web-service-connector-overview.adoc[[.card-title]#Web service# [.card-body.card-content-overflow]#pass:q[Connect your processes to any generic Web service]#]
 --
+
+[.card-section]
+== Bonita official connectors [BETA]
+
+These connectors are currently in beta and have not yet been fully validated in production environments. We welcome feedback from early adopters — each connector page includes a link to report testing results.


### PR DESCRIPTION
## Summary

- Add a new **Bonita official connectors [BETA]** section to the connectors index page
- This section will hold cards for connectors that are in beta and not yet validated in production
- Each per-connector doc PR will add its card to this section after this PR merges

## Context

All newly generated connectors (S3, SharePoint, Google Drive, MS Teams, JasperReports) are in beta. This structural change separates GA connectors from beta ones in the docs index.

## Dependency

Per-connector doc PRs (#3266, #3267, #3264, #3269, #3271) depend on this PR. They should be rebased after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)