### PR TITLE
docs(Release notes): prepare release 2025.1-u8/10.3.8

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -519,7 +519,7 @@ The notable changes are:
 
 == Bug fixes
 
-=== Fixes in Bonita 2025.1-u8 (2026-04-27)
+=== Fixes in Bonita 2025.1-u8 (2026-04-24)
 
 * BPA-183 - Process instance never completes: row in FLOWNODE_INSTANCE table with stateid 28 and kind multi
 * BPA-297 - BDM REST API returns empty JSON for HibernateProxy entities

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -519,6 +519,14 @@ The notable changes are:
 
 == Bug fixes
 
+=== Fixes in Bonita 2025.1-u8 (2026-04-27)
+
+* BPA-183 - Process instance never completes: row in FLOWNODE_INSTANCE table with stateid 28 and kind multi
+* BPA-297 - BDM REST API returns empty JSON for HibernateProxy entities
+* BPA-443 - [Cluster] NPE on HTTP API for every void method (retryTask, logout, ...) — BypassSpringSessionFilter ineffective
+* BPA-449 - Studio: .bar built from a process with no declared dependencies contains all project dependencies
+* Several dependencies updated
+
 === Fixes in Bonita 2025.1-u7 (2026-04-01)
 
 * This version restores the Java dependencies configuration page with selective export that was available in 2024.3 and older versions.

--- a/modules/version-update/pages/product-versioning.adoc
+++ b/modules/version-update/pages/product-versioning.adoc
@@ -37,7 +37,7 @@ Here is a Bonita Platform version / Technical Id / UI Designer version correspon
 |===
 | Release date | Bonita Platform version | Technical Id | UI Designer version
 
-| 2026-04-27
+| 2026-04-24
 | 2025.1-u8
 | 10.3.8
 | 1.19.1

--- a/modules/version-update/pages/product-versioning.adoc
+++ b/modules/version-update/pages/product-versioning.adoc
@@ -37,6 +37,11 @@ Here is a Bonita Platform version / Technical Id / UI Designer version correspon
 |===
 | Release date | Bonita Platform version | Technical Id | UI Designer version
 
+| 2026-04-27
+| 2025.1-u8
+| 10.3.8
+| 1.19.1
+
 | 2026-04-01
 | 2025.1-u7
 | 10.3.7


### PR DESCRIPTION
## Summary

Prepares release notes for Bonita **2025.1-u8 / 10.3.8**.

## Changes

- Add `Fixes in Bonita 2025.1-u8 (2026-04-27)` section listing the 4 bug fixes shipped in this release.
- Declare the new version in `product-versioning.adoc` (UID unchanged, still 1.19.1).

## Bug fixes included

- [BPA-183](https://bonitasoft.atlassian.net/browse/BPA-183) — Process instance never completes (FLOWNODE_INSTANCE row with stateid 28, kind multi)
- [BPA-297](https://bonitasoft.atlassian.net/browse/BPA-297) — BDM REST API returns empty JSON for HibernateProxy entities
- [BPA-443](https://bonitasoft.atlassian.net/browse/BPA-443) — [Cluster] NPE on HTTP API for every void method (BypassSpringSessionFilter ineffective)
- [BPA-449](https://bonitasoft.atlassian.net/browse/BPA-449) — Studio: `.bar` built from a process with no declared dependencies contains all project dependencies

Follows the same format as #3289 (2025.1-u7 / 10.3.7).

[BPA-183]: https://bonitasoft.atlassian.net/browse/BPA-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BPA-297]: https://bonitasoft.atlassian.net/browse/BPA-297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BPA-443]: https://bonitasoft.atlassian.net/browse/BPA-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BPA-449]: https://bonitasoft.atlassian.net/browse/BPA-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ