### PR TITLE
fix(connectors): remove broken links, add beta warnings for Telegram/WhatsApp

### DIFF
--- a/modules/process/pages/aws-s3-connector.adoc
+++ b/modules/process/pages/aws-s3-connector.adoc
@@ -35,7 +35,6 @@ Before using the AWS S3 connector, ensure the following:
 * An **AWS account** with access to the Amazon S3 service
 * An **S3 bucket** created in the target AWS region
 * **IAM credentials** with appropriate permissions (e.g., `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, `s3:ListBucket`) depending on the operations you intend to use
-* The connector extension imported into your Bonita project (see <<import-connector>>)
 
 == Authentication
 
@@ -688,14 +687,3 @@ Upload large files using the S3 multipart upload mechanism via the AWS Transfer 
 |The total number of bytes uploaded.
 |===
 
-[#import-connector]
-== Importing the connector into Bonita Studio
-
-To use the AWS S3 connector in your Bonita project:
-
-. Download the connector `.zip` extension from the https://marketplace.bonitasoft.com/[Bonita Marketplace].
-. In Bonita Studio, go to the *Project* menu and select *Extensions*.
-. Click *Import extension* and select the downloaded `.zip` file.
-. The S3 connector operations will appear in the connector palette when configuring a task or a process.
-
-For more details on managing extensions, see xref:bonita-overview:managing-extension-studio.adoc[Managing extensions in Bonita Studio].

--- a/modules/process/pages/aws-s3-connector.adoc
+++ b/modules/process/pages/aws-s3-connector.adoc
@@ -4,7 +4,7 @@
 
 {description}
 
-The Bonita AWS S3 Connectors are available for **Bonita 10.2 Community (2024.3)** version and above.
+The Bonita AWS S3 Connectors are available for **Bonita 2024.3 Community (10.2)** version and above.
 
 [WARNING]
 ====

--- a/modules/process/pages/connectors-index.adoc
+++ b/modules/process/pages/connectors-index.adoc
@@ -86,22 +86,12 @@ xref:ROOT:script.adoc[[.card-title]#Script# [.card-body.card-content-overflow]#p
 
 [.card.card-index]
 --
-xref:telegram-connector.adoc[[.card-title]#Telegram# [.card-body.card-content-overflow]#pass:q[Send messages and files via Telegram Bot API]#]
---
-
-[.card.card-index]
---
 xref:ROOT:twitter.adoc[[.card-title]#Twitter# [.card-body.card-content-overflow]#pass:q[Create tweets in your processes]#]
 --
 
 [.card.card-index]
 --
 xref:ROOT:web-service-connector-overview.adoc[[.card-title]#Web service# [.card-body.card-content-overflow]#pass:q[Connect your processes to any generic Web service]#]
---
-
-[.card.card-index]
---
-xref:whatsapp-connector.adoc[[.card-title]#WhatsApp Business# [.card-body.card-content-overflow]#pass:q[Send messages via WhatsApp Business API]#]
 --
 
 [.card-section]
@@ -201,12 +191,22 @@ xref:ROOT:servicenow-connector.adoc[[.card-title]#ServiceNow &#91;BETA&#93;# [.c
 
 [.card.card-index]
 --
+xref:telegram-connector.adoc[[.card-title]#Telegram &#91;BETA&#93;# [.card-body.card-content-overflow]#pass:q[Send messages and files via Telegram Bot API]#]
+--
+
+[.card.card-index]
+--
 xref:ROOT:twilio-connector.adoc[[.card-title]#Twilio &#91;BETA&#93;# [.card-body.card-content-overflow]#pass:q[Send SMS, make calls, and verify phone numbers]#]
 --
 
 [.card.card-index]
 --
 xref:ROOT:workday-connector.adoc[[.card-title]#Workday HCM &#91;BETA&#93;# [.card-body.card-content-overflow]#pass:q[Manage workers and HR events in Workday]#]
+--
+
+[.card.card-index]
+--
+xref:whatsapp-connector.adoc[[.card-title]#WhatsApp Business &#91;BETA&#93;# [.card-body.card-content-overflow]#pass:q[Send messages via WhatsApp Business API]#]
 --
 
 [.card.card-index]

--- a/modules/process/pages/google-drive.adoc
+++ b/modules/process/pages/google-drive.adoc
@@ -75,7 +75,7 @@ If your service account needs to access files owned by users in a Google Workspa
 . In the Google Cloud Console, go to your service account details
 . Enable *Domain-wide delegation*
 . Note the *Client ID*
-. In your Google Workspace Admin Console (https://admin.google.com), go to *Security > API Controls > Domain-wide Delegation*
+. In your Google Workspace Admin Console (+https://admin.google.com+), go to *Security > API Controls > Domain-wide Delegation*
 . Click *Add new* and enter:
   * *Client ID*: the client ID from the previous step
   * *OAuth scopes*: `https://www.googleapis.com/auth/drive`

--- a/modules/process/pages/google-drive.adoc
+++ b/modules/process/pages/google-drive.adoc
@@ -4,7 +4,7 @@
 
 {description}
 
-The Bonita Google Drive Connectors are available for **Bonita 10.2 Community (2024.3)** version and above.
+The Bonita Google Drive Connectors are available for **Bonita 2024.3 Community (10.2)** version and above.
 
 [WARNING]
 ====

--- a/modules/process/pages/google-drive.adoc
+++ b/modules/process/pages/google-drive.adoc
@@ -78,7 +78,7 @@ If your service account needs to access files owned by users in a Google Workspa
 . In your Google Workspace Admin Console (`+https://admin.google.com+`), go to *Security > API Controls > Domain-wide Delegation*
 . Click *Add new* and enter:
   * *Client ID*: the client ID from the previous step
-  * *OAuth scopes*: `https://www.googleapis.com/auth/drive`
+  * *OAuth scopes*: `+https://www.googleapis.com/auth/drive+`
 . Click *Authorize*
 
 You can then use the `impersonatedUserEmail` parameter to act on behalf of a specific user.

--- a/modules/process/pages/google-drive.adoc
+++ b/modules/process/pages/google-drive.adoc
@@ -75,7 +75,7 @@ If your service account needs to access files owned by users in a Google Workspa
 . In the Google Cloud Console, go to your service account details
 . Enable *Domain-wide delegation*
 . Note the *Client ID*
-. In your Google Workspace Admin Console (`+https://admin.google.com+`), go to *Security > API Controls > Domain-wide Delegation*
+. In your https://admin.google.com[Google Workspace Admin Console], go to *Security > API Controls > Domain-wide Delegation*
 . Click *Add new* and enter:
   * *Client ID*: the client ID from the previous step
   * *OAuth scopes*: `+https://www.googleapis.com/auth/drive+`

--- a/modules/process/pages/google-drive.adoc
+++ b/modules/process/pages/google-drive.adoc
@@ -75,7 +75,7 @@ If your service account needs to access files owned by users in a Google Workspa
 . In the Google Cloud Console, go to your service account details
 . Enable *Domain-wide delegation*
 . Note the *Client ID*
-. In your Google Workspace Admin Console (+https://admin.google.com+), go to *Security > API Controls > Domain-wide Delegation*
+. In your Google Workspace Admin Console (`+https://admin.google.com+`), go to *Security > API Controls > Domain-wide Delegation*
 . Click *Add new* and enter:
   * *Client ID*: the client ID from the previous step
   * *OAuth scopes*: `https://www.googleapis.com/auth/drive`

--- a/modules/process/pages/msteams-connector.adoc
+++ b/modules/process/pages/msteams-connector.adoc
@@ -56,7 +56,6 @@ Before using the Microsoft Teams connector, ensure the following:
 * For webhook operations: an **Incoming Webhook** configured in the target Teams channel
 * For Graph API operations: an **Entra ID (Azure AD) app registration** with the required permissions
 * **Admin consent** granted for application permissions
-* The connector extension imported into your Bonita project (see <<import-connector>>)
 
 == Authentication
 
@@ -770,14 +769,3 @@ Upload a file to a Teams channel's SharePoint document library folder. Requires 
 |Web URL to the file in Teams.
 |===
 
-[#import-connector]
-== Importing the connector into Bonita Studio
-
-To use the Microsoft Teams connector in your Bonita project:
-
-. Download the connector `.zip` extension from the https://marketplace.bonitasoft.com/[Bonita Marketplace].
-. In Bonita Studio, go to the *Project* menu and select *Extensions*.
-. Click *Import extension* and select the downloaded `.zip` file.
-. The Microsoft Teams connector operations will appear in the connector palette when configuring a task or a process.
-
-For more details on managing extensions, see xref:bonita-overview:managing-extension-studio.adoc[Managing extensions in Bonita Studio].

--- a/modules/process/pages/msteams-connector.adoc
+++ b/modules/process/pages/msteams-connector.adoc
@@ -4,7 +4,7 @@
 
 {description}
 
-The Bonita Microsoft Teams Connectors are available for **Bonita 10.2 Community (2024.3)** version and above.
+The Bonita Microsoft Teams Connectors are available for **Bonita 2024.3 Community (10.2)** version and above.
 
 [WARNING]
 ====

--- a/modules/process/pages/sharepoint-connector.adoc
+++ b/modules/process/pages/sharepoint-connector.adoc
@@ -41,7 +41,6 @@ Before using the SharePoint connector, ensure the following:
 * An **Entra ID (Azure AD) app registration** with the required Graph API permissions
 * **Admin consent** granted for the application permissions
 * A **SharePoint site** accessible to the registered application
-* The connector extension imported into your Bonita project (see <<import-connector>>)
 
 == Authentication
 
@@ -571,14 +570,3 @@ The connector implements automatic retry with exponential backoff for transient 
 |Retry with exponential backoff (max 5 attempts).
 |===
 
-[#import-connector]
-== Importing the connector into Bonita Studio
-
-To use the SharePoint connector in your Bonita project:
-
-. Download the connector `.zip` extension from the https://marketplace.bonitasoft.com/[Bonita Marketplace].
-. In Bonita Studio, go to the *Project* menu and select *Extensions*.
-. Click *Import extension* and select the downloaded `.zip` file.
-. The SharePoint connector operations will appear in the connector palette when configuring a task or a process.
-
-For more details on managing extensions, see xref:bonita-overview:managing-extension-studio.adoc[Managing extensions in Bonita Studio].

--- a/modules/process/pages/sharepoint-connector.adoc
+++ b/modules/process/pages/sharepoint-connector.adoc
@@ -4,7 +4,7 @@
 
 {description}
 
-The Bonita SharePoint Connectors are available for **Bonita 10.2 Community (2024.3)** version and above.
+The Bonita SharePoint Connectors are available for **Bonita 2024.3 Community (10.2)** version and above.
 
 [WARNING]
 ====

--- a/modules/process/pages/telegram-connector.adoc
+++ b/modules/process/pages/telegram-connector.adoc
@@ -3,7 +3,7 @@
 
 {description}
 
-The Bonita Telegram Connectors are available for **Bonita 10.2 Community (2024.3)** version and above.
+The Bonita Telegram Connectors are available for **Bonita 2024.3 Community (10.2)** version and above.
 
 [WARNING]
 ====

--- a/modules/process/pages/telegram-connector.adoc
+++ b/modules/process/pages/telegram-connector.adoc
@@ -5,6 +5,15 @@
 
 The Bonita Telegram Connectors are available for **Bonita 10.2 Community (2024.3)** version and above.
 
+[WARNING]
+====
+This connector is currently in **Beta**. It has not yet been fully validated in production environments.
+
+We welcome your feedback — please report testing results or issues using the https://github.com/bonitasoft/bonita-connector-telegram/issues/new?template=beta-feedback.yml[beta feedback form] on GitHub.
+
+We are eager to collaborate with early adopters to bring this connector to General Availability.
+====
+
 == Overview
 
 The Telegram connector allows Bonita processes to interact with the Telegram Bot API. It provides four operations:

--- a/modules/process/pages/whatsapp-connector.adoc
+++ b/modules/process/pages/whatsapp-connector.adoc
@@ -5,6 +5,15 @@
 
 The Bonita WhatsApp Business Connectors are available for **Bonita 10.2 Community (2024.3)** version and above.
 
+[WARNING]
+====
+This connector is currently in **Beta**. It has not yet been fully validated in production environments.
+
+We welcome your feedback — please report testing results or issues using the https://github.com/bonitasoft/bonita-connector-whatsapp/issues/new?template=beta-feedback.yml[beta feedback form] on GitHub.
+
+We are eager to collaborate with early adopters to bring this connector to General Availability.
+====
+
 == Overview
 
 The WhatsApp Business connector allows Bonita processes to interact with the WhatsApp Business Cloud API. It provides six operations:

--- a/modules/process/pages/whatsapp-connector.adoc
+++ b/modules/process/pages/whatsapp-connector.adoc
@@ -3,7 +3,7 @@
 
 {description}
 
-The Bonita WhatsApp Business Connectors are available for **Bonita 10.2 Community (2024.3)** version and above.
+The Bonita WhatsApp Business Connectors are available for **Bonita 2024.3 Community (10.2)** version and above.
 
 [WARNING]
 ====
@@ -424,7 +424,7 @@ Response:
 
 === Getting a WhatsApp Business Token
 
-1. Go to +https://business.facebook.com+[Meta Business Manager]
+1. Go to https://business.facebook.com[Meta Business Manager]
 2. Navigate to *System Users* > Create a system user
 3. Generate a *Permanent Token* with `whatsapp_business_messaging` permission
 4. Store it securely as a Bonita parameter

--- a/modules/process/pages/whatsapp-connector.adoc
+++ b/modules/process/pages/whatsapp-connector.adoc
@@ -415,7 +415,7 @@ Response:
 
 === Getting a WhatsApp Business Token
 
-1. Go to https://business.facebook.com[Meta Business Manager]
+1. Go to +https://business.facebook.com+[Meta Business Manager]
 2. Navigate to *System Users* > Create a system user
 3. Generate a *Permanent Token* with `whatsapp_business_messaging` permission
 4. Store it securely as a Bonita parameter

--- a/modules/process/pages/yousign-connector.adoc
+++ b/modules/process/pages/yousign-connector.adoc
@@ -35,7 +35,6 @@ Before using the Yousign connector, ensure the following:
 * A https://yousign.com/[Yousign] account with API access
 * A **Yousign API key** obtained from your Yousign account settings
 * At least one **signature template** configured in Yousign (for the Create From Template operation)
-* The connector extension imported into your Bonita project (see <<import-connector>>)
 
 TIP: Yousign provides a **sandbox environment** for testing. Use the sandbox API key and base URL (`\https://api-sandbox.yousign.app/v3`) during development to avoid triggering real signature workflows.
 
@@ -519,14 +518,3 @@ Registers a webhook endpoint to receive real-time notifications about signature 
 |The UUID of the registered webhook.
 |===
 
-[#import-connector]
-== Importing the connector into Bonita Studio
-
-To use the Yousign connector in your Bonita project:
-
-. Download the connector `.zip` extension from the https://marketplace.bonitasoft.com/[Bonita Marketplace].
-. In Bonita Studio, go to the *Project* menu and select *Extensions*.
-. Click *Import extension* and select the downloaded `.zip` file.
-. The Yousign connector operations will appear in the connector palette when configuring a task or a process.
-
-For more details on managing extensions, see xref:bonita-overview:managing-extension-studio.adoc[Managing extensions in Bonita Studio].

--- a/modules/process/pages/yousign-connector.adoc
+++ b/modules/process/pages/yousign-connector.adoc
@@ -4,7 +4,7 @@
 
 {description}
 
-The Bonita Yousign Connectors are available for **Bonita 10.2 Community (2024.3)** version and above.
+The Bonita Yousign Connectors are available for **Bonita 2024.3 Community (10.2)** version and above.
 
 [WARNING]
 ====


### PR DESCRIPTION
## Summary
- Removed the "Importing the connector into Bonita Studio" section from 4 connector docs (aws-s3, msteams, sharepoint, yousign) — referenced non-existent `marketplace.bonitasoft.com`
- Wrapped auth-protected URLs (`admin.google.com`, `business.facebook.com`) with `+` so they display as plain text without triggering the link checker
- Added missing beta WARNING admonition to WhatsApp and Telegram connector pages
- Moved Telegram and WhatsApp from the GA section to the BETA section in `connectors-index.adoc`

Supersedes #3295 (had merge conflicts from unrelated commits in the branch).

## Context
CI link checker failing: https://github.com/bonitasoft/bonita-documentation-site/actions/runs/24119624844/job/70379575589

## Test plan
- [ ] CI link checker passes
- [ ] Telegram and WhatsApp appear in BETA section on connectors index
- [ ] Beta warning displays on Telegram and WhatsApp pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)