### PR TITLE
docs: document BDM data retention feature — BPA-439

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -12,6 +12,11 @@ The {bonitaVersion} version is in development.
 
 === BDM data retention (GDPR)
 
+[NOTE]
+====
+For Performance, Enterprise and Scale editions only. +
+====
+
 A new feature lets administrators configure data retention rules per BDM object type to automatically delete expired business data on a scheduled basis. For each top-level object type, you can choose the reference date (creation or last update) and a retention period in days; a scheduled cleanup job then removes every expired instance, cascading to composition children.
 
 Rules are managed through the new *Data Retention (GDPR)* page in the Admin application. Each cleanup run is audited via the new `BUSINESS_DATA_CLEANED_UP` queriable log event, and the schedule is driven by the new `bonita.runtime.retention.schedule.cron` configuration property (default: `0 0 2 * * 6`, every Saturday at 02:00 UTC).

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -19,9 +19,9 @@ A new feature lets administrators configure data retention rules per BDM object 
 
 Rules are managed through the new *Data Retention (GDPR)* page in the Admin application. Each cleanup run is audited via the new `BUSINESS_DATA_CLEANED_UP` queriable log event, and the schedule is driven by the new `bonita.runtime.retention.schedule.cron` configuration property (default: `0 0 2 * * 6`, every Saturday at 02:00 UTC).
 
-Legacy BDM instances created before this version are not tracked automatically. A migration procedure is documented to backfill them when you want them subject to retention rules.
+Legacy BDM object instances created before this version are not tracked automatically. A migration procedure is documented to backfill them when you want them subject to retention rules.
 
-When updating from an earlier version with the Bonita Update Tool, the new *Data Retention (GDPR)* page is provided automatically but must be added to your existing Admin application's menu manually — see xref:runtime:bdm-data-retention.adoc[BDM data retention] for details.
+When updating from an earlier version with the Bonita Update Tool, the new *Data Retention (GDPR)* page is installed automatically but must be added to your existing Admin application's menu manually — see xref:runtime:bdm-data-retention.adoc[BDM data retention] for details.
 
 See xref:runtime:bdm-data-retention.adoc[BDM data retention] for the complete reference.
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -21,7 +21,7 @@ Rules are managed through the new *Data Retention (GDPR)* page in the Admin appl
 
 Legacy BDM object instances created before this version are not tracked automatically. A migration procedure is documented to backfill them when you want them subject to retention rules.
 
-When updating from an earlier version with the Bonita Update Tool, the new *Data Retention (GDPR)* page is installed automatically but must be added to your existing Admin application's menu manually — see xref:runtime:bdm-data-retention.adoc[BDM data retention] for details.
+When updating from an earlier version with the Bonita Update Tool, the new *Data Retention (GDPR)* page is installed automatically but must be added to your existing Admin application's menu manually.
 
 See xref:runtime:bdm-data-retention.adoc[BDM data retention] for the complete reference.
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -10,6 +10,16 @@ The {bonitaVersion} version is in development.
 
 == Notable changes
 
+=== BDM data retention (GDPR)
+
+A new feature lets administrators configure data retention rules per BDM object type to automatically delete expired business data on a scheduled basis. For each top-level object type, you can choose the reference date (creation or last update) and a retention period in days; a scheduled cleanup job then removes every expired instance, cascading to composition children.
+
+Rules are managed through the new *Data Retention (GDPR)* page in the Admin application. Each cleanup run is audited via the new `BUSINESS_DATA_CLEANED_UP` queriable log event, and the schedule is driven by the new `bonita.runtime.retention.schedule.cron` configuration property (default: `0 0 2 * * 6`, every Saturday at 02:00 UTC).
+
+Legacy BDM instances created before this version are not tracked automatically. A migration procedure is documented to backfill them when you want them subject to retention rules.
+
+See xref:runtime:bdm-data-retention.adoc[BDM data retention] for the complete reference.
+
 === BDM REST API response format standardization
 
 Starting from this version, the response format for BDM queries via REST API has been standardized to follow REST conventions:

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -8,13 +8,11 @@ The {bonitaVersion} version is in development.
 
 == New available values
 
-== Notable changes
-
 === BDM data retention (GDPR)
 
 [NOTE]
 ====
-For Performance, Enterprise and Scale editions only. +
+For Teamwork, Efficiency, Performance, Enterprise and Scale editions only. +
 ====
 
 A new feature lets administrators configure data retention rules per BDM object type to automatically delete expired business data on a scheduled basis. For each top-level object type, you can choose the reference date (creation or last update) and a retention period in days; a scheduled cleanup job then removes every expired instance, cascading to composition children.
@@ -24,6 +22,8 @@ Rules are managed through the new *Data Retention (GDPR)* page in the Admin appl
 Legacy BDM instances created before this version are not tracked automatically. A migration procedure is documented to backfill them when you want them subject to retention rules.
 
 See xref:runtime:bdm-data-retention.adoc[BDM data retention] for the complete reference.
+
+== Notable changes
 
 === BDM REST API response format standardization
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -21,6 +21,8 @@ Rules are managed through the new *Data Retention (GDPR)* page in the Admin appl
 
 Legacy BDM instances created before this version are not tracked automatically. A migration procedure is documented to backfill them when you want them subject to retention rules.
 
+When updating from an earlier version with the Bonita Update Tool, the new *Data Retention (GDPR)* page is provided automatically but must be added to your existing Admin application's menu manually — see xref:runtime:bdm-data-retention.adoc[BDM data retention] for details.
+
 See xref:runtime:bdm-data-retention.adoc[BDM data retention] for the complete reference.
 
 == Notable changes

--- a/modules/best-practices/pages/gdpr-guidelines.adoc
+++ b/modules/best-practices/pages/gdpr-guidelines.adoc
@@ -60,7 +60,7 @@ For subscribers of Bonita Cloud, the management and application of the Purge Too
 
 [NOTE]
 ====
-For Subscription editions only. +
+For Performance, Enterprise and Scale editions only. +
 ====
 
 Beyond archived process instances, business data stored in the Business Data Model (BDM) is also subject to data protection regulations. Bonita provides a dedicated xref:runtime:bdm-data-retention.adoc[BDM data retention] feature that lets administrators configure retention rules per BDM object type and automatically delete expired records on a scheduled basis.

--- a/modules/best-practices/pages/gdpr-guidelines.adoc
+++ b/modules/best-practices/pages/gdpr-guidelines.adoc
@@ -55,3 +55,17 @@ By default, Bonita Runtime retains all archives indefinitely. Given the operatio
 
 Implementing a consistent purge policy not only simplifies data management but also enhances the performance of your runtime environment by optimizing storage utilization and ensuring smooth system operations.
 For subscribers of Bonita Cloud, the management and application of the Purge Tool are handled entirely by the Bonita Cloud team. As a user, you are relieved of this responsibility; rest assured, the Bonita Cloud team diligently manages this process, ensuring optimal performance and compliance without any required action on your part.
+
+== BDM data retention
+
+[NOTE]
+====
+For Subscription editions only. +
+====
+
+Beyond archived process instances, business data stored in the Business Data Model (BDM) is also subject to data protection regulations. Bonita provides a dedicated xref:runtime:bdm-data-retention.adoc[BDM data retention] feature that lets administrators configure retention rules per BDM object type and automatically delete expired records on a scheduled basis.
+
+Key points to consider when designing your retention policy:
+
+* Retention rules apply to top-level BDM object types only. xref:data:define-and-deploy-the-bdm.adoc#compos[Composition children] are deleted automatically with their parent; xref:data:define-and-deploy-the-bdm.adoc#compos[aggregation children] must be managed independently.
+* Each cleanup run produces a queriable log entry (`BUSINESS_DATA_CLEANED_UP`), giving you an audit trail of deletions.

--- a/modules/best-practices/pages/gdpr-guidelines.adoc
+++ b/modules/best-practices/pages/gdpr-guidelines.adoc
@@ -60,7 +60,7 @@ For subscribers of Bonita Cloud, the management and application of the Purge Too
 
 [NOTE]
 ====
-For Performance, Enterprise and Scale editions only. +
+For Teamwork, Efficiency, Performance, Enterprise and Scale editions only. +
 ====
 
 Beyond archived process instances, business data stored in the Business Data Model (BDM) is also subject to data protection regulations. Bonita provides a dedicated xref:runtime:bdm-data-retention.adoc[BDM data retention] feature that lets administrators configure retention rules per BDM object type and automatically delete expired records on a scheduled basis.

--- a/modules/data/pages/define-and-deploy-the-bdm.adoc
+++ b/modules/data/pages/define-and-deploy-the-bdm.adoc
@@ -149,8 +149,8 @@ When you create a process that uses a business object with a composition or aggr
 
 Composition and aggregation relationships behave differently with regard to the xref:runtime:bdm-data-retention.adoc[BDM data retention feature]:
 
-* *Composition children*: They have no dedicated retention rule and do not appear in the administration page. Their lifecycle is fully bound to their parent — when the parent is deleted by a retention rule, Hibernate cascades the deletion to all composition children automatically (via `CascadeType.ALL` and `orphanRemoval`). No separate tracking record is maintained for them.
-* *Aggregation children*: They are tracked for retention *only when they are created or updated independently* through the BDM API (for example, via a Groovy script, a DAO call, or a dedicated operation). When they are instantiated along with a parent — that is, persisted via a Hibernate cascade triggered by the parent — no tracking record is created, and the aggregated child is therefore not subject to retention rules through that parent's lifecycle. To apply a retention rule to aggregation children, ensure they are created or modified as standalone entities.
+* *Composition children*: They have no dedicated retention rule and do not appear in the administration page. Their lifecycle is fully bound to their parent — when the parent is deleted by a retention rule, Hibernate cascades the deletion to all composition children automatically. No separate tracking record is maintained for them.
+* *Aggregation children*: They are tracked for retention *only when they are created or updated independently* through the BDM API or a process execution (for example, via a Groovy script, a DAO call, or a dedicated operation). When they are instantiated along with a parent — that is, persisted via a Hibernate cascade triggered by the parent — no tracking record is created, and the aggregated child is therefore not subject to retention rules through that parent's lifecycle. To apply a retention rule to aggregation children, ensure they are created or modified as standalone entities.
 
 [#lazy_eager_loading]
 

--- a/modules/data/pages/define-and-deploy-the-bdm.adoc
+++ b/modules/data/pages/define-and-deploy-the-bdm.adoc
@@ -145,6 +145,13 @@ When you create a process that uses a business object with a composition or aggr
 * You can use getter and setter methods in process or activity operations to set the composed objects as a single instance or as a `java.util.list` for a list of instances.
 * If your process uses a query from a Groovy expression or uses DAO objects from a client Java application, load the complete composite objects including the child objects.
 
+==== Data retention and tracking behavior
+
+Composition and aggregation relationships behave differently with regard to the xref:runtime:bdm-data-retention.adoc[BDM data retention feature]:
+
+* *Composition children*: They have no dedicated retention rule and do not appear in the administration page. Their lifecycle is fully bound to their parent — when the parent is deleted by a retention rule, Hibernate cascades the deletion to all composition children automatically (via `CascadeType.ALL` and `orphanRemoval`). No separate tracking record is maintained for them.
+* *Aggregation children*: They are tracked for retention *only when they are created or updated independently* through the BDM API (for example, via a Groovy script, a DAO call, or a dedicated operation). When they are instantiated along with a parent — that is, persisted via a Hibernate cascade triggered by the parent — no tracking record is created, and the aggregated child is therefore not subject to retention rules through that parent's lifecycle. To apply a retention rule to aggregation children, ensure they are created or modified as standalone entities.
+
 [#lazy_eager_loading]
 
 === Loading BDM objects

--- a/modules/data/pages/define-and-deploy-the-bdm.adoc
+++ b/modules/data/pages/define-and-deploy-the-bdm.adoc
@@ -145,7 +145,7 @@ When you create a process that uses a business object with a composition or aggr
 * You can use getter and setter methods in process or activity operations to set the composed objects as a single instance or as a `java.util.list` for a list of instances.
 * If your process uses a query from a Groovy expression or uses DAO objects from a client Java application, load the complete composite objects including the child objects.
 
-==== Data retention and tracking behavior
+==== Data retention and tracking behavior (Subscription editions)
 
 Composition and aggregation relationships behave differently with regard to the xref:runtime:bdm-data-retention.adoc[BDM data retention feature]:
 

--- a/modules/runtime/pages/admin-application-overview.adoc
+++ b/modules/runtime/pages/admin-application-overview.adoc
@@ -96,6 +96,7 @@ After validation, the application is imported or cloned; you can view its conten
 
 Saving in the UI Designer makes the new page available in Bonita Studio.
 
+[#change-navigation-menu]
 === Change the navigation menu
 
 . Get all the application's pages available:

--- a/modules/runtime/pages/bdm-data-retention.adoc
+++ b/modules/runtime/pages/bdm-data-retention.adoc
@@ -92,7 +92,7 @@ In a clustered setup, the cleanup job is coordinated so that only a single node 
 
 === Execution audit trail
 
-Each cleanup run produces one queriable log entry per BDM object type that had at least one expired instance deleted. The entry has:
+Each cleanup run produces one xref:api:queriable-logging.adoc[queriable log] entry per BDM object type that had at least one expired instance deleted. The entry has:
 
 * `action_type`: `BUSINESS_DATA_CLEANED_UP`,
 * `message`: the fully qualified BDM class name,
@@ -100,8 +100,6 @@ Each cleanup run produces one queriable log entry per BDM object type that had a
 * `severity`: `INTERNAL`.
 
 These entries can be queried through the existing `/API/system/log` REST endpoint and are displayed in the *Audit log* tab of the *Data Retention (GDPR)* administration page.
-
-See xref:api:queriable-logging.adoc[Queriable logging] for the full list of events.
 
 == Related topics
 

--- a/modules/runtime/pages/bdm-data-retention.adoc
+++ b/modules/runtime/pages/bdm-data-retention.adoc
@@ -3,7 +3,7 @@
 
 [NOTE]
 ====
-For Performance, Enterprise and Scale editions only.
+For Teamwork, Efficiency, Performance, Enterprise and Scale editions only.
 ====
 
 The BDM data retention feature enables you to configure retention rules on Business Data Model object types so that expired records are deleted automatically on a scheduled basis. This supports GDPR compliance and prevents unbounded growth of the business data database.

--- a/modules/runtime/pages/bdm-data-retention.adoc
+++ b/modules/runtime/pages/bdm-data-retention.adoc
@@ -101,7 +101,7 @@ Each cleanup run produces one queriable log entry per BDM object type that had a
 
 These entries can be queried through the existing `/API/system/log` REST endpoint and are displayed in the *Audit log* tab of the *Data Retention (GDPR)* administration page.
 
-See xref:api:queriable-logging.adoc[Queriable logging] for the full list of configurable events.
+See xref:api:queriable-logging.adoc[Queriable logging] for the full list of events.
 
 == Related topics
 

--- a/modules/runtime/pages/bdm-data-retention.adoc
+++ b/modules/runtime/pages/bdm-data-retention.adoc
@@ -20,7 +20,7 @@ When the scheduled cleanup job runs, every BDM object instance whose reference d
 * its xref:data:define-and-deploy-the-bdm.adoc#compos[composition children] (deleted automatically via Hibernate cascade),
 * its tracking record in the `data_retention_bdm_tracking` table.
 
-Retention rules are configured through the *Data Retention (GDPR)* administration page of the Admin application.
+Retention rules are configured through the *Data Retention (GDPR)* administration page of the Admin application, available by default under the *BDM* menu.
 
 [NOTE]
 ====

--- a/modules/runtime/pages/bdm-data-retention.adoc
+++ b/modules/runtime/pages/bdm-data-retention.adoc
@@ -3,8 +3,7 @@
 
 [NOTE]
 ====
-For Subscription editions only. +
-Available from version 2026.1. Requires the `DATA_RETENTION` feature in your license.
+For Performance, Enterprise and Scale editions only.
 ====
 
 The BDM data retention feature enables you to configure retention rules on Business Data Model object types so that expired records are deleted automatically on a scheduled basis. This supports GDPR compliance and prevents unbounded growth of the business data database.

--- a/modules/runtime/pages/bdm-data-retention.adoc
+++ b/modules/runtime/pages/bdm-data-retention.adoc
@@ -15,40 +15,21 @@ For each top-level BDM object type, an administrator can configure:
 * a *reference date*: either the object's creation date or its last update date,
 * a *retention period* (in days).
 
-When the scheduled cleanup job runs, every BDM object instance whose reference date is older than `now - retention period` is deleted from the database, along with:
-
-* its xref:data:define-and-deploy-the-bdm.adoc#compos[composition children] (deleted automatically via Hibernate cascade),
-* its tracking record in the `data_retention_bdm_tracking` table.
+When the scheduled cleanup job runs, every BDM object instance whose reference date is older than `now - retention period` is deleted from the database, along with its xref:data:define-and-deploy-the-bdm.adoc#compos[composition children].
 
 Retention rules are configured through the *Data Retention (GDPR)* administration page of the Admin application, available by default under the *BDM* menu.
 
 [NOTE]
 ====
 *Updating from a Bonita version earlier than 2026.1 ?* +
-The *Data Retention (GDPR)* page is provided with Bonita 2026.1 and is automatically available in the resources of the Admin application after the update. However, it is not added to your existing Admin application's navigation menu automatically — you must add it yourself by xref:runtime:admin-application-overview.adoc#_change_the_navigation_menu[customizing the Admin application]. +
+The *Data Retention (GDPR)* page is provided with Bonita 2026.1 and is automatically available in the resources of the Admin application after the update. However, it is not added to your existing Admin application's navigation menu automatically — you must add it yourself by xref:runtime:admin-application-overview.adoc#change-navigation-menu[customizing the Admin application]. +
 This step is not needed on a fresh 2026.1 (or later) install, where the page is already part of the default menu.
 ====
 
-== How BDM object instances are tracked
-
-To decide which records have expired, Bonita maintains a dedicated tracking table (named `data_retention_bdm_tracking`). Each entry in this table represents the lifecycle of a single BDM object instance (there is only one tracking record per BDM object instance).
-
-Tracking records are created and maintained automatically:
-
-* *On creation*: a new row is inserted with both `created_at` and `last_modified_at` set to the current time.
-* *On update*: `last_modified_at` is refreshed with the current time. `created_at` is left unchanged.
-* *On deletion*: the tracking row is removed.
-
-=== Composition and aggregation
-
-The relationship type between BDM objects determines how tracking is applied — see xref:data:define-and-deploy-the-bdm.adoc#compos[Composition and aggregation]:
-
-* *Composition children* are not tracked independently. They are deleted automatically by Hibernate cascade when their parent is deleted by a retention rule, so no dedicated retention configuration is needed or exposed.
-* *Aggregation children* are tracked only when they are created or updated as standalone entities through the BDM API. When Hibernate cascade-persists them along with a parent (via `CascadeType.MERGE`), no tracking record is created. To apply a retention rule to aggregation children, persist them explicitly.
 
 == Scheduling the cleanup
 
-The cleanup job is triggered by a Spring `@Scheduled` task driven by a cron expression. The default schedule runs once a week, every Saturday at 02:00 UTC.
+A CRON job performs the BDM data retention cleanup. The default schedule runs once a week, every Saturday at 02:00 UTC.
 
 === Configuration parameter
 
@@ -57,16 +38,10 @@ The cleanup job is triggered by a Spring `@Scheduled` task driven by a cron expr
 | Property | Description
 
 | `bonita.runtime.retention.schedule.cron`
-| Spring 6-field cron expression (`second minute hour day-of-month month day-of-week`) defining when the cleanup job runs. The job executes in the JVM default timezone. Default: `0 0 2 * * 6` (every Saturday at 02:00).
+| 6-field cron expression (`second minute hour day-of-month month day-of-week`) defining when the cleanup job runs. The job executes in the JVM default timezone. Default: `0 0 2 * * 6` (every Saturday at 02:00).
 |===
 
-To override the default, declare the property in `bonita-platform-sp-custom.properties` and restart the platform:
-
-[source,properties]
-----
-# Run every day at 03:30
-bonita.runtime.retention.schedule.cron=0 30 3 * * *
-----
+To override the default, declare the property in `bonita-platform-sp-custom.properties` and restart the platform.
 
 In a clustered setup, the cleanup job is coordinated so that only a single node runs it at a given time.
 
@@ -76,8 +51,7 @@ Each cleanup run produces one xref:api:queriable-logging.adoc[queriable log] ent
 
 * `action_type`: `BUSINESS_DATA_CLEANED_UP`,
 * `message`: the fully qualified BDM class name,
-* `action_scope`: the number of deleted instances (as a string),
-* `severity`: `INTERNAL`.
+* `action_scope`: the number of deleted instances (as a string).
 
 These entries can be queried through the existing `/API/system/log` REST endpoint and are displayed in the *Audit log* tab of the *Data Retention (GDPR)* administration page.
 

--- a/modules/runtime/pages/bdm-data-retention.adoc
+++ b/modules/runtime/pages/bdm-data-retention.adoc
@@ -101,13 +101,6 @@ Each cleanup run produces one queriable log entry per BDM object type that had a
 
 These entries can be queried through the existing `/API/system/log` REST endpoint and are displayed in the *Audit log* tab of the *Data Retention (GDPR)* administration page.
 
-If you do not want these entries stored in the database, disable the event in `bonita-tenant-sp-custom.properties`:
-
-[source,properties]
-----
-bonita.tenant.queriable.log.BUSINESS_DATA_CLEANED_UP.INTERNAL=false
-----
-
 See xref:api:queriable-logging.adoc[Queriable logging] for the full list of configurable events.
 
 == Related topics

--- a/modules/runtime/pages/bdm-data-retention.adoc
+++ b/modules/runtime/pages/bdm-data-retention.adoc
@@ -22,6 +22,13 @@ When the scheduled cleanup job runs, every BDM instance whose reference date is 
 
 Retention rules are configured through the *Data Retention (GDPR)* administration page of the Admin application.
 
+[NOTE]
+====
+*Updating from a Bonita version earlier than 2026.1?* +
+The *Data Retention (GDPR)* page is provided with Bonita 2026.1 and is automatically available in the resources of the Admin application after the update. However, it is not added to your existing Admin application's navigation menu automatically — you must add it yourself by xref:runtime:admin-application-overview.adoc#_change_the_navigation_menu[customizing the Admin application]. +
+This step is not needed on a fresh 2026.1 (or later) install, where the page is already part of the default menu.
+====
+
 == How BDM instances are tracked
 
 To decide which records have expired, Bonita maintains a dedicated tracking table named `data_retention_bdm_tracking`. Each row represents the lifecycle of a single BDM instance:

--- a/modules/runtime/pages/bdm-data-retention.adoc
+++ b/modules/runtime/pages/bdm-data-retention.adoc
@@ -15,7 +15,7 @@ For each top-level BDM object type, an administrator can configure:
 * a *reference date*: either the object's creation date or its last update date,
 * a *retention period* (in days).
 
-When the scheduled cleanup job runs, every BDM instance whose reference date is older than `now - retention period` is deleted from the database, along with:
+When the scheduled cleanup job runs, every BDM object instance whose reference date is older than `now - retention period` is deleted from the database, along with:
 
 * its xref:data:define-and-deploy-the-bdm.adoc#compos[composition children] (deleted automatically via Hibernate cascade),
 * its tracking record in the `data_retention_bdm_tracking` table.
@@ -24,41 +24,14 @@ Retention rules are configured through the *Data Retention (GDPR)* administratio
 
 [NOTE]
 ====
-*Updating from a Bonita version earlier than 2026.1?* +
+*Updating from a Bonita version earlier than 2026.1 ?* +
 The *Data Retention (GDPR)* page is provided with Bonita 2026.1 and is automatically available in the resources of the Admin application after the update. However, it is not added to your existing Admin application's navigation menu automatically — you must add it yourself by xref:runtime:admin-application-overview.adoc#_change_the_navigation_menu[customizing the Admin application]. +
 This step is not needed on a fresh 2026.1 (or later) install, where the page is already part of the default menu.
 ====
 
-== How BDM instances are tracked
+== How BDM object instances are tracked
 
-To decide which records have expired, Bonita maintains a dedicated tracking table named `data_retention_bdm_tracking`. Each row represents the lifecycle of a single BDM instance:
-
-[cols="1,1,3"]
-|===
-| Column | Type | Description
-
-| `id`
-| `BIGINT`
-| Primary key (Bonita internal).
-
-| `data_id`
-| `BIGINT`
-| Persistence ID of the tracked BDM instance.
-
-| `data_classname`
-| `VARCHAR(255)`
-| Fully qualified Java class name of the BDM object type (for example `com.company.model.Invoice`).
-
-| `created_at`
-| `BIGINT`
-| Epoch timestamp in milliseconds, set when the tracking record is first created.
-
-| `last_modified_at`
-| `BIGINT`
-| Epoch timestamp in milliseconds, updated every time the BDM instance is modified.
-|===
-
-A unique constraint on `(data_id, data_classname)` guarantees that there is exactly one tracking record per BDM instance.
+To decide which records have expired, Bonita maintains a dedicated tracking table (named `data_retention_bdm_tracking`). Each entry in this table represents the lifecycle of a single BDM object instance (there is only one tracking record per BDM object instance).
 
 Tracking records are created and maintained automatically:
 

--- a/modules/runtime/pages/bdm-data-retention.adoc
+++ b/modules/runtime/pages/bdm-data-retention.adoc
@@ -1,0 +1,118 @@
+= BDM data retention
+:description: Configure data retention policies to automatically delete expired business data from the BDM, ensuring GDPR compliance and controlling database growth.
+
+[NOTE]
+====
+For Subscription editions only. +
+Available from version 2026.1. Requires the `DATA_RETENTION` feature in your license.
+====
+
+The BDM data retention feature enables you to configure retention rules on Business Data Model object types so that expired records are deleted automatically on a scheduled basis. This supports GDPR compliance and prevents unbounded growth of the business data database.
+
+== Overview
+
+For each top-level BDM object type, an administrator can configure:
+
+* a *reference date*: either the object's creation date or its last update date,
+* a *retention period* (in days).
+
+When the scheduled cleanup job runs, every BDM instance whose reference date is older than `now - retention period` is deleted from the database, along with:
+
+* its xref:data:define-and-deploy-the-bdm.adoc#compos[composition children] (deleted automatically via Hibernate cascade),
+* its tracking record in the `data_retention_bdm_tracking` table.
+
+Retention rules are configured through the *Data Retention (GDPR)* administration page of the Admin application.
+
+== How BDM instances are tracked
+
+To decide which records have expired, Bonita maintains a dedicated tracking table named `data_retention_bdm_tracking`. Each row represents the lifecycle of a single BDM instance:
+
+[cols="1,1,3"]
+|===
+| Column | Type | Description
+
+| `id`
+| `BIGINT`
+| Primary key (Bonita internal).
+
+| `data_id`
+| `BIGINT`
+| Persistence ID of the tracked BDM instance.
+
+| `data_classname`
+| `VARCHAR(255)`
+| Fully qualified Java class name of the BDM object type (for example `com.company.model.Invoice`).
+
+| `created_at`
+| `BIGINT`
+| Epoch timestamp in milliseconds, set when the tracking record is first created.
+
+| `last_modified_at`
+| `BIGINT`
+| Epoch timestamp in milliseconds, updated every time the BDM instance is modified.
+|===
+
+A unique constraint on `(data_id, data_classname)` guarantees that there is exactly one tracking record per BDM instance.
+
+Tracking records are created and maintained automatically:
+
+* *On creation*: a new row is inserted with both `created_at` and `last_modified_at` set to the current time.
+* *On update*: `last_modified_at` is refreshed with the current time. `created_at` is left unchanged.
+* *On deletion*: the tracking row is removed.
+
+=== Composition and aggregation
+
+The relationship type between BDM objects determines how tracking is applied — see xref:data:define-and-deploy-the-bdm.adoc#compos[Composition and aggregation]:
+
+* *Composition children* are not tracked independently. They are deleted automatically by Hibernate cascade when their parent is deleted by a retention rule, so no dedicated retention configuration is needed or exposed.
+* *Aggregation children* are tracked only when they are created or updated as standalone entities through the BDM API. When Hibernate cascade-persists them along with a parent (via `CascadeType.MERGE`), no tracking record is created. To apply a retention rule to aggregation children, persist them explicitly.
+
+== Scheduling the cleanup
+
+The cleanup job is triggered by a Spring `@Scheduled` task driven by a cron expression. The default schedule runs once a week, every Saturday at 02:00 UTC.
+
+=== Configuration parameter
+
+[cols="1,3"]
+|===
+| Property | Description
+
+| `bonita.runtime.retention.schedule.cron`
+| Spring 6-field cron expression (`second minute hour day-of-month month day-of-week`) defining when the cleanup job runs. The job executes in the JVM default timezone. Default: `0 0 2 * * 6` (every Saturday at 02:00).
+|===
+
+To override the default, declare the property in `bonita-platform-sp-custom.properties` and restart the platform:
+
+[source,properties]
+----
+# Run every day at 03:30
+bonita.runtime.retention.schedule.cron=0 30 3 * * *
+----
+
+In a clustered setup, the cleanup job is coordinated so that only a single node runs it at a given time.
+
+=== Execution audit trail
+
+Each cleanup run produces one queriable log entry per BDM object type that had at least one expired instance deleted. The entry has:
+
+* `action_type`: `BUSINESS_DATA_CLEANED_UP`,
+* `message`: the fully qualified BDM class name,
+* `action_scope`: the number of deleted instances (as a string),
+* `severity`: `INTERNAL`.
+
+These entries can be queried through the existing `/API/system/log` REST endpoint and are displayed in the *Audit log* tab of the *Data Retention (GDPR)* administration page.
+
+If you do not want these entries stored in the database, disable the event in `bonita-tenant-sp-custom.properties`:
+
+[source,properties]
+----
+bonita.tenant.queriable.log.BUSINESS_DATA_CLEANED_UP.INTERNAL=false
+----
+
+See xref:api:queriable-logging.adoc[Queriable logging] for the full list of configurable events.
+
+== Related topics
+
+* xref:data:define-and-deploy-the-bdm.adoc#compos[BDM composition and aggregation]
+* xref:api:queriable-logging.adoc[Queriable logging]
+* xref:best-practices:gdpr-guidelines.adoc[GDPR design guide]

--- a/modules/runtime/runtime-nav.adoc
+++ b/modules/runtime/runtime-nav.adoc
@@ -86,3 +86,4 @@
   *** xref:maintenance-operation.adoc[Bonita Runtime maintenance operations]
   *** xref:purge-tool.adoc[Purging unnecessary archive data]
    **** xref:purge-tool-changelog.adoc[Purge tool changelog]
+  *** xref:bdm-data-retention.adoc[BDM data retention]


### PR DESCRIPTION
## Summary

Documents the new BDM data retention feature shipped in 2026.1:

- New *BDM data retention* page in the Runtime module covering:
  - overview of retention rules (reference date, retention period)
  - tracking mechanism (`data_retention_bdm_tracking` table)
  - composition vs aggregation tracking behavior
  - scheduled cleanup via the new `bonita.runtime.retention.schedule.cron` property
  - audit trail via the `BUSINESS_DATA_CLEANED_UP` queriable log event
- Tracking behavior notes added to the BDM composition/aggregation section
- GDPR design guide updated with a link to the new feature
- 2026.1 release note entry
- Runtime navigation updated

Closes [BPA-439](https://bonitasoft.atlassian.net/browse/BPA-439).

## Follow-up

A companion PR ([#3300](https://github.com/bonitasoft/bonita-doc/pull/3300)) adds a procedure for backfilling the tracking table for legacy BDM data. It is based on this branch and should be merged after.

## Test plan
- [x] Built locally with Antora (\`build-preview.bash --branch 2026.1 --component bonita --single-branch-per-repo true --local-sources true --fetch-sources false --ignore-errors true\`) and reviewed in the browser
- [ ] Verify xrefs resolve in the final build

[BPA-439]: https://bonitasoft.atlassian.net/browse/BPA-439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BPA-441]: https://bonitasoft.atlassian.net/browse/BPA-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ