### PR TITLE
chore: preserve antora.yml during doc propagation into 2026.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+antora.yml merge=ours
 modules/ROOT/pages/release-notes.adoc merge=ours
 modules/ROOT/pages/index.adoc merge=ours
 modules/ROOT/pages/bonita-ui-designer-dependencies.adoc merge=ours


### PR DESCRIPTION
## Summary

Add `antora.yml merge=ours` to `.gitattributes` on the `2026.2` branch so the documentation propagation script (`2026.1` → `2026.2`) keeps the `2026.2`-specific version values instead of triggering a merge conflict.

## Context

Observed on a manual run of the [Propagate documentation workflow](https://github.com/bonitasoft/bonita-documentation-site/actions/runs/24667637806/job/72129967121):

```
> Merging branch '2026.1' into '2026.2'
Auto-merging antora.yml
CONFLICT (content): Merge conflict in antora.yml
```

The `antora.yml` file diverged between `2026.1` and `2026.2` (version, prerelease, bonitaTechnicalVersion, javadocVersion, page-hide-search-bar). Without `merge=ours` driver, git cannot auto-resolve.

## Test plan

- [ ] Re-run the [Propagate documentation workflow](https://github.com/bonitasoft/bonita-documentation-site/actions/workflows/propagate-doc-upwards.yml) on the PR branch https://github.com/bonitasoft/bonita-documentation-site/pull/969 → merge `2026.1` → `2026.2` succeeds