### PR TITLE
docs: fix typo in the vulnerability reporting policy page

### DIFF
--- a/modules/contributing/pages/vulnerability-reporting-policy.adoc
+++ b/modules/contributing/pages/vulnerability-reporting-policy.adoc
@@ -7,7 +7,7 @@ It sets forth the principles under which Vulnerabilities should be discussed, ma
 
 == Terms
 
-Vulnerability:: As defined by the ISO 27005 definition, see <<_what_is_a_technical_vulnerability, bellow>>.
+Vulnerability:: As defined by the ISO 27005 definition, see <<_what_is_a_technical_vulnerability, below>>.
 
 Bonita Security Team::
 The Bonita Security Team handles tasks related to Vulnerability management regarding the Bonita solution. +


### PR DESCRIPTION
typo in word "below"