### PR TITLE
docs(connectors): align Mistral OCR, Yousign and Slack docs with hotfix PRs

### DIFF
--- a/modules/process/pages/connectors-index.adoc
+++ b/modules/process/pages/connectors-index.adoc
@@ -211,6 +211,11 @@ xref:ROOT:workday-connector.adoc[[.card-title]#Workday HCM &#91;BETA&#93;# [.car
 
 [.card.card-index]
 --
+xref:ROOT:slack-connector.adoc[[.card-title]#Slack &#91;BETA&#93;# [.card-body.card-content-overflow]#pass:q[Send messages, DMs, files; create and manage channels]#]
+--
+
+[.card.card-index]
+--
 xref:ROOT:yousign-connector.adoc[[.card-title]#Yousign &#91;BETA&#93;# [.card-body.card-content-overflow]#pass:q[Create and manage electronic signature requests]#]
 --
 

--- a/modules/process/pages/mistral-ocr-connector.adoc
+++ b/modules/process/pages/mistral-ocr-connector.adoc
@@ -124,7 +124,7 @@ Extract raw text from documents or images using OCR.
 |Integer
 |Number of pages processed
 
-|*tokensUsed*
+|*pagesProcessed*
 |Integer
 |Number of tokens consumed
 
@@ -185,7 +185,7 @@ Extract structured fields from a document using a JSON schema definition.
 |Double
 |Overall extraction confidence score
 
-|*tokensUsed*
+|*pagesProcessed*
 |Integer
 |Number of tokens consumed
 
@@ -241,7 +241,7 @@ Classify a document into one of several predefined categories.
 |String
 |JSON with scores for all document types
 
-|*tokensUsed*
+|*pagesProcessed*
 |Integer
 |Number of tokens consumed
 
@@ -274,10 +274,15 @@ Extract tabular data from a document.
 |Description of the table to extract
 |--
 
-|*pageNumber*
+|*startPage*
 |No
-|Page number to extract the table from
-|1
+|First page to scan for tables, 1-indexed (optional). Removed `pageNumber` from 1.0.1-beta.1 onwards.
+|--
+
+|*endPage*
+|No
+|Last page to scan for tables, 1-indexed inclusive (optional). Use together with `startPage`.
+|--
 |===
 
 === Output parameters
@@ -306,7 +311,7 @@ Extract tabular data from a document.
 |String
 |Detected column headers
 
-|*tokensUsed*
+|*pagesProcessed*
 |Integer
 |Number of tokens consumed
 
@@ -367,7 +372,7 @@ Process multi-page documents with optional page range selection.
 |Integer
 |Total word count
 
-|*tokensUsed*
+|*pagesProcessed*
 |Integer
 |Number of tokens consumed
 

--- a/modules/process/pages/yousign-connector.adoc
+++ b/modules/process/pages/yousign-connector.adoc
@@ -137,41 +137,25 @@ Creates a signature request from a pre-configured Yousign template.
 |A name for the signature request.
 |
 
-|*signerFirstName*
+|*templatePlaceholdersJson*
 |String
 |Yes
-|First name of the signer.
+|JSON object with `signers[]` (mandatory non-empty) and optionally `read_only_text_fields[]`. The connector validates the shape before sending and rejects malformed payloads up-front (instead of letting Yousign return an opaque API error). Example shape:
+[source,json]
+----
+{
+  "signers": [
+    {
+      "label": "policyHolder",
+      "info": { "first_name": "Jane", "last_name": "Doe", "email": "jane.doe@example.com", "locale": "en" }
+    }
+  ],
+  "read_only_text_fields": [
+    { "label": "claim_id", "text": "SIN-2026-42" }
+  ]
+}
+----
 |
-
-|*signerLastName*
-|String
-|Yes
-|Last name of the signer.
-|
-
-|*signerEmail*
-|String
-|Yes
-|Email address of the signer.
-|
-
-|*signerPhoneNumber*
-|String
-|No
-|Phone number of the signer (international format).
-|
-
-|*signerLabel*
-|String
-|Yes
-|The signer role label as defined in the template (e.g., `Signer`).
-|
-
-|*signerLocale*
-|String
-|No
-|The signer's locale for the signing interface.
-|`fr` (options: `fr`, `en`, `de`, `it`, `es`, `nl`, `pl`)
 
 |*deliveryMode*
 |String
@@ -184,18 +168,6 @@ Creates a signature request from a pre-configured Yousign template.
 |No
 |When `true`, signers must sign in the order they are added.
 |`false`
-
-|*templateTextFieldsJson*
-|String
-|No
-|JSON string with template text field values to pre-fill.
-|
-
-|*additionalSignersJson*
-|String
-|No
-|JSON string with additional signers (for multi-signer templates).
-|
 
 |*externalId*
 |String


### PR DESCRIPTION
## Summary

Bring the official documentation in sync with three recent connector hotfix PRs that have been reviewed and updated based on review feedback:

- bonitasoft/bonita-connector-mistral-ocr#11
- bonitasoft/bonita-connector-yousign#17
- bonitasoft/bonita-connector-slack-all#16

## Changes

**`mistral-ocr-connector.adoc`**
- Rename `tokensUsed` → `pagesProcessed` in the five operations. The underlying value comes from `usage_info.pages_processed` in the API response and was never counting tokens; the old parameter name was misleading.
- Replace the removed `pageNumber` row in Extract Table with `startPage` / `endPage` (consistent with the other operations that now support page-range filtering).

**`yousign-connector.adoc`**
- Remove eight rows that documented inputs that have been deleted from the connector (`signerFirstName`, `signerLastName`, `signerEmail`, `signerPhoneNumber`, `signerLabel`, `signerLocale`, `templateTextFieldsJson`, `additionalSignersJson`).
- Add a single mandatory `templatePlaceholdersJson` row that documents the JSON shape expected by Yousign API v3 (`signers[]` non-empty, optional `read_only_text_fields[]`) with an inline example.

**`connectors-index.adoc`**
- Add the Slack connector card. The page already existed in `2026.1` but was not surfaced in the index.

**`slack-connector.adoc`**
- No changes — the upstream `2026.1` version already documents the correct `Invited User IDs` / `Skipped User IDs` / `Failed Emails` outputs and the `chat:write.public` scope.

## Test plan

- [x] No broken xrefs introduced (Slack page already exists in `2026.1`).
- [ ] Reviewer skims to confirm the changes match the merged connector PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)