### PR TITLE
docs(task-delegation): remove duplicated one-delegation sentence on admin page

### DIFF
--- a/modules/runtime/pages/admin-delegation.adoc
+++ b/modules/runtime/pages/admin-delegation.adoc
@@ -56,7 +56,7 @@ Click *Save* to create the rule. Click *Edit* on any row to reopen the same form
 
 === Replace an existing rule
 
-A user can have only one delegation at a time. If you create a delegation for a user who already has one, the form warns you and offers to edit the existing rule.
+If you create a delegation for a user who already has one, the form warns you and offers to edit the existing rule.
 
 === Delegate conflict warning
 


### PR DESCRIPTION
## What

Remove a duplicated sentence on the admin **Delegations administration** page (`runtime/admin-delegation.adoc`).

"A user can have only one delegation at a time." appeared twice: in the delegation-rules note and again as the opening of the *Replace an existing rule* section.

## Fix

Keep the sentence in the note (which states the rule) and drop it from the *Replace an existing rule* section, which now just explains the replace/upsert behavior:

> If you create a delegation for a user who already has one, the form warns you and offers to edit the existing rule.

Follow-up to PR #3379 (review finding).
