### PR TITLE
feat: add central 1.0 to archives

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -2,7 +2,7 @@ name: bonita
 title: Bonita
 version: 0
 display_version: Archives
-start_page: ROOT:archives.adoc
+start_page: archives:index.adoc
 asciidoc:
   attributes:
     page-editable: true

--- a/antora.yml
+++ b/antora.yml
@@ -9,4 +9,4 @@ asciidoc:
     page-out-of-support: false
     page-hide-search-bar: true
 nav:
-  - modules/ROOT/taxonomy.adoc
+  - modules/archives/taxonomy.adoc

--- a/modules/ROOT/taxonomy.adoc
+++ b/modules/ROOT/taxonomy.adoc
@@ -1,1 +1,0 @@
-* xref:archives.adoc[Old bonita versions]

--- a/modules/archives/pages/bonita.adoc
+++ b/modules/archives/pages/bonita.adoc
@@ -1,11 +1,12 @@
-= Download archived documentations of old Bonita versions
+= Download archived documentation of old Bonita versions
+:page-aliases: ROOT:archives.adoc
 :description: This page gives access to the download of Bonita documentation archives, in case you need something very specific to those versions.
 
-This page gives access to the download of Bonita documentation archives, in case you need something very specific to those versions. The format is either html (for not so old versions) or pdf (for very old versions).
+This page gives access to the download of Bonita documentation archives, in case you need something very specific to those versions. The format is either HTML (for not-so-old versions) or PDF (for ancient versions).
 
 == From Bonita 7.6
 
-The format here is html. +
+The format here is HTML. +
 Download the .zip archive, extract it, and then open the index.html file to launch the site. +
 You can navigate those sites with the table of content on the left.
 
@@ -22,7 +23,7 @@ You can navigate those sites with the table of content on the left.
 
 == Bonita BPM 7.3 to Bonita BPM 7.5
 
-The format here is html. +
+The format here is HTML. +
 Download the .zip archive, extract it, and then open the index.html file to launch the site. +
 You can navigate those sites with the table of content on the left.
 
@@ -32,9 +33,9 @@ You can navigate those sites with the table of content on the left.
 
 == From Bonita BPM 6.0 to Bonita BPM 7.2
 
-The format of those versions is pdf. It replaces the very old documentation website. +
-Download the .zip archive and open the pdf document.
-You can navigate those documents by using Ctrl+F.
+The format of those versions is PDF. It replaces the ancient documentation website. +
+Download the .zip archive and open the PDF document.
+You can navigate to those documents by using Ctrl+F.
 
 * https://github.com/bonitasoft/bonita-doc/releases/download/6.0-7.2_archives/BonitaBPM_7.2.zip[Bonita BPM 7.2]
 * https://github.com/bonitasoft/bonita-doc/releases/download/6.0-7.2_archives/BonitaBPM_7.1.zip[Bonita BPM 7.1]

--- a/modules/archives/pages/central.adoc
+++ b/modules/archives/pages/central.adoc
@@ -1,0 +1,12 @@
+= Download archived documentation of old Bonita Central versions
+:description: This page gives access to the download of Bonita Central documentation archives, in case you need something very specific to those versions.
+
+This page gives access to the download of Bonita Central documentation archives, in case you need something very specific to those versions. The format is either HTML (for not-so-old versions) or PDF (for ancient versions).
+
+== From Bonita Central 1.0
+
+The format here is HTML. +
+Download the .zip archive, extract it, and then open the index.html file to launch the site. +
+You can navigate those sites with the table of content on the left.
+
+* https://github.com/bonitasoft/bonita-central-doc/releases/download/1.0-20260513_142912/documentation-central-1.0.zip[Bonita Central 1.0]

--- a/modules/archives/pages/index.adoc
+++ b/modules/archives/pages/index.adoc
@@ -1,0 +1,11 @@
+= Download archived documentation of old Bonita Component versions
+:description: This page references the archive of the Bonita documentation, in case you need something very specific to those versions.
+
+This page references the archive of the Bonita documentation, in case you need something very specific to those versions.
+
+The format is either HTML (for not-so-old versions) or PDF (for ancient versions).
+
+Available archives:
+
+- xref:bonita.adoc[Bonita]
+- xref:central.adoc[Bonita Central]

--- a/modules/archives/taxonomy.adoc
+++ b/modules/archives/taxonomy.adoc
@@ -1,0 +1,3 @@
+* xref:index.adoc[Archives]
+** xref:bonita.adoc[Bonita]
+** xref:central.adoc[Bonita Central]


### PR DESCRIPTION
The central archives are stored in a dedicated page.
The bonita archives also live in a dedicated page, and a new home page references all archive pages.

### Notes

The Bonita archive page includes the "Bonita BPM" wording which is not allowed. We have no choice here, because it is the former name of the Bonita product and we must use it in the page. 
So, this Contribution Guidelines checks error can be ignored.