### PR TITLE
feat(release): set the beta status on 2026.1

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,7 +1,7 @@
 name: bonita
 title: Bonita
 version: 2026.1
-prerelease: -alpha
+prerelease: -beta
 asciidoc:
   attributes:
     bonitaVersion: 2026.1
@@ -30,7 +30,7 @@ asciidoc:
     page-pagination: true # display links to previous/next pages at the bottom of the page
     page-editable: true
     page-out-of-support: false
-    page-next-release: true
+    page-next-release: false
     page-hide-search-bar: false
     page-hide-components: 'bcd'
 nav:


### PR DESCRIPTION
Set the beta status on 2026.1 (technical version 11.0.0):

- `prerelease: -alpha` → `-beta`
- `page-next-release: true` → `false` (removes the "next release" banner)