### PR TITLE
docs(task-delegation): show delegation rules on the admin Delegations page

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -49,7 +49,7 @@ The Bonita Administrator Application is updated in place (no new application was
 
 [NOTE]
 ====
-This release ships updated versions of the provided REST API permission rules. The task endpoints' rules `TaskPermissionRule` and `TaskExecutionPermissionRule` are updated so that an active delegate is granted access to the delegated tasks, and a new `DelegationPermissionRule` secures the delegation endpoints (`delegation/rule` and `delegation/task`), with the matching entries added to `dynamic-permissions-checks.properties`.
+This release ships updated versions of the provided REST API dynamic authorization rules. The task endpoints' rules `TaskPermissionRule` and `TaskExecutionPermissionRule` are updated so that an active delegate is granted access to the delegated tasks, and a new `DelegationPermissionRule` secures the delegation endpoints (`delegation/rule` and `delegation/task`), with the matching entries added to `dynamic-permissions-checks.properties`.
 
 If you customized any of the provided permission rules, you need to update your custom rules to re-apply your changes on top of the new versions of those rules after upgrading (otherwise the delegation feature will not work). See xref:identity:rest-api-authorization.adoc#dynamic_authorization[Dynamic authorization checking].
 ====

--- a/modules/runtime/pages/admin-delegation.adoc
+++ b/modules/runtime/pages/admin-delegation.adoc
@@ -15,7 +15,27 @@ As an administrator, you manage the delegation rules of the whole organization f
 The *Delegations* page is only visible to users with the Administrator profile.
 ====
 
-For what a delegation is and the rules that govern it (assigned tasks only, root process, BDM privileges, and one rule per delegator), see xref:user-delegation.adoc#concepts[How delegation works].
+For what a delegation is and how it behaves during the active period, see xref:user-delegation.adoc#concepts[How delegation works]. The same rules govern every delegation, whether you create it here or a user sets up their own:
+
+[NOTE]
+====
+Delegation only covers tasks *assigned* to the delegator, either taken manually or assigned automatically by an actor filter. A task that is only _pending_ for a group is not delegated until someone takes it.
+====
+
+[NOTE]
+====
+Delegation always applies at the *root process* level. If a process uses call activities (sub-processes), select the root process: a delegation set on a sub-process covers nothing, even for tasks that belong to that sub-process. Unfortunately it is not possible to list only the root processes for the end user as some processes may be used both as subprocesses and root processes and there is no way to know.
+====
+
+[NOTE]
+====
+The delegate must have the same business data (BDM) access privileges as the delegator to open the task forms. Delegation does not grant these privileges automatically. If the delegate hits an access error on a form, an administrator can assign the appropriate permissions (e.g. through profiles or groups) so they can open the task forms.
+====
+
+[NOTE]
+====
+A user can have only one delegation at a time. To cover a new absence, edit the existing delegation instead of creating a new one. The delegate and process list are kept, so you usually only update the dates.
+====
 
 == The delegations table
 


### PR DESCRIPTION
## What

Surface the four governing-rule notes on the admin **Delegations administration** page (`runtime/admin-delegation.adoc`). They previously lived only on the user Delegations page and were cross-referenced from the admin page.

## Why

These rules apply equally when an administrator creates a delegation on behalf of a user, so an admin should see them on the page they work from, not only via a link.

## Details

- Reworded the "How delegation works" cross-reference so it no longer re-lists the rules inline.
- Added the notes: tasks must be **assigned** (not just pending for a group), delegation applies at the **root process** level, the delegate needs the same **BDM** access as the delegator, and a user can have only **one delegation at a time**.
- Notes 1-3 are identical to the user page; the one-rule note is phrased for the admin context ("A user can have only one delegation at a time"), since the verbatim user-page wording ("You can have only one...") would be incorrect on a page where the admin manages many users' delegations.

## Reference

- Jira: https://bonitasoft.atlassian.net/browse/BPA-347
- Follow-up to PR #3367 (Task Delegation documentation)
