### PR TITLE
fix(2022.2): hide the search bar

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -22,7 +22,7 @@ asciidoc:
     page-editable: false
     page-out-of-support: true
     page-next-release: false
-    page-hide-search-bar: false
+    page-hide-search-bar: true
 nav:
   - modules/ROOT/release-note-nav.adoc
   - modules/bonita-overview/bonita-overview-nav.adoc


### PR DESCRIPTION
Bonita 2022.2 will be removed from the documentation site soon. The DocSearch index no longer includes this version.
So today, as searches return no result for the bonita 2022.2 version, hide the search bar.
Readers now have a consistent experience.