### PR TITLE
chore: update links pointing to future archived versions

### DIFF
--- a/modules/ROOT/pages/creating-a-new-look-feel.adoc
+++ b/modules/ROOT/pages/creating-a-new-look-feel.adoc
@@ -4,7 +4,6 @@
 {description}
 
 Since the xref:ROOT:portal-removal.adoc[removal of Portal in 2021.2], the Look & Feel was re-packaged in the bundle itself. You can find it in the `server/webapps/bonita/portal-theme` folder.
-For a reference about the contained files go to xref:2021.1@ROOT:creating-a-new-look-feel.adoc[the previous version of Bonita]. +
 
 The two places that still use the old Look & Feel are old pages not made using the UI Designer and the Bonita Login page. +
 Those old pages take into account the theme of your application. If you want to modify their style, we strongly suggest xref:ROOT:themes.adoc[you change the theme]. +

--- a/modules/ROOT/pages/portal-removal.adoc
+++ b/modules/ROOT/pages/portal-removal.adoc
@@ -7,8 +7,8 @@ The removal of this part of the product implied removal, deprecation or conversi
 
 Some that can be mentioned are: +
 
-- Custom profiles are xref:2021.2@ROOT:release-notes.adoc#_new_bonita_applications[converted into Living Applications], using Bonita Layout and Bonita Theme
-- xref:2021.2@ROOT:release-notes.adoc#_new_bonita_applications[Process Manager profile], which has been removed and will be re-done in a future release
+- Custom profiles are converted into Living Applications, using Bonita Layout and Bonita Theme
+- Process Manager profile, which has been removed and will be re-done in a future release
 - Removal of Analytics page, which will be remade in a newer technology
 - The Living Application Layout, which has been replaced by the Bonita Layout
 - The Look & Feel files, which were used to define how the Portal will be displayed, are removed from the database. The default Look & Feel is re-packaged directly in the `server/webapps/bonita/portal-theme` folder in the Bundle
@@ -16,18 +16,23 @@ Some that can be mentioned are: +
 
 The changes done for these features implied a removal of some pages that referenced them. The list of links to previous versions of the pages that have been removed is : +
 
-- xref:2021.1@ROOT:analytics.adoc[Analytics]
-- xref:2021.1@ROOT:living-application-layout.adoc[Living Application Layout]
-- xref:2021.1@ROOT:managing-look-feel.adoc[Manage the Portal Look & Feel]
-- xref:2021.1@ROOT:restore-default-look-feel.adoc[Restore the default Look & Feel]
-- xref:2021.1@ROOT:group.adoc[Administrator Group list in Bonita Portal]
-- xref:2021.1@ROOT:manage-a-user.adoc[Administrator User list in Bonita Portal]
-- xref:2021.1@ROOT:processes.adoc[Administrator Process list in Bonita Portal]
-- xref:2021.1@ROOT:role.adoc[Administrator Role list in Bonita Portal]
-- xref:2021.1@ROOT:tasks.adoc[Administrator Task list in Bonita Portal]
-- xref:2021.1@ROOT:profile-list-portal.adoc[Profiles management in Bonita Portal]
-- xref:2021.1@ROOT:portal-user-case-list.adoc[User Case list in Bonita Portal]
-- xref:2021.1@ROOT:mobile-portal.adoc[Mobile User Portal]
-- xref:2021.1@ROOT:comparison-of-7-x-and-6-x.adoc[Comparison of 7.x and 6.x version]
-- xref:2021.1@ROOT:create-a-report.adoc[Create a report]
-- xref:2021.1@ROOT:reporting-overview.adoc[Reporting overview]
+- Analytics
+- Living Application Layout
+- Manage the Portal Look & Feel
+- Restore the default Look & Feel
+- Administrator Group list in Bonita Portal
+- Administrator User list in Bonita Portal
+- Administrator Process list in Bonita Portal
+- Administrator Role list in Bonita Portal
+- Administrator Task list in Bonita Portal
+- Profiles management in Bonita Portal
+- User Case list in Bonita Portal
+- Mobile User Portal
+- Comparison of 7.x and 6.x version
+- Create a report
+- Reporting overview
+
+[NOTE]
+====
+To get the documentation related to the features that have been removed, you can refer to the 2021.1 documentation, which is available as xref:0@bonita::archives.adoc[a zip archive].
+====

--- a/modules/version-update/pages/mtmr-tool.adoc
+++ b/modules/version-update/pages/mtmr-tool.adoc
@@ -1,10 +1,10 @@
 = Bonita Multi-Tenant to Multi-Runtime conversion tool
 :page-aliases: ROOT:multi-tenancy-and-tenant-configuration.adoc
-:description: This pages describes how to use the multi-tenant to multi-runtime conversion tool.
+:description: This page describes how to use the multi-tenant to multi-runtime conversion tool.
 
 {description}
 
-WARNING: xref:2022.2@ROOT:multi-tenancy-and-tenant-configuration.adoc[Multi-tenancy] has been removed starting from Bonita 2023.1. *If you are using multi-tenancy, you will have to run this conversion tool before updating to Bonita 2023.1.*
+WARNING: Multi-tenancy has been removed starting from Bonita 2023.1. *If you are using multi-tenancy, you will have to run this conversion tool before updating to Bonita 2023.1.*
 
 Learn how to use the multi-tenant to multi-runtime tool to convert a multi-tenant platform into a multi-runtime one.
 

--- a/modules/version-update/pages/update-with-migration-tool.adoc
+++ b/modules/version-update/pages/update-with-migration-tool.adoc
@@ -137,9 +137,18 @@ If you are updating from a version lower than 7.3, see special cases <<lower-7-3
 Starting with Bonita 2021.2 (Bonita Runtime 7.13), Bonita Applications replaced Bonita Portal. If you need to use some of the Portal Look&Feel assets in the themes of your applications, make sure you create backups of those files before launching the updating procedure.
 There is no guarantee that the Look & Feel definition is compatible across maintenance versions.
 For example, in 6.2.2, `jquery+` was renamed `jqueryplus` in `BonitaConsole.html`, for compatibility with more application servers.
-If you are using a custom Look & Feel,  xref:2021.1@ROOT:managing-look-feel.adoc[export] it before updating
-Once the update is complete,  xref:2021.1@ROOT:managing-look-feel.adoc[export the default Look & Feel] from the new version,
-modify your custom Look & Feel to be compatible with the new definition, and with the  xref:2021.1@ROOT:creating-a-new-look-feel.adoc[recommendations for form footers]. Then xref:2021.1@ROOT:managing-look-feel.adoc[import] your updated custom Look & Feel into Bonita Portal.
+If you are using a custom Look & Feel, export it before updating
+Once the update is complete, export the default Look & Feel from the new version,
+modify your custom Look & Feel to be compatible with the new definition, and with the recommendations for form footers.
+Then import your updated custom Look & Feel into Bonita Portal.
+
+[NOTE]
+====
+Refer to the documentation of the version 2021.1 documentation to know how to export the Look & Feel, get the recommendations for form footers and import the Look & Feel.
+
+This documentation is available as xref:0@bonita::archives.adoc[a zip archive].
+====
+
 
 === JRE requirements
 Based on your target Bonita version, check whether JRE update is required in your environment before launching the update process:


### PR DESCRIPTION
Remove the links or link to the "archives" page instead.