### PR TITLE
fix: update release notes for Bonita 2024.2 version

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -156,7 +156,7 @@ We are pleased to bring several exciting advancements in this release, including
 * STUDIO-4533 - Refreshing a project after a git switch branch now adds/removes submodules as expected.
 * STUDIO-4535 - Renaming a project without bdm or extensions fails
 
-=== Fixes in Bonita 2024.2 (2024-05-28)
+=== Fixes in Bonita 2024.2-u0 (2024-05-28)
 
 ==== Fixes in Bonita Runtime (including Bonita Applications)
 


### PR DESCRIPTION
The GA version also contains a `-u` postfix as described in the product-versioning page.