### PR TITLE
docs(update-tool): add 3.10.1 changelog entry for BPA-557

### DIFF
--- a/modules/version-update/pages/update-tools-changelog.adoc
+++ b/modules/version-update/pages/update-tools-changelog.adoc
@@ -10,6 +10,12 @@ All changes in both tools are logged: from the version that was delivered with t
 This is due to the fact that improvements in any version of the tools can affect all supported Bonita versions.
 This changelog must be read before xref:update-overview.adoc[updating to a newer version of Bonita].
 
+== 3.10.1 - September 3, 2026 - Bonita Update Tool changes
+Bonita Update Tool handles updates from all Bonita 7.10 versions up to Bonita 2026.2 (11.1) version.
+
+* [BPA-557] PostgreSQL: the tool only looked for the Bonita tables in the `public` schema. When the tables are stored in another schema, some update steps were silently skipped and the update ended without error, although it was incomplete. +
+All table, column, constraint and index lookups now follow the `search_path` of the database connection. If the Bonita tables are stored in a custom schema, add `currentSchema=<schema>` to the `db.url` property, as described in the xref:update-with-update-tool.adoc#updating-bonita-bundle-step-by-step-procedure[step-by-step procedure]. The schemas actually used are logged at startup under "Database Information".
+
 == 3.10.0 - June 30, 2026 - Bonita Update Tool changes
 Bonita Update Tool handles updates from all Bonita 7.10 versions up to Bonita 2026.2 (11.1) version.
 

--- a/modules/version-update/pages/update-with-update-tool.adoc
+++ b/modules/version-update/pages/update-with-update-tool.adoc
@@ -248,8 +248,11 @@ This section explains how to update a platform that uses one of the Bonita bundl
 |===
 
 
-NOTE: If you are using MySQL, add ?allowMultiQueries=true to the URL.
-For example, db.url=jdbc:mysql://localhost:3306/bonita-update?allowMultiQueries=true.
+NOTE: If you are using MySQL, add `?allowMultiQueries=true` to the URL.
+For example, `db.url=jdbc:mysql://localhost:3306/bonita-update?allowMultiQueries=true`.
+
+NOTE: If you are using PostgreSQL and the Bonita tables are stored in a schema other than the default one of the database user, add `?currentSchema=<schema>` to the URL, with the same schema as the one configured in the Bonita runtime. The schemas actually used by the tool are logged at startup under "Database Information".
+For example, `db.url=jdbc:postgresql://localhost:5432/bonita-update?currentSchema=bonita`.
 
 === Stop Bonita
 [WARNING]


### PR DESCRIPTION
Covers [BPA-557](https://bonitasoft.atlassian.net/browse/BPA-557), fixed in Bonita Update Tool 3.10.1 by bonitasoft/bonita-migration-sp#659.

## Changes

- `update-tools-changelog.adoc`: add the 3.10.1 entry. On PostgreSQL the tool only looked for the Bonita tables in the `public` schema, so with a custom schema some update steps were silently skipped and the update ended without error. All metadata lookups now follow the connection `search_path`.
- `update-with-update-tool.adoc`: add a PostgreSQL note after the configuration table, next to the existing MySQL one, explaining that `?currentSchema=<schema>` must be added to `db.url` when the Bonita tables live in a custom schema, and that the schemas used are logged at startup. The MySQL note gets the same inline code formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[BPA-557]: https://bonitasoft.atlassian.net/browse/BPA-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ