### PR TITLE
fix(connectors): broken mistral.ai URL rendering in OCR connector

### DIFF
--- a/modules/process/pages/mistral-ocr-connector.adoc
+++ b/modules/process/pages/mistral-ocr-connector.adoc
@@ -43,7 +43,7 @@ Add the connector as an extension dependency to your Bonita project. Import the 
 |*baseUrl*
 |No
 |Mistral API base URL
-|https://api.mistral.ai/v1
+|`++https://api.mistral.ai/v1++`
 
 |*model*
 |No


### PR DESCRIPTION
## Summary
The Mistral API base URL in the Mistral OCR connector page was being auto-linked by AsciiDoc, producing a broken link in the rendered docs.

## Changes
Wrap `https://api.mistral.ai/v1` in inline pass-through (`++...++`) and code formatting so AsciiDoc renders it as plain code text instead of a hyperlink.

## Test plan
- [ ] Wait for the PR preview build
- [ ] Check the Mistral OCR connector page renders the URL as code text (no hyperlink)

🤖 Generated with [Claude Code](https://claude.com/claude-code) using model claude-opus-4-7 (Opus 4.7)

Co-Authored-By: Claude (claude-opus-4-7) <noreply@anthropic.com>