### PR TITLE
docs: add proxy-url property to OIDC configuration reference

### DIFF
--- a/modules/identity/pages/single-sign-on-with-oidc.adoc
+++ b/modules/identity/pages/single-sign-on-with-oidc.adoc
@@ -235,6 +235,9 @@ NOTE: Activating this option means any user authorized by the IdP to access Boni
     "^/bonita/(.*)$" : "/$1"
   }
 ----
+  *** `proxy-url` URL of an HTTP proxy for the OIDC adapter's outbound connections to the identity provider (e.g. `\http://proxy.example.com:3128`). This property is required when the Bonita server cannot reach the OIDC provider directly due to network restrictions. 
++
+  Note that standard JVM proxy properties (`-Dhttp.proxyHost`, `-Dhttps.proxyHost`) set via `CATALINA_OPTS` or `setenv.sh` do not apply here. The OIDC adapter requires proxy configuration through this dedicated property. 
 
 [NOTE]
 ====

--- a/modules/identity/pages/single-sign-on-with-oidc.adoc
+++ b/modules/identity/pages/single-sign-on-with-oidc.adoc
@@ -235,9 +235,7 @@ NOTE: Activating this option means any user authorized by the IdP to access Boni
     "^/bonita/(.*)$" : "/$1"
   }
 ----
-  *** `proxy-url` URL of an HTTP proxy for the OIDC adapter's outbound connections to the identity provider (e.g. `\http://proxy.example.com:3128`). This property is required when the Bonita server cannot reach the OIDC provider directly due to network restrictions. 
-+
-  Note that standard JVM proxy properties (`-Dhttp.proxyHost`, `-Dhttps.proxyHost`) set via `CATALINA_OPTS` or `setenv.sh` do not apply here. The OIDC adapter requires proxy configuration through this dedicated property. 
+  *** `proxy-url` URL of an HTTP proxy for the OIDC adapter's outbound connections to the identity provider (e.g. `\http://proxy.example.com:3128`). This property is required when the Bonita server cannot reach the OIDC provider directly due to network restrictions. Note that standard JVM proxy properties (`-Dhttp.proxyHost`, `-Dhttps.proxyHost`) set via `CATALINA_OPTS` or `setenv.sh` do not apply here. The OIDC adapter requires proxy configuration through this dedicated property. 
 
 [NOTE]
 ====


### PR DESCRIPTION
Add documentation for the proxy-url property in keycloak-oidc.json, which configures an HTTP proxy for outbound connections to the OIDC identity provider.

This property is required in hardened network environments where the Bonita server cannot reach the OIDC provider directly. Standard JVM proxy properties (-Dhttp.proxyHost, -Dhttps.proxyHost) set via CATALINA_OPTS do not apply, as the OIDC adapter manages its own HTTP client.

Applies to versions: 2023.2, 2024.1, 2024.2, 2024.3, 2025.1, 2025.2

Ref: Customer feedback from support case #392035