### PR TITLE
fix: use a new link to bonita archives

### DIFF
--- a/modules/ROOT/pages/portal-removal.adoc
+++ b/modules/ROOT/pages/portal-removal.adoc
@@ -34,5 +34,5 @@ The changes done for these features implied a removal of some pages that referen
 
 [NOTE]
 ====
-To get the documentation related to the features that have been removed, you can refer to the 2021.1 documentation, which is available as xref:0@bonita::archives.adoc[a zip archive].
+To get the documentation related to the features that have been removed, you can refer to the 2021.1 documentation, which is available as xref:0@bonita:archives:bonita.adoc[a zip archive].
 ====

--- a/modules/version-update/pages/update-with-migration-tool.adoc
+++ b/modules/version-update/pages/update-with-migration-tool.adoc
@@ -146,7 +146,7 @@ Then import your updated custom Look & Feel into Bonita Portal.
 ====
 Refer to the documentation of the version 2021.1 documentation to know how to export the Look & Feel, get the recommendations for form footers and import the Look & Feel.
 
-This documentation is available as xref:0@bonita::archives.adoc[a zip archive].
+This documentation is available as xref:0@bonita:archives:bonita.adoc[a zip archive].
 ====
 
 


### PR DESCRIPTION
It was not possible to add a page alias to the former page, otherwise it would have prevented from accessing to the new archives home.
The issue only occurred with xref. Direct access to the former archives page correctly redirects the new archives home.