### PR TITLE
docs: fix grammar and wording in super admin application overview

### DIFF
--- a/modules/runtime/pages/super-administrator-application-overview.adoc
+++ b/modules/runtime/pages/super-administrator-application-overview.adoc
@@ -10,16 +10,16 @@ This application is only available to the user with the xref:ROOT:special-users.
 It is the tool needed to:
 
 * Bootstrap a Bonita Runtime in Non-Production and Production environments, for example, xref:first-steps-after-setup.adoc#_create_a_bonita_administrator_profile[creating the administrators]
-* Ability to notify users about a scheduled maintenance by a custom message that will be displayed to logged-in users. This message is also displayed on the maintenance page when the maintenance mode is enabled.
+* Notify users about a scheduled maintenance by a custom message that will be displayed to logged-in users. This message is also displayed on the maintenance page when the maintenance mode is enabled.
 * Activate maintenance mode for operations, among which the update of the Business Data Model (and the related database migration)
-* Apply temporary fixes to some projects elements (resources, applications, organization entities) to recover from errors
+* Apply temporary fixes to some project elements (resources, applications, organization entities) to recover from errors
 
 [CAUTION]
 ====
 
 Most updates at runtime should be performed through a change in the project sources to create a new project version. +
-This new version can then be deployed in a  Bonita self-contained application.
-Previous update methods, like Bonita Continuous Delivery, are now deprecated +
+This new version can then be deployed in a Bonita self-contained application.
+Previous update methods, like Bonita Continuous Delivery, are now deprecated. +
 This methodology guarantees the consistency between the project sources and the deployed version, making all subsequent changes much simpler and error-proof. +
 
 The Super Administrator Application is meant for emergency changes to recover from an urgent issue. +
@@ -41,7 +41,7 @@ By default, in our provided ACME organization, the default user is Walter Bates,
 . Log back in with the Technical User credentials. In Bonita Studio, use the username: `install` and password `install`.
 . In the Application Directory, select _Bonita Super Administrator Application_
 
-You are now logged in Bonita Super Administrator Application.
+You are now logged in to the Bonita Super Administrator Application.
 
 To access its content:
 

--- a/modules/runtime/pages/super-administrator-application-overview.adoc
+++ b/modules/runtime/pages/super-administrator-application-overview.adoc
@@ -1,8 +1,8 @@
 = Bonita Super Administrator Application overview
 :page-aliases: ROOT:super-administrator-application-overview.adoc
-:description: This pages describes Bonita _Super Administrator Application_: its values, how to access it, and how to customize it.
+:description: This page describes the Bonita Super Administrator Application: its values, how to access it, and how to customize it.
 
-{description}
+This page describes the Bonita _Super Administrator Application_: its values, how to access it, and how to customize it.
 
 == Values
 
@@ -10,14 +10,14 @@ This application is only available to the user with the xref:ROOT:special-users.
 It is the tool needed to:
 
 * Bootstrap a Bonita Runtime in Non-Production and Production environments, for example, xref:first-steps-after-setup.adoc#_create_a_bonita_administrator_profile[creating the administrators]
-* Ability to notify users about a scheduled maintenance, by a custom message that will be displayed to logged-in users. this message is also displayed on the maintenance page when the maintenance mode is enabled.
+* Ability to notify users about a scheduled maintenance by a custom message that will be displayed to logged-in users. This message is also displayed on the maintenance page when the maintenance mode is enabled.
 * Activate maintenance mode for operations, among which the update of the Business Data Model (and the related database migration)
 * Apply temporary fixes to some projects elements (resources, applications, organization entities) to recover from errors
 
 [CAUTION]
 ====
 
-Most updates at runtime should be performed through a change in the project sources, to create a new project version. +
+Most updates at runtime should be performed through a change in the project sources to create a new project version. +
 This new version can then be deployed in a  Bonita self-contained application.
 Previous update methods, like Bonita Continuous Delivery, are now deprecated +
 This methodology guarantees the consistency between the project sources and the deployed version, making all subsequent changes much simpler and error-proof. +
@@ -45,12 +45,12 @@ You are now logged in Bonita Super Administrator Application.
 
 To access its content:
 
-. From Bonita Super Administrator Application menu, click on "Applications"
+. From the Bonita Super Administrator Application menu, click on "Applications"
 . On the "Bonita Super Administrator Application" row, click on the "..." _View application details_ icon
 
 
 == Status
-This application is core to Bonita Platform. It is embedded in the Runtime and cannot be downloaded from Bonita Studio nor be part of your automation project. +
+This application is core to the Bonita Platform. It is embedded in the Runtime and cannot be downloaded from Bonita Studio nor be part of your automation project. +
 This is the reason why you will not see it in Bonita Studio's Project Explorer. +
 It is also the reason why the list of pages is fixed, and no navigation can be created. +
 
@@ -74,15 +74,15 @@ The new logo is applied.
 To update the layout and/or theme:
 
 . Create a new xref:applications:layout-development.adoc[layout] and/or xref:applications:customize-living-application-theme.adoc[theme]
-. Go the _Resources_ tab
+. Go to the _Resources_ tab
 . Install it
 . Go back to the application details
 . Click on the current layout or theme
-. Select the new one from the drop down list
+. Select the new one from the drop-down list
 
 [NOTE]
 ====
 
 Once the Super Administrator Application has been customized, its customized aspects are not supported. +
-But you can reach one of our Professional Services team member to help you develop or maintain it. To do so, go to the {cscCustomerServices}[Customer Service Center].
+But you can reach one of our Professional Services team members to help you develop or maintain it. To do so, go to the {cscCustomerServices}[Customer Service Center].
 ====


### PR DESCRIPTION
## What

Fixes grammar, article usage, phrasing, and punctuation issues in the _Super Administrator Application_ overview page.

## Why

Several small wording problems made the page read awkwardly (e.g. "This pages describes", missing articles, inconsistent phrasing, punctuation glitches). This polishes the text without changing the documented behavior.

## Changes

- Correct typos, capitalization, and punctuation throughout the page
- Add missing articles and fix hyphenation for smoother reading
- Streamline phrasing of the feature list for consistency
- Replace the `{description}` attribute reference in the body with explicit text so the introduction renders independently of the description metadata
