### PR TITLE
fix(connectors): remove broken marketplace links and wrap auth-protected URLs

### DIFF
--- a/modules/process/pages/aws-s3-connector.adoc
+++ b/modules/process/pages/aws-s3-connector.adoc
@@ -35,7 +35,6 @@ Before using the AWS S3 connector, ensure the following:
 * An **AWS account** with access to the Amazon S3 service
 * An **S3 bucket** created in the target AWS region
 * **IAM credentials** with appropriate permissions (e.g., `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, `s3:ListBucket`) depending on the operations you intend to use
-* The connector extension imported into your Bonita project (see <<import-connector>>)
 
 == Authentication
 
@@ -688,14 +687,3 @@ Upload large files using the S3 multipart upload mechanism via the AWS Transfer 
 |The total number of bytes uploaded.
 |===
 
-[#import-connector]
-== Importing the connector into Bonita Studio
-
-To use the AWS S3 connector in your Bonita project:
-
-. Download the connector `.zip` extension from the https://marketplace.bonitasoft.com/[Bonita Marketplace].
-. In Bonita Studio, go to the *Project* menu and select *Extensions*.
-. Click *Import extension* and select the downloaded `.zip` file.
-. The S3 connector operations will appear in the connector palette when configuring a task or a process.
-
-For more details on managing extensions, see xref:bonita-overview:managing-extension-studio.adoc[Managing extensions in Bonita Studio].

--- a/modules/process/pages/connectors-index.adoc
+++ b/modules/process/pages/connectors-index.adoc
@@ -86,22 +86,12 @@ xref:ROOT:script.adoc[[.card-title]#Script# [.card-body.card-content-overflow]#p
 
 [.card.card-index]
 --
-xref:telegram-connector.adoc[[.card-title]#Telegram# [.card-body.card-content-overflow]#pass:q[Send messages and files via Telegram Bot API]#]
---
-
-[.card.card-index]
---
 xref:ROOT:twitter.adoc[[.card-title]#Twitter# [.card-body.card-content-overflow]#pass:q[Create tweets in your processes]#]
 --
 
 [.card.card-index]
 --
 xref:ROOT:web-service-connector-overview.adoc[[.card-title]#Web service# [.card-body.card-content-overflow]#pass:q[Connect your processes to any generic Web service]#]
---
-
-[.card.card-index]
---
-xref:whatsapp-connector.adoc[[.card-title]#WhatsApp Business# [.card-body.card-content-overflow]#pass:q[Send messages via WhatsApp Business API]#]
 --
 
 [.card-section]
@@ -201,12 +191,22 @@ xref:ROOT:servicenow-connector.adoc[[.card-title]#ServiceNow &#91;BETA&#93;# [.c
 
 [.card.card-index]
 --
+xref:telegram-connector.adoc[[.card-title]#Telegram &#91;BETA&#93;# [.card-body.card-content-overflow]#pass:q[Send messages and files via Telegram Bot API]#]
+--
+
+[.card.card-index]
+--
 xref:ROOT:twilio-connector.adoc[[.card-title]#Twilio &#91;BETA&#93;# [.card-body.card-content-overflow]#pass:q[Send SMS, make calls, and verify phone numbers]#]
 --
 
 [.card.card-index]
 --
 xref:ROOT:workday-connector.adoc[[.card-title]#Workday HCM &#91;BETA&#93;# [.card-body.card-content-overflow]#pass:q[Manage workers and HR events in Workday]#]
+--
+
+[.card.card-index]
+--
+xref:whatsapp-connector.adoc[[.card-title]#WhatsApp Business &#91;BETA&#93;# [.card-body.card-content-overflow]#pass:q[Send messages via WhatsApp Business API]#]
 --
 
 [.card.card-index]

--- a/modules/process/pages/connectors-index.adoc
+++ b/modules/process/pages/connectors-index.adoc
@@ -211,5 +211,10 @@ xref:ROOT:workday-connector.adoc[[.card-title]#Workday HCM &#91;BETA&#93;# [.car
 
 [.card.card-index]
 --
+xref:ROOT:yousign-connector.adoc[[.card-title]#Yousign &#91;BETA&#93;# [.card-body.card-content-overflow]#pass:q[Create and manage electronic signature requests]#]
+--
+
+[.card.card-index]
+--
 xref:ROOT:zendesk-connector.adoc[[.card-title]#Zendesk &#91;BETA&#93;# [.card-body.card-content-overflow]#pass:q[Manage support tickets and comments]#]
 --

--- a/modules/process/pages/google-drive.adoc
+++ b/modules/process/pages/google-drive.adoc
@@ -75,7 +75,7 @@ If your service account needs to access files owned by users in a Google Workspa
 . In the Google Cloud Console, go to your service account details
 . Enable *Domain-wide delegation*
 . Note the *Client ID*
-. In your Google Workspace Admin Console (https://admin.google.com), go to *Security > API Controls > Domain-wide Delegation*
+. In your Google Workspace Admin Console (+https://admin.google.com+), go to *Security > API Controls > Domain-wide Delegation*
 . Click *Add new* and enter:
   * *Client ID*: the client ID from the previous step
   * *OAuth scopes*: `https://www.googleapis.com/auth/drive`

--- a/modules/process/pages/msteams-connector.adoc
+++ b/modules/process/pages/msteams-connector.adoc
@@ -56,7 +56,6 @@ Before using the Microsoft Teams connector, ensure the following:
 * For webhook operations: an **Incoming Webhook** configured in the target Teams channel
 * For Graph API operations: an **Entra ID (Azure AD) app registration** with the required permissions
 * **Admin consent** granted for application permissions
-* The connector extension imported into your Bonita project (see <<import-connector>>)
 
 == Authentication
 
@@ -770,14 +769,3 @@ Upload a file to a Teams channel's SharePoint document library folder. Requires 
 |Web URL to the file in Teams.
 |===
 
-[#import-connector]
-== Importing the connector into Bonita Studio
-
-To use the Microsoft Teams connector in your Bonita project:
-
-. Download the connector `.zip` extension from the https://marketplace.bonitasoft.com/[Bonita Marketplace].
-. In Bonita Studio, go to the *Project* menu and select *Extensions*.
-. Click *Import extension* and select the downloaded `.zip` file.
-. The Microsoft Teams connector operations will appear in the connector palette when configuring a task or a process.
-
-For more details on managing extensions, see xref:bonita-overview:managing-extension-studio.adoc[Managing extensions in Bonita Studio].

--- a/modules/process/pages/sharepoint-connector.adoc
+++ b/modules/process/pages/sharepoint-connector.adoc
@@ -41,7 +41,6 @@ Before using the SharePoint connector, ensure the following:
 * An **Entra ID (Azure AD) app registration** with the required Graph API permissions
 * **Admin consent** granted for the application permissions
 * A **SharePoint site** accessible to the registered application
-* The connector extension imported into your Bonita project (see <<import-connector>>)
 
 == Authentication
 
@@ -571,14 +570,3 @@ The connector implements automatic retry with exponential backoff for transient 
 |Retry with exponential backoff (max 5 attempts).
 |===
 
-[#import-connector]
-== Importing the connector into Bonita Studio
-
-To use the SharePoint connector in your Bonita project:
-
-. Download the connector `.zip` extension from the https://marketplace.bonitasoft.com/[Bonita Marketplace].
-. In Bonita Studio, go to the *Project* menu and select *Extensions*.
-. Click *Import extension* and select the downloaded `.zip` file.
-. The SharePoint connector operations will appear in the connector palette when configuring a task or a process.
-
-For more details on managing extensions, see xref:bonita-overview:managing-extension-studio.adoc[Managing extensions in Bonita Studio].

--- a/modules/process/pages/telegram-connector.adoc
+++ b/modules/process/pages/telegram-connector.adoc
@@ -5,6 +5,15 @@
 
 The Bonita Telegram Connectors are available for **Bonita 10.2 Community (2024.3)** version and above.
 
+[WARNING]
+====
+This connector is currently in **Beta**. It has not yet been fully validated in production environments.
+
+We welcome your feedback — please report testing results or issues using the https://github.com/bonitasoft/bonita-connector-telegram/issues/new?template=beta-feedback.yml[beta feedback form] on GitHub.
+
+We are eager to collaborate with early adopters to bring this connector to General Availability.
+====
+
 == Overview
 
 The Telegram connector allows Bonita processes to interact with the Telegram Bot API. It provides four operations:

--- a/modules/process/pages/whatsapp-connector.adoc
+++ b/modules/process/pages/whatsapp-connector.adoc
@@ -5,6 +5,15 @@
 
 The Bonita WhatsApp Business Connectors are available for **Bonita 10.2 Community (2024.3)** version and above.
 
+[WARNING]
+====
+This connector is currently in **Beta**. It has not yet been fully validated in production environments.
+
+We welcome your feedback — please report testing results or issues using the https://github.com/bonitasoft/bonita-connector-whatsapp/issues/new?template=beta-feedback.yml[beta feedback form] on GitHub.
+
+We are eager to collaborate with early adopters to bring this connector to General Availability.
+====
+
 == Overview
 
 The WhatsApp Business connector allows Bonita processes to interact with the WhatsApp Business Cloud API. It provides six operations:

--- a/modules/process/pages/whatsapp-connector.adoc
+++ b/modules/process/pages/whatsapp-connector.adoc
@@ -415,7 +415,7 @@ Response:
 
 === Getting a WhatsApp Business Token
 
-1. Go to https://business.facebook.com[Meta Business Manager]
+1. Go to +https://business.facebook.com+[Meta Business Manager]
 2. Navigate to *System Users* > Create a system user
 3. Generate a *Permanent Token* with `whatsapp_business_messaging` permission
 4. Store it securely as a Bonita parameter

--- a/modules/process/pages/yousign-connector.adoc
+++ b/modules/process/pages/yousign-connector.adoc
@@ -35,7 +35,6 @@ Before using the Yousign connector, ensure the following:
 * A https://yousign.com/[Yousign] account with API access
 * A **Yousign API key** obtained from your Yousign account settings
 * At least one **signature template** configured in Yousign (for the Create From Template operation)
-* The connector extension imported into your Bonita project (see <<import-connector>>)
 
 TIP: Yousign provides a **sandbox environment** for testing. Use the sandbox API key and base URL (`\https://api-sandbox.yousign.app/v3`) during development to avoid triggering real signature workflows.
 
@@ -519,14 +518,3 @@ Registers a webhook endpoint to receive real-time notifications about signature 
 |The UUID of the registered webhook.
 |===
 
-[#import-connector]
-== Importing the connector into Bonita Studio
-
-To use the Yousign connector in your Bonita project:
-
-. Download the connector `.zip` extension from the https://marketplace.bonitasoft.com/[Bonita Marketplace].
-. In Bonita Studio, go to the *Project* menu and select *Extensions*.
-. Click *Import extension* and select the downloaded `.zip` file.
-. The Yousign connector operations will appear in the connector palette when configuring a task or a process.
-
-For more details on managing extensions, see xref:bonita-overview:managing-extension-studio.adoc[Managing extensions in Bonita Studio].

--- a/modules/process/pages/yousign-connector.adoc
+++ b/modules/process/pages/yousign-connector.adoc
@@ -1,0 +1,532 @@
+= Yousign eSignature connectors
+:page-aliases: ROOT:yousign-connector.adoc
+:description: The Bonita Yousign connectors enable your processes to create, manage, and track electronic signature requests using the Yousign API v3, with operations for creating signature requests from templates, activating them, monitoring status, downloading signed documents and audit trails, and managing webhooks.
+
+{description}
+
+The Bonita Yousign Connectors are available for **Bonita 10.2 Community (2024.3)** version and above.
+
+[WARNING]
+====
+This connector is currently in **Beta**. It has not yet been fully validated in production environments.
+
+We welcome your feedback — please report testing results or issues using the https://github.com/bonitasoft/bonita-connector-yousign/issues/new?template=beta-feedback.yml[beta feedback form] on GitHub.
+
+We are eager to collaborate with early adopters to bring this connector to General Availability.
+====
+
+== Overview
+
+The Yousign connector provides eight operations to manage electronic signature workflows:
+
+* **Create From Template** -- create a signature request from a Yousign template
+* **Activate** -- activate a signature request (sends invitations to signers)
+* **Get Status** -- retrieve the current status of a signature request
+* **Cancel** -- cancel an active signature request
+* **Download Document** -- download signed documents (single or ZIP)
+* **Download Audit Trail** -- download the audit trail PDF
+* **List** -- list signature requests with filters and pagination
+* **Register Webhook** -- register a webhook for signature events
+
+== Prerequisites
+
+Before using the Yousign connector, ensure the following:
+
+* A https://yousign.com/[Yousign] account with API access
+* A **Yousign API key** obtained from your Yousign account settings
+* At least one **signature template** configured in Yousign (for the Create From Template operation)
+* The connector extension imported into your Bonita project (see <<import-connector>>)
+
+TIP: Yousign provides a **sandbox environment** for testing. Use the sandbox API key and base URL (`\https://api-sandbox.yousign.app/v3`) during development to avoid triggering real signature workflows.
+
+== Authentication
+
+All Yousign connector operations share a common connection configuration using API key authentication.
+
+=== Common connection parameters
+
+[caption=Configuration]
+|===
+|Parameter name |Type |Required |Description |Default value
+
+|*apiKey*
+|String (Password)
+|Yes
+|Your Yousign API key. Obtain it from your Yousign account settings.
+|
+
+|*baseUrl*
+|String
+|No
+|The Yousign API base URL. Use the sandbox URL for testing.
+|`\https://api-sandbox.yousign.app/v3`
+
+|*connectTimeout*
+|Integer
+|No
+|Connection timeout in milliseconds.
+|`30000`
+
+|*readTimeout*
+|Integer
+|No
+|Read timeout in milliseconds.
+|`60000`
+|===
+
+== Common outputs
+
+All operations return the following outputs in addition to their specific outputs:
+
+|===
+|Output name |Type |Description
+
+|*success*
+|Boolean
+|`true` if the operation completed successfully, `false` otherwise.
+
+|*errorMessage*
+|String
+|Error details if `success` is `false`. Empty when the operation succeeds.
+|===
+
+== Error handling
+
+The connector handles HTTP errors as follows:
+
+|===
+|HTTP code |Behavior
+
+|400
+|Fail immediately (validation error)
+
+|401
+|Fail immediately (authentication error)
+
+|403
+|Fail immediately (access denied)
+
+|404
+|Fail immediately (resource not found)
+
+|429, 5xx
+|Retry up to 3 times with exponential backoff (1s, 2s, 4s)
+|===
+
+== Operations
+
+[#create-from-template]
+=== Create From Template
+
+Creates a signature request from a pre-configured Yousign template.
+
+==== Inputs
+
+|===
+|Parameter name |Type |Required |Description |Default value
+
+|*templateId*
+|String
+|Yes
+|The UUID of the Yousign template to use.
+|
+
+|*requestName*
+|String
+|Yes
+|A name for the signature request.
+|
+
+|*signerFirstName*
+|String
+|Yes
+|First name of the signer.
+|
+
+|*signerLastName*
+|String
+|Yes
+|Last name of the signer.
+|
+
+|*signerEmail*
+|String
+|Yes
+|Email address of the signer.
+|
+
+|*signerPhoneNumber*
+|String
+|No
+|Phone number of the signer (international format).
+|
+
+|*signerLabel*
+|String
+|Yes
+|The signer role label as defined in the template (e.g., `Signer`).
+|
+
+|*signerLocale*
+|String
+|No
+|The signer's locale for the signing interface.
+|`fr` (options: `fr`, `en`, `de`, `it`, `es`, `nl`, `pl`)
+
+|*deliveryMode*
+|String
+|No
+|How the signer receives the invitation.
+|`email` (options: `email`, `none`)
+
+|*orderedSigners*
+|Boolean
+|No
+|When `true`, signers must sign in the order they are added.
+|`false`
+
+|*templateTextFieldsJson*
+|String
+|No
+|JSON string with template text field values to pre-fill.
+|
+
+|*additionalSignersJson*
+|String
+|No
+|JSON string with additional signers (for multi-signer templates).
+|
+
+|*externalId*
+|String
+|No
+|An external identifier to associate with the request.
+|
+
+|*expirationDate*
+|String
+|No
+|Expiration date for the signature request.
+|
+|===
+
+==== Outputs
+
+|===
+|Output name |Type |Description
+
+|*signatureRequestId*
+|String
+|The UUID of the created signature request.
+
+|*status*
+|String
+|The initial status of the signature request (typically `draft`).
+|===
+
+[#activate]
+=== Activate
+
+Activates a draft signature request, which sends invitation emails to the signers.
+
+==== Inputs
+
+|===
+|Parameter name |Type |Required |Description |Default value
+
+|*signatureRequestId*
+|String
+|Yes
+|The UUID of the signature request to activate.
+|
+|===
+
+==== Outputs
+
+|===
+|Output name |Type |Description
+
+|*status*
+|String
+|The status after activation (typically `ongoing`).
+
+|*signerLinksJson*
+|String
+|JSON string containing the signing links for each signer.
+|===
+
+[#get-status]
+=== Get Status
+
+Retrieves the current status of a signature request, including individual signer statuses.
+
+==== Inputs
+
+|===
+|Parameter name |Type |Required |Description |Default value
+
+|*signatureRequestId*
+|String
+|Yes
+|The UUID of the signature request.
+|
+|===
+
+==== Outputs
+
+|===
+|Output name |Type |Description
+
+|*status*
+|String
+|The current status of the signature request (e.g., `draft`, `ongoing`, `done`, `canceled`, `expired`, `declined`).
+
+|*signerStatusesJson*
+|String
+|JSON string with the status of each individual signer.
+
+|*isTerminal*
+|Boolean
+|`true` if the signature request has reached a terminal state (`done`, `canceled`, `expired`, `declined`).
+
+|*signedDocumentIdsJson*
+|String
+|JSON string with the IDs of signed documents (when status is `done`).
+|===
+
+[#cancel]
+=== Cancel
+
+Cancels an active signature request.
+
+==== Inputs
+
+|===
+|Parameter name |Type |Required |Description |Default value
+
+|*signatureRequestId*
+|String
+|Yes
+|The UUID of the signature request to cancel.
+|
+
+|*cancellationReason*
+|String
+|No
+|A reason for the cancellation.
+|`Cancelled by Bonita process`
+|===
+
+[#download-document]
+=== Download Document
+
+Downloads the signed document(s) from a completed signature request. If no specific document ID is provided, all documents are downloaded as a ZIP archive.
+
+==== Inputs
+
+|===
+|Parameter name |Type |Required |Description |Default value
+
+|*signatureRequestId*
+|String
+|Yes
+|The UUID of the signature request.
+|
+
+|*documentId*
+|String
+|No
+|The UUID of a specific document to download. If omitted, all documents are downloaded as a ZIP.
+|
+|===
+
+==== Outputs
+
+|===
+|Output name |Type |Description
+
+|*documentContent*
+|byte[]
+|The binary content of the downloaded document or ZIP archive.
+
+|*documentName*
+|String
+|The file name of the downloaded document.
+
+|*contentType*
+|String
+|The MIME type of the downloaded content (e.g., `application/pdf`, `application/zip`).
+
+|*fileSizeBytes*
+|Long
+|The size of the downloaded file in bytes.
+|===
+
+[#download-audit-trail]
+=== Download Audit Trail
+
+Downloads the audit trail PDF for a signature request, providing a certified record of the signature process.
+
+==== Inputs
+
+|===
+|Parameter name |Type |Required |Description |Default value
+
+|*signatureRequestId*
+|String
+|Yes
+|The UUID of the signature request.
+|
+
+|*signerIdsJson*
+|String
+|No
+|JSON string with specific signer IDs to include in the audit trail. If omitted, the full audit trail is downloaded.
+|
+|===
+
+==== Outputs
+
+|===
+|Output name |Type |Description
+
+|*auditTrailContent*
+|byte[]
+|The binary content of the audit trail PDF.
+
+|*auditTrailName*
+|String
+|The file name of the audit trail document.
+
+|*fileSizeBytes*
+|Long
+|The size of the audit trail file in bytes.
+|===
+
+[#list]
+=== List
+
+Lists signature requests with optional filters and pagination support.
+
+==== Inputs
+
+|===
+|Parameter name |Type |Required |Description |Default value
+
+|*statusFilter*
+|String
+|No
+|Filter by status.
+|Options: `approval`, `ongoing`, `done`, `deleted`, `expired`, `canceled`, `declined`
+
+|*externalIdFilter*
+|String
+|No
+|Filter by external ID.
+|
+
+|*afterCursor*
+|String
+|No
+|Pagination cursor for fetching the next page of results.
+|
+
+|*pageSize*
+|Integer
+|No
+|Number of results per page.
+|`20`
+
+|*sortOrder*
+|String
+|No
+|Sort order for results.
+|`desc` (options: `desc`, `asc`)
+|===
+
+==== Outputs
+
+|===
+|Output name |Type |Description
+
+|*signatureRequestsJson*
+|String
+|JSON string containing the list of signature requests.
+
+|*nextCursor*
+|String
+|Cursor for the next page of results. Use this value as `afterCursor` in a subsequent call.
+
+|*hasMore*
+|Boolean
+|`true` if there are more results available beyond the current page.
+|===
+
+[#register-webhook]
+=== Register Webhook
+
+Registers a webhook endpoint to receive real-time notifications about signature events.
+
+==== Inputs
+
+|===
+|Parameter name |Type |Required |Description |Default value
+
+|*webhookEndpointUrl*
+|String
+|Yes
+|The HTTPS URL where Yousign will send event notifications.
+|
+
+|*subscribedEventsJson*
+|String
+|No
+|JSON array of event types to subscribe to.
+|`["signature_request.done","signature_request.canceled","signature_request.declined","signer.done"]`
+
+|*autoRetry*
+|Boolean
+|No
+|When `true`, Yousign will automatically retry failed webhook deliveries.
+|`true`
+
+|*enabled*
+|Boolean
+|No
+|When `true`, the webhook is active immediately after creation.
+|`true`
+
+|*sandbox*
+|Boolean
+|No
+|When `true`, the webhook is registered in the sandbox environment.
+|`true`
+
+|*webhookSecret*
+|String (Password)
+|No
+|A secret used to sign webhook payloads for verification.
+|
+|===
+
+==== Outputs
+
+|===
+|Output name |Type |Description
+
+|*webhookId*
+|String
+|The UUID of the registered webhook.
+|===
+
+[#import-connector]
+== Importing the connector into Bonita Studio
+
+To use the Yousign connector in your Bonita project:
+
+. Download the connector `.zip` extension from the https://marketplace.bonitasoft.com/[Bonita Marketplace].
+. In Bonita Studio, go to the *Project* menu and select *Extensions*.
+. Click *Import extension* and select the downloaded `.zip` file.
+. The Yousign connector operations will appear in the connector palette when configuring a task or a process.
+
+For more details on managing extensions, see xref:bonita-overview:managing-extension-studio.adoc[Managing extensions in Bonita Studio].

--- a/modules/process/process-nav.adoc
+++ b/modules/process/process-nav.adoc
@@ -75,6 +75,7 @@
     **** xref:uipath.adoc[UiPath]
     **** xref:whatsapp-connector.adoc[WhatsApp Business]
     **** xref:workday-connector.adoc[Workday HCM]
+    **** xref:yousign-connector.adoc[Yousign]
     **** Web service
         ***** xref:web-service-connector-overview.adoc[Connector web service]
         ***** xref:web-service-tutorial.adoc[Web service tutorial]


### PR DESCRIPTION
## Summary
- Removed the "Importing the connector into Bonita Studio" section from 4 connector docs (aws-s3, msteams, sharepoint, yousign) — this section referenced a non-existent `marketplace.bonitasoft.com` URL and the installation pattern is not used by existing connectors
- Wrapped auth-protected URLs (`admin.google.com`, `business.facebook.com`) with `+` in google-drive and whatsapp-connector docs so they display as plain text without triggering the link checker

## Context
The documentation site CI link checker was failing on these URLs:
1. `https://marketplace.bonitasoft.com` — site doesn't exist yet
2. `https://admin.google.com` / `https://business.facebook.com` — require authentication

See: https://github.com/bonitasoft/bonita-documentation-site/actions/runs/24119624844/job/70379575589

## Test plan
- [ ] CI link checker passes
- [ ] Auth-protected URLs still display correctly in rendered docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)