### PR TITLE
fix: continue the Bonitasoft to Ofelia renaming of urls

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -12,7 +12,7 @@ asciidoc:
     keycloakDocumentationVersion: 21.1.2
     openApiUrl: 'https://api-documentation.ofelia.com'
     javadocUrl: 'https://javadoc.documentation.ofelia.com'
-    cscRootUrl: 'https://csc.bonitacloud.bonitasoft.com'
+    cscRootUrl: 'https://csc.bonitacloud.ofelia.com'
     cscCustomerServices: '{cscRootUrl}/apps/CustomerServices'
     cscDownloadUrl: '{cscCustomerServices}/downloads'
     cscLicenseUrl: '{cscCustomerServices}/licenses'

--- a/modules/ROOT/pages/bonita-studio-download-installation.adoc
+++ b/modules/ROOT/pages/bonita-studio-download-installation.adoc
@@ -38,7 +38,7 @@ Another solution is to download and execute manually the installer, https://adop
 The security feature called *SmartScreen* prevents execution of Bonita Studio installer.  When you get the "Windows protect your PC" pop up window, click on "More info" link and click on "Run anyway" button.
 
 === Community edition
-To download the latest version of Bonita Studio Community edition, open the https://www.bonitasoft.com/downloads[download page] and click on the *Download* button. This will start the download of the Bonita Studio installer for your operating system.
+To download the latest version of Bonita Studio Community edition, open the https://www.ofelia.com/downloads[download page] and click on the *Download* button. This will start the download of the Bonita Studio installer for your operating system.
 
 // update package name
 
@@ -92,7 +92,7 @@ When you install or launch Bonita Studio for the first time, you need to install
 
 . From the installer, click *_Copy to clipboard_* to copy the request key generated specifically for your Bonita Studio
 . Go to the {cscLicenseUrl}[Customer Service Center] and request a license using the request key in the clipboard
-. Wait a few seconds to get the file from the license page, or check your email box (after a few minutes) and open the email from `no-reply@bonitasoft.com`
+. Wait a few seconds to get the file from the license page, or check your email box (after a few minutes) and open the email from `no-reply@ofelia.com`
 . Download the license file (.lic)
 . Go back to your Bonita Studio, click *_Install license..._*, and select your .lic file.
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -50,12 +50,12 @@ xref:ROOT:runtime-installation-index.adoc[[.card-title]#Runtime installation# [.
 
 [.card.card-index]
 --
-https://community.bonitasoft.com/c/q-a/6[[.card-title]#Questions & Answers among Bonita Community# [.card-body.card-content-overflow]#pass:q[Ask your question, provide an answer]#]
+https://community.ofelia.com/c/q-a/6[[.card-title]#Questions & Answers among Bonita Community# [.card-body.card-content-overflow]#pass:q[Ask your question, provide an answer]#]
 --
 
 [.card.card-index]
 --
-https://community.bonitasoft.com/c/project/5[[.card-title]#Community projects# [.card-body.card-content-overflow]#pass:q[Do not start from scratch and use artifacts shared by the Community members]#]
+https://community.ofelia.com/c/project/5[[.card-title]#Community projects# [.card-body.card-content-overflow]#pass:q[Do not start from scratch and use artifacts shared by the Community members]#]
 --
 
 [.card.card-index]

--- a/modules/applications/pages/custom-applications-index.adoc
+++ b/modules/applications/pages/custom-applications-index.adoc
@@ -82,7 +82,7 @@ xref:ROOT:admin-application-overview.adoc[[.card-title]#Bonita Administrator App
 
 [.card.card-index]
 --
-https://community.bonitasoft.com/c/project/5[[.card-title]#Community projects# [.card-body.card-content-overflow]#pass:q[Browse the Community members' applications to get inspired]#]
+https://community.ofelia.com/c/project/5[[.card-title]#Community projects# [.card-body.card-content-overflow]#pass:q[Browse the Community members' applications to get inspired]#]
 --
 
 [.card.card-index]

--- a/modules/bonita-overview/pages/what-is-bonita-index.adoc
+++ b/modules/bonita-overview/pages/what-is-bonita-index.adoc
@@ -24,7 +24,7 @@ Both parts of this unified project team use BPMN (Business Process Model and Not
 
 == Editions
 With the Open Source edition *Community*, experiment the value of the platform, create, and operate pretty complex projects. +
-For core and critical projects, for enterprise-grade performance and for support, choose our edition per subscription: the https://www.bonitasoft.com/pricing[Enterprise edition]. +
+For core and critical projects, for enterprise-grade performance and for support, choose our edition per subscription: the https://www.ofelia.com/pricing[Enterprise edition]. +
 
 On top of the Enterprise edition, Bonita Runtime can be deployed in xref:ROOT:overview-of-bonita-bpm-in-a-cluster.adoc[clusters]. +
 Alternatively, you can choose to let us supervise your runtime environments by choosing xref:cloud:ROOT:Overview.adoc[Bonita Cloud].

--- a/modules/getting-started/pages/create-application.adoc
+++ b/modules/getting-started/pages/create-application.adoc
@@ -63,5 +63,5 @@ Confirm that the application is available :
 
 To learn more about Bonita components and concepts, we recommend the https://www.youtube.com/playlist?list=PLvvoQatxaHOMHRiP7hFayNXTJNdxIEiYp[Bonita Camp tutorial].
 Of course the xref:ROOT:index.adoc[official documentation] is also a great place to learn more about Bonita.
-If you prefer to learn from examples, you can find several on the https://community.bonitasoft.com/c/project/5[community website]. +
-And finally, remember that you can always get help and https://community.bonitasoft.com/c/q-a/6/[ask questions of the Bonita Community].
+If you prefer to learn from examples, you can find several on the https://community.ofelia.com/c/project/5[community website]. +
+And finally, remember that you can always get help and https://community.ofelia.com/c/q-a/6/[ask questions of the Bonita Community].

--- a/modules/getting-started/pages/getting-started-index.adoc
+++ b/modules/getting-started/pages/getting-started-index.adoc
@@ -11,7 +11,7 @@ You will then be able to adapt and extend this example to fit your own needs.
 [NOTE]
 ====
 
-* If you have any problems while working through this tutorial, you can https://community.bonitasoft.com/c/q-a/6[ask for help on the Bonita Community web site] and/or open an issue on the Bonita https://bonita.atlassian.net/projects/BBPMC/issues[Community issue tracker].
+* If you have any problems while working through this tutorial, you can https://community.ofelia.com/c/q-a/6[ask for help on the Bonita Community web site] and/or open an issue on the Bonita https://bonita.atlassian.net/projects/BBPMC/issues[Community issue tracker].
 * This example has also been implemented and packaged to be downloaded from Bonita Studio's Welcome page (see below). +
 This can be useful to compare your creations with the already implemented example, or just to learn by watching how it has been implemented. +
 ====

--- a/modules/pages-and-forms/pages/create-or-modify-a-page.adoc
+++ b/modules/pages-and-forms/pages/create-or-modify-a-page.adoc
@@ -21,7 +21,7 @@ Developers can xref:applications:customize-living-application-theme.adoc[create 
 
 Bonita UI Designer comes with a set of xref:ROOT:widgets.adoc[provided containers and widgets]. +
 xref:custom-widgets.adoc[Custom widgets] can also be created to make the palette richer. +
-Those are developed by professional developers, from scratch or from an https://community.bonitasoft.com/c/project/5[existing project] of the Community. +
+Those are developed by professional developers, from scratch or from an https://community.ofelia.com/c/project/5[existing project] of the Community. +
 
 The following chapters give more information on how to develop all the others elements in the UI Designer.
 

--- a/modules/runtime/pages/user-application-case-list.adoc
+++ b/modules/runtime/pages/user-application-case-list.adoc
@@ -5,7 +5,7 @@
 This page explains what a user with the _User_ profile can see and do about cases (the process instances) in xref:user-application-overview.adoc[Bonita User Application]. +
 It describes the value and details of the User Case List in Bonita User Application, as well as its related pages Case Details and Case Overview.
 
-This page has been created using our https://community.bonitasoft.com/blog/development-ui-designer-page-done-bonitasoft[R&D best practices].
+This page has been created using our https://community.ofelia.com/blog/development-ui-designer-page-done-bonitasoft[R&D best practices].
 
 It features:
 

--- a/modules/software-extensibility/pages/bonita-repository-access.adoc
+++ b/modules/software-extensibility/pages/bonita-repository-access.adoc
@@ -35,7 +35,7 @@ Credentials are unique per subscription access and include:
 * A subscription access username (email used for the subscription registration)
 * A subscription access token (password)
 
-In case of any issues regarding credentials information, please contact Customer Success at customer.success@bonitasoft.com
+In case of any issues regarding credentials information, please contact Customer Success at customer.success@ofelia.com
 
 [#maven]
 == Maven

--- a/modules/version-update/pages/update-studio.adoc
+++ b/modules/version-update/pages/update-studio.adoc
@@ -8,7 +8,7 @@
 
 . Read the version xref:ROOT:release-notes.adoc[release notes] to understand the major changes and their possible impact on your projects
 . Download the latest Bonita Studio version:
- * https://www.bonitasoft.com/downloads[Community edition]
+ * https://www.ofelia.com/downloads[Community edition]
  * {cscDownloadUrl}[Subscription editions]
 . Install Bonita Studio
 . Launch it


### PR DESCRIPTION
Follow-up on the Bonitasoft to Ofelia renaming, for the `bonitasoft.com` urls and email addresses that have an `ofelia.com` counterpart.

Targeting `2023.2` so the fix propagates upwards to all the other version branches.

## Changes

- **`antora.yml`** — `cscRootUrl` → `csc.bonitacloud.ofelia.com`. No trailing slash, so that `cscCustomerServices` keeps building a single slash.
- **7 links** `community.bonitasoft.com` → `community.ofelia.com`
- **`www.bonitasoft.com/downloads`** (2 pages) and **`/pricing`** → `www.ofelia.com`
- **`no-reply@`** and **`customer.success@`** → `@ofelia.com`, the aliases are in place on the `ofelia.com` domain

## Verification

Every target was checked over http and answers 200, except `csc.bonitacloud.ofelia.com/apps/CustomerServices` which answers 400 just like the `bonitasoft.com` host did.

## Deliberately not renamed

Please keep these as they are, they look like links but are not:

- `http://www.bonitasoft.org/ns/connector/definition/6.1` and `.../implementation/6.0` (`actor-filter-archetype.adoc`, `connector-archetype.adoc`, `connector-migration.adoc`) and `http://documentation.bonitasoft.com/bdm-xml-schema/1.0` (`how-a-bdm-is-deployed.adoc`) are **xml namespaces**. Renaming them would break customer connectors and business object models. The BDM one already carries a source comment saying so.
- `win2008tomcat.corp.bonitasoft.com` is an example fqdn in `setspn` commands, and the `www.bonitasoft.com` of `bonita-bpm-studio-preferences.adoc` is an example `UnknownHostException` output.

## Needs an editorial decision, out of scope here

- `/videos/*` (6 links), `/library/the-ultimate-guide-to-bpmn2`, `/news/adaptive-case-management-with-bpm`, `/bonita-cloud` and `/robotic-process-automation` (2 links) all **redirect to `www.ofelia.com/product/bonita-bpm`**. Renaming them would turn the link check green while silently sending the reader to a generic product page instead of the announced content.
- `fr.bonitasoft.com/videos/*` (6), `es.bonitasoft.com/videos/*` (5) and `translate.bonitasoft.org` (3) have no `ofelia.com` counterpart: `fr.`, `es.` and `translate.` do not exist on that domain.
- `www.bonitasoft.com/industries` redirects to `/use-cases`, which answers 404.
- `www.ofelia.com/customer-services` (`gdpr-guidelines.adoc`, `bonita-on-kubernetes.adoc`) already uses the new domain but answers **404**. `www.ofelia.com/support` redirects to that same missing page, so this one looks like a website side issue rather than a doc one.

## Follow-up needed

`modules/ROOT/pages/index.adoc` is marked `merge=ours` in `.gitattributes`, so its 2 community links will **not** propagate: one PR per branch is needed for `2024.1` → `2027.1`. Same story for `release-notes.adoc` of `2025.1`, which hardcodes `javadoc.bonitasoft.com` where it could use the `{javadocUrl}` attribute, already correct on every branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)