### PR TITLE
docs(runtime): document the Hazelcast 5.7.0 update and the cluster work recovery properties

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -82,6 +82,48 @@ Note that this new API is now also available in the Community edition and provid
 
 == Bug fixes
 
+=== Fixes in Bonita 2024.3-u10 (TBD)
+
+* Hazelcast, the library used by the Cluster feature, is updated from 5.4.0 to 5.7.0. If you run a cluster, read <<v2024-3-u10-cluster-update,Updating a cluster to 2024.3-u10>> before updating.
+* Security hardening of the Hazelcast member. On a single node, the member Bonita starts for its second-level cache now
+listens on loopback only instead of on every interface.
+Set `bonita.platform.hazelcast.interfaces.list` to an empty value in `bonita-platform-sp-custom.properties` to restore
+the previous behaviour, for a deployment that attaches a Hazelcast client on purpose. In a cluster,
+`bonita.platform.cluster.hazelcast.interfaces.list` now binds the member to one address of the node matching the
+patterns it lists, which it never did before; its default no longer names an interface. If your cluster configuration sets that property, verify its
+value or unset it before updating: a value that matches no interface of the node, harmless until now, stops the node
+from starting. See
+xref:runtime:install-a-bonita-bpm-cluster.adoc#hazelcast-port-hardening[Allow communication between servers] for how to
+restrict the port.
+
+[#v2024-3-u10-cluster-update]
+*Updating a cluster to 2024.3-u10*
+
+These points apply to Subscription editions running the Cluster feature. Installations that do not enable the
+Cluster feature are not affected, and Bonita Community edition does not use Hazelcast.
+
+* *All nodes must be stopped to update.* Hazelcast does not support updating the members of a cluster one at a
+time, so a node running 5.4.0 cannot join a cluster running 5.7.0. Stop every node, update them, then start
+them again.
+* *No configuration change is required.* The update introduces two new cluster properties, both with default
+values, so nothing needs to be added to your configuration. See
+xref:runtime:install-a-bonita-bpm-cluster.adoc#work-recovery[Work recovery when a node leaves the cluster] if
+you want to tune them.
+* *Work recovery is more robust.* The recovery of a departed node's work runs in the background instead of on
+a Hazelcast event thread, gives up on its own before its lock expires, and is tried again at the next departure
+or start for whatever it could not take over. A node that resumes after a tenant pause now resubmits the work
+that arrived while it was paused, which previously waited until the node left the cluster.
+* *Clusters updated from an earlier version log a warning about the configuration schema at every start.*
+Fresh installations do not. The message reports that the Hazelcast schema location is incorrect and that the
+default is used instead. It is harmless: your stored configuration still refers to the schema of the previous
+version, and the update does not rewrite it. To make it stop, update the version in the schema location in
+`platform_engine/hazelcast.xml` with the platform setup tool.
+* *Two diagnostics change.* The `Number of locks` column of the Hazelcast statistics file now counts the locks
+currently held on the node that writes the file, where it previously counted lock objects across the cluster,
+so expect a different magnitude and a value that varies with load. A lock whose lease expires before it is
+released is now reported as an error instead of a warning; if you raise alerts on errors from the cluster
+lock service, you may start seeing them for a condition that was already being reported at a lower level.
+
 === Fixes in Bonita 2024.3-u9 (2026-07-17)
 
 * BPA-445 - [SAML] authentication: race condition on /favicon.ico overwrites __REDIRECT_URI session attribute, causing 404 after successful SSO login

--- a/modules/runtime/pages/install-a-bonita-bpm-cluster.adoc
+++ b/modules/runtime/pages/install-a-bonita-bpm-cluster.adoc
@@ -34,6 +34,22 @@ Bonita cluster uses Hazelcast as the distributed cluster dispatcher layer.
 Hazelcast needs the port 5701 (by default) to be opened on all the servers that compose the cluster.
 Ensure that these ports are opened in all the nodes of your cluster.
 
+[#hazelcast-port-hardening]
+IMPORTANT: For security reasons, Port 5701 must be reachable only from the other Bonita Runtime nodes of the same cluster, 
+and from nothing at all in a single-node installation. With Docker Compose, every container of a project shares
+the default network, so a compromised sibling container can reach the port; With Kubernetes, pod-to-pod traffic is
+unrestricted across namespaces unless a NetworkPolicy says otherwise, and leaving 5701 out of the Service does
+not block the pod IP. Restrict the port explicitly: a NetworkPolicy that admits only the Bonita pods, a dedicated
+network that third-party services are not attached to, or a security group or host firewall.
+A cluster member can also be bound to one address with `bonita.platform.cluster.hazelcast.interfaces.list`
+in `bonita-platform-sp-cluster-custom.properties`, for example `10.0.0.5` on a host with several networks. The value is
+a comma separated list of patterns, such as `10.0.0.*`; Hazelcast picks one address of the node matching one of them and
+the member listens on that address only, so several entries are alternatives, not several addresses to listen on. This
+property only takes effect from Bonita 2024.3-u10 (xref:version-update:product-versioning.adoc#technical-id[technical id] 10.2.10).
+Outside cluster mode a single node also starts a Hazelcast member, for its second-level cache; from 2024.3-u10 that
+member listens on loopback only, so nothing has to be done for it. Set `bonita.platform.hazelcast.interfaces.list`
+to an empty value in `bonita-platform-sp-custom.properties` if a Hazelcast client or Management Center must reach it.
+
 [#create_init_bonita_db]
 === Create and initialize the database for Bonita Platform
 
@@ -221,6 +237,63 @@ will continue until completion. Do not remove the node completely, because the l
 . Update the load balancer to remove the node from the cluster.
 
 The node is now removed from the cluster.
+
+[#work-recovery]
+=== Work recovery when a node leaves the cluster
+
+When a node leaves the cluster, whether it was stopped in a planned way or failed, the work it had started
+but not finished is taken over by one of the remaining nodes. Only one node performs that recovery: the
+others detect it is already being handled and carry on with their own work. The recovery runs in the
+background on that node, one departed node at a time, and no longer holds up the handling of other cluster
+events on it.
+
+Work that a recovery could not take over stays in the departed node's queue. It is taken over again the next
+time a node leaves or starts, and in the meantime the periodic recovery (`bonita.tenant.recover.*`) picks up
+what it covers. A node that resumes after a tenant pause resubmits the work that arrived while it was paused.
+
+Two properties limit how long that takes. Their default values suit most installations; they can be changed
+in the file `platform_engine/bonita-platform-sp-cluster-custom.properties`, together with the lease used by
+the lock service:
+
+NOTE: `bonita.platform.cluster.work.recoveryLockTimeoutSeconds` and
+`bonita.platform.cluster.work.recoveryLockLeaseSeconds` are available from Bonita 2024.3-u10
+(xref:version-update:product-versioning.adoc#technical-id[technical id] 10.2.10) onwards.
+`bonita.platform.cluster.lock.leaseTimeSeconds` is also available in earlier versions.
+
+[source,properties]
+----
+# Seconds a node waits for its turn to recover the work of a node that has left.
+bonita.platform.cluster.work.recoveryLockTimeoutSeconds=30
+# Seconds a node may spend handing over the work of a node that has left. The handover stops by
+# itself after 90% of this time; work not handed over by then is taken over again when a node next
+# leaves or starts, or picked up by the periodic recovery.
+bonita.platform.cluster.work.recoveryLockLeaseSeconds=14400
+# Seconds a lock on a process instance or a task is held before the cluster releases it.
+bonita.platform.cluster.lock.leaseTimeSeconds=600
+----
+
+These properties can also be set as Java system properties, using the name above unchanged, or as environment
+variables:
+
+[source,bash]
+----
+BONITA_PLATFORM_CLUSTER_WORK_RECOVERYLOCKTIMEOUTSECONDS=30
+BONITA_PLATFORM_CLUSTER_WORK_RECOVERYLOCKLEASESECONDS=14400
+BONITA_PLATFORM_CLUSTER_LOCK_LEASETIMESECONDS=600
+----
+
+Keep `bonita.platform.cluster.work.recoveryLockLeaseSeconds` high, in hours rather than minutes. The handover
+of a departed node's work stops by itself after 90% of the lease, so that it never outlives its lock, and the
+work not handed over by then waits for the periodic recovery. Too low a value therefore cuts short the handover
+of a large queue. Raise it if the log reports that a handover gave up because it had spent its share of the
+lease, or that a work recovery lock could not be released because its lease had expired. In the second case,
+another node may have started the same handover, and some work may have run twice.
+
+A high value has one cost: if a node hangs while holding the lease, the recovery of that node's work waits that
+long. A node that stops or fails releases the lease by leaving the cluster.
+
+Raising `bonita.platform.cluster.work.recoveryLockTimeoutSeconds` is rarely useful: on every departure all
+remaining nodes but one are expected to give up waiting, and the message reporting it is informational.
 
 === Dismantle a cluster
 

--- a/modules/version-update/pages/product-versioning.adoc
+++ b/modules/version-update/pages/product-versioning.adoc
@@ -37,6 +37,11 @@ Here is a Bonita Platform version / Technical Id / UI Designer version correspon
 |===
 | Release date | Bonita Platform version | Technical Id | UI Designer version
 
+| TBD
+| 2024.3-u10
+| 10.2.10
+| 1.19.1
+
 | 2026-07-17
 | 2024.3-u9
 | 10.2.9


### PR DESCRIPTION
**On hold until bonitasoft/bonita-engine-sp#4108, bonitasoft/bonita-engine-sp#4112 and bonitasoft/bonita-engine-sp#4113 are merged into `10.2.x`.** The work-recovery paragraphs and the "Work recovery is more robust" release-note bullet describe the first two; the Hazelcast interface properties in the hardening paragraph and the "Security hardening of the Hazelcast member" bullet describe the third. Merging this before them would document behaviour 2024.3-u10 does not have.

Documents the Hazelcast update shipping in **2024.3-u10** (technical id 10.2.10).

## Release notes (`modules/ROOT/pages/release-notes.adoc`)

A `2024.3-u10` section recording the Hazelcast update from 5.4.0 to 5.7.0, plus an **Updating a cluster to 2024.3-u10** block covering what an administrator has to act on:

- **all nodes must be stopped** to update, because Hazelcast does not support updating cluster members one at a time, so a 5.4.0 node cannot join a 5.7.0 cluster;
- **no configuration change is required** - the two new properties ship with defaults;
- a **harmless schema warning** at every node start, because the stored configuration still names the previous schema and the update does not rewrite it;
- **two diagnostics change**: `Number of locks` in the Hazelcast statistics file changes unit and scope, and an expired lock lease is now reported as an error rather than a warning.

Scoped to Subscription editions with the Cluster feature; single-node installations are unaffected and Community does not use Hazelcast.

## Cluster page (`modules/runtime/pages/install-a-bonita-bpm-cluster.adoc`)

A new **Work recovery when a node leaves the cluster** section under *Cluster management*, documenting the two new properties with their defaults and when to change them:

- `bonita.platform.cluster.work.recoveryLockTimeoutSeconds` (30)
- `bonita.platform.cluster.work.recoveryLockLeaseSeconds` (14400)

The work-recovery section also describes, from bonitasoft/bonita-engine-sp#4112, that the recovery runs in the background, that work it leaves behind is tried again at the next departure or start, and that a node resuming after a tenant pause resubmits the work that arrived meanwhile; the release notes carry one bullet for it.

The sizing advice for the lease reflects bonitasoft/bonita-engine-sp#4108: the handover of a departed node's work stops by itself at 90% of the lease, so the lease is a working limit rather than a backstop, and the page says to keep it in hours rather than minutes.

It also documents `bonita.platform.cluster.lock.leaseTimeSeconds` (600) beside them - that property already existed and appeared nowhere in the documentation.

## Version correspondence table (`modules/version-update/pages/product-versioning.adoc`)

The `2024.3-u10` / `10.2.10` row.

## Notes for the reviewer

- **The release date is `TBD`** in the release-notes heading and in the correspondence table, and needs filling in when the release is dated.
- Kept deliberately non-technical: the section explains what the properties bound and when to raise them, not how the locking works.



